### PR TITLE
Add full-screen weather theme inspired by iOS Weather and Foreca

### DIFF
--- a/src/render/canvas.py
+++ b/src/render/canvas.py
@@ -5,6 +5,7 @@ from src.data.models import DashboardData
 from src.config import DisplayConfig
 from src.render.components import (
     header, week_view, weather_panel, birthday_bar, info_panel, today_view, qotd_panel,
+    weather_full as weather_full_comp,
 )
 from src.render.theme import Theme, default_theme
 
@@ -87,6 +88,11 @@ def render_dashboard(
         "qotd_weather": lambda: qotd_panel.draw_qotd_weather(
             draw, data.weather, today,
             region=layout.weather,
+            style=style,
+        ),
+        "weather_full": lambda: weather_full_comp.draw_weather_full(
+            draw, data.weather, today,
+            region=layout.weather_full,
             style=style,
         ),
     }

--- a/src/render/components/weather_full.py
+++ b/src/render/components/weather_full.py
@@ -1,0 +1,426 @@
+"""Full-screen weather component for the ``weather`` theme.
+
+Renders a large, iOS-Weather-inspired layout across the entire 800×480
+canvas.  The display is divided into three visual zones:
+
+1. **Hero** (top): large weather icon, hero temperature, condition text,
+   today's hi/lo range.
+2. **Metric cards + detail strip** (middle): four rounded-rectangle cards
+   (feels like, wind, humidity, UV) followed by a single-line detail strip
+   (sunrise/sunset, pressure, moon phase).
+3. **Forecast grid** (bottom): five-day forecast columns separated by a
+   thin rule, with day name, icon, hi/lo, and precipitation chance.
+
+When weather alerts are present, an inverted banner is drawn above the
+forecast grid.
+"""
+
+from datetime import date
+
+from PIL import ImageDraw
+
+from src.data.models import WeatherData
+from src.render.fonts import weather_icon as weather_icon_font
+from src.render.icons import OWM_ICON_MAP, FALLBACK_ICON
+from src.render.moon import moon_phase_glyph, moon_phase_name
+from src.render.primitives import (
+    draw_text_truncated, filled_rect, hline, text_height, text_width,
+)
+from src.render.theme import ComponentRegion, ThemeStyle
+
+# Weather Icons font glyph code points for metric card icons.
+_GLYPH_THERMOMETER = "\uf055"
+_GLYPH_WIND = "\uf050"
+_GLYPH_HUMIDITY = "\uf07a"
+_GLYPH_UV = "\uf06e"
+_GLYPH_BAROMETER = "\uf079"
+_GLYPH_SUNRISE = "\uf051"
+_GLYPH_SUNSET = "\uf052"
+
+
+def draw_weather_full(
+    draw: ImageDraw.ImageDraw,
+    weather: WeatherData | None,
+    today: date | None = None,
+    *,
+    region: ComponentRegion | None = None,
+    style: ThemeStyle | None = None,
+) -> None:
+    """Draw the full-screen weather display."""
+    if region is None:
+        region = ComponentRegion(0, 0, 800, 480)
+    if style is None:
+        style = ThemeStyle()
+
+    if weather is None:
+        _draw_unavailable(draw, region, style)
+        return
+
+    x0, y0 = region.x, region.y
+    W, H = region.w, region.h
+
+    # ── Zone heights (proportional to 480px canvas) ──────────────────
+    hero_h = int(H * 0.44)        # ~211px: icon + temp + desc + hi/lo
+    cards_h = int(H * 0.115)      # ~55px: metric cards row
+    detail_h = int(H * 0.06)      # ~29px: sunrise/sunset/pressure/moon
+    alert_h = int(H * 0.055)      # ~26px: alert banner (if needed)
+    # Remaining space goes to forecast grid
+
+    hero_top = y0
+    cards_top = hero_top + hero_h
+    detail_top = cards_top + cards_h
+
+    has_alerts = bool(weather.alerts)
+    if has_alerts:
+        alert_top = detail_top + detail_h
+        forecast_top = alert_top + alert_h
+    else:
+        alert_top = None
+        forecast_top = detail_top + detail_h
+
+    forecast_h = y0 + H - forecast_top
+
+    # ── Draw each zone ───────────────────────────────────────────────
+    _draw_hero(draw, weather, x0, hero_top, W, hero_h, style)
+    _draw_metric_cards(draw, weather, x0, cards_top, W, cards_h, style)
+    _draw_detail_strip(draw, weather, today, x0, detail_top, W, detail_h, style)
+
+    if has_alerts and alert_top is not None:
+        _draw_alert_banner(draw, weather, x0, alert_top, W, alert_h, style)
+
+    # Thin rule above forecast
+    rule_y = forecast_top - 1
+    hline(draw, rule_y, x0 + 30, x0 + W - 30, fill=style.fg)
+
+    _draw_forecast_grid(draw, weather, x0, forecast_top, W, forecast_h, style)
+
+
+def _draw_hero(draw, weather, x0, y0, W, H, style):
+    """Large weather icon, hero temperature, description, and hi/lo."""
+    fg = style.fg
+    cx = x0 + W // 2  # horizontal centre
+
+    # Weather icon — large centred glyph
+    icon_size = 70
+    icon_font = weather_icon_font(icon_size)
+    glyph = OWM_ICON_MAP.get(weather.current_icon, FALLBACK_ICON)
+    glyph_bbox = draw.textbbox((0, 0), glyph, font=icon_font)
+    glyph_w = glyph_bbox[2] - glyph_bbox[0]
+    glyph_h = glyph_bbox[3] - glyph_bbox[1]
+    icon_x = cx - glyph_w // 2 - glyph_bbox[0]
+    icon_y = y0 + 8 - glyph_bbox[1]
+    draw.text((icon_x, icon_y), glyph, font=icon_font, fill=fg)
+
+    # Hero temperature
+    temp_str = f"{weather.current_temp:.0f}°"
+    temp_size = 64
+    temp_font = style.font_bold(temp_size)
+    # Auto-scale down if temp string is too wide (e.g. "-100°")
+    max_temp_w = int(W * 0.5)
+    while temp_size > 40:
+        temp_font = style.font_bold(temp_size)
+        tw = text_width(draw, temp_str, temp_font)
+        if tw <= max_temp_w:
+            break
+        temp_size -= 4
+
+    temp_bbox = draw.textbbox((0, 0), temp_str, font=temp_font)
+    temp_w = temp_bbox[2] - temp_bbox[0]
+    temp_x = cx - temp_w // 2 - temp_bbox[0]
+    temp_y = y0 + 8 + glyph_h + 2
+    draw.text((temp_x, temp_y), temp_str, font=temp_font, fill=fg)
+    temp_bottom = temp_y + text_height(temp_font)
+
+    # Description
+    desc_font = style.font_medium(16)
+    desc = weather.current_description.title()
+    desc_w = text_width(draw, desc, desc_font)
+    desc_x = cx - desc_w // 2
+    desc_y = temp_bottom + 4
+    draw_text_truncated(draw, (desc_x, desc_y), desc, desc_font, W - 60, fill=fg)
+
+    # Hi / Lo
+    hilo_font = style.font_regular(13)
+    hilo_str = f"H: {weather.high:.0f}°  ·  L: {weather.low:.0f}°"
+    hilo_w = text_width(draw, hilo_str, hilo_font)
+    hilo_x = cx - hilo_w // 2
+    hilo_y = desc_y + text_height(desc_font) + 2
+    # Clamp to stay within hero zone
+    max_hilo_y = y0 + H - text_height(hilo_font) - 2
+    hilo_y = min(hilo_y, max_hilo_y)
+    draw.text((hilo_x, hilo_y), hilo_str, font=hilo_font, fill=fg)
+
+
+def _draw_metric_cards(draw, weather, x0, y0, W, H, style):
+    """Four evenly-spaced rounded-rect metric cards."""
+    fg = style.fg
+
+    # Build card data: list of (icon_glyph, value, label)
+    cards = []
+
+    # Feels like
+    if weather.feels_like is not None:
+        cards.append((_GLYPH_THERMOMETER, f"{weather.feels_like:.0f}°", "Feels like"))
+    else:
+        cards.append((_GLYPH_THERMOMETER, f"{weather.current_temp:.0f}°", "Temp"))
+
+    # Wind
+    if weather.wind_speed is not None:
+        wind_val = f"{weather.wind_speed:.0f}"
+        if weather.wind_deg is not None:
+            try:
+                from src.fetchers.weather import deg_to_compass
+                wind_val += f" {deg_to_compass(weather.wind_deg)}"
+            except ImportError:
+                pass
+        cards.append((_GLYPH_WIND, wind_val, "Wind mph"))
+    else:
+        cards.append((_GLYPH_WIND, "—", "Wind"))
+
+    # Humidity
+    cards.append((_GLYPH_HUMIDITY, f"{weather.humidity}%", "Humidity"))
+
+    # UV index or Pressure (prefer UV when available)
+    if weather.uv_index is not None:
+        cards.append((_GLYPH_UV, f"{weather.uv_index:.0f}", "UV index"))
+    elif weather.pressure is not None:
+        cards.append((_GLYPH_BAROMETER, f"{weather.pressure:.0f}", "hPa"))
+    else:
+        cards.append((_GLYPH_UV, "—", "UV index"))
+
+    # Layout: 4 cards with gaps
+    n = len(cards)
+    margin = 30
+    gap = 16
+    total_gap = gap * (n - 1)
+    card_w = (W - 2 * margin - total_gap) // n
+    card_h = H - 8  # 4px top/bottom padding
+    card_y = y0 + 4
+
+    icon_font = weather_icon_font(18)
+    value_font = style.font_semibold(14)
+    label_font = style.font_regular(10)
+
+    for i, (glyph, value, label) in enumerate(cards):
+        card_x = x0 + margin + i * (card_w + gap)
+
+        # Rounded rectangle outline
+        draw.rounded_rectangle(
+            [card_x, card_y, card_x + card_w, card_y + card_h],
+            radius=6, outline=fg, width=1,
+        )
+
+        # Centre content vertically within card
+        inner_cx = card_x + card_w // 2
+
+        # Icon glyph + value on one line
+        glyph_bbox = draw.textbbox((0, 0), glyph, font=icon_font)
+        glyph_w = glyph_bbox[2] - glyph_bbox[0]
+        val_w = text_width(draw, value, value_font)
+        spacing = 5
+        total_w = glyph_w + spacing + val_w
+        line_x = inner_cx - total_w // 2
+
+        line_y = card_y + 6
+        draw.text(
+            (line_x - glyph_bbox[0], line_y - glyph_bbox[1]),
+            glyph, font=icon_font, fill=fg,
+        )
+        val_bbox = draw.textbbox((0, 0), value, font=value_font)
+        draw.text(
+            (line_x + glyph_w + spacing - val_bbox[0],
+             line_y - val_bbox[1]),
+            value, font=value_font, fill=fg,
+        )
+
+        # Label below
+        label_w = text_width(draw, label, label_font)
+        label_x = inner_cx - label_w // 2
+        label_y = card_y + card_h - text_height(label_font) - 5
+        draw.text((label_x, label_y), label, font=label_font, fill=fg)
+
+
+def _draw_detail_strip(draw, weather, today, x0, y0, W, H, style):
+    """Single centred line: sunrise/sunset · pressure · moon phase."""
+    fg = style.fg
+    cx = x0 + W // 2
+    font = style.font_regular(12)
+    mid_y = y0 + (H - text_height(font)) // 2
+
+    parts = []
+
+    # Sunrise / sunset
+    if weather.sunrise is not None or weather.sunset is not None:
+        sun_parts = []
+        if weather.sunrise is not None:
+            sun_parts.append(f"\u2191{_fmt_time(weather.sunrise)}")
+        if weather.sunset is not None:
+            sun_parts.append(f"\u2193{_fmt_time(weather.sunset)}")
+        parts.append("  ".join(sun_parts))
+
+    # Pressure (if not already shown in cards — i.e. when UV is available)
+    if weather.pressure is not None and weather.uv_index is not None:
+        parts.append(f"{weather.pressure:.0f} hPa")
+
+    # Moon phase
+    if today is not None:
+        # Placeholder entry — the moon glyph is rendered with its own font below
+        parts.append("__moon__")
+
+    if not parts:
+        return
+
+    # Join all parts with a dot separator, but render moon glyph with its own font
+    # For simplicity: if moon is the last part, render it specially
+    if today is not None and len(parts) >= 1:
+        # Render text parts (everything except moon) then moon separately
+        text_parts = parts[:-1]
+
+        text_str = "   ·   ".join(text_parts)
+        if text_str:
+            text_str += "   ·   "
+
+        # Calculate total width for centering
+        text_w = text_width(draw, text_str, font) if text_str else 0
+        moon_icon_font = weather_icon_font(16)
+
+        # Moon glyph and name
+        moon_glyph_char = moon_phase_glyph(today)
+        moon_name_str = moon_phase_name(today)
+
+        glyph_bbox = draw.textbbox((0, 0), moon_glyph_char, font=moon_icon_font)
+        glyph_w = glyph_bbox[2] - glyph_bbox[0]
+        moon_label_w = text_width(draw, f"  {moon_name_str}", font)
+        moon_total_w = glyph_w + moon_label_w
+
+        total_w = text_w + moon_total_w
+        start_x = cx - total_w // 2
+
+        if text_str:
+            draw.text((start_x, mid_y), text_str, font=font, fill=fg)
+
+        # Moon glyph (weather icon font)
+        moon_x = start_x + text_w
+        glyph_mid_y = mid_y + text_height(font) // 2
+        draw.text(
+            (moon_x - glyph_bbox[0],
+             glyph_mid_y - (glyph_bbox[3] - glyph_bbox[1]) // 2 - glyph_bbox[1]),
+            moon_glyph_char, font=moon_icon_font, fill=fg,
+        )
+
+        # Moon name (regular font)
+        name_x = moon_x + glyph_w
+        draw.text((name_x, mid_y), f"  {moon_name_str}", font=font, fill=fg)
+    else:
+        full_str = "   ·   ".join(parts)
+        full_w = text_width(draw, full_str, font)
+        draw.text((cx - full_w // 2, mid_y), full_str, font=font, fill=fg)
+
+
+def _draw_alert_banner(draw, weather, x0, y0, W, H, style):
+    """Inverted banner showing weather alerts."""
+    fg = style.fg
+    bg = style.bg
+
+    filled_rect(draw, (x0, y0, x0 + W - 1, y0 + H - 1), fill=fg)
+
+    alert_texts = [f"⚠ {a.event}" for a in weather.alerts[:3]]
+    alert_str = "   ·   ".join(alert_texts)
+
+    alert_font = style.font_semibold(12)
+    max_w = W - 60
+
+    aw = text_width(draw, alert_str, alert_font)
+    if aw > max_w:
+        # Truncate
+        draw_text_truncated(
+            draw,
+            (x0 + 30, y0 + (H - text_height(alert_font)) // 2),
+            alert_str, alert_font, max_w, fill=bg,
+        )
+    else:
+        draw.text(
+            (x0 + (W - aw) // 2, y0 + (H - text_height(alert_font)) // 2),
+            alert_str, font=alert_font, fill=bg,
+        )
+
+
+def _draw_forecast_grid(draw, weather, x0, y0, W, H, style):
+    """Five-day forecast columns: day name, icon, hi/lo, precip chance."""
+    fg = style.fg
+    forecast = (weather.forecast or [])[:5]
+
+    if not forecast:
+        font = style.font_regular(13)
+        msg = "No forecast data"
+        mw = text_width(draw, msg, font)
+        draw.text(
+            (x0 + (W - mw) // 2, y0 + (H - text_height(font)) // 2),
+            msg, font=font, fill=fg,
+        )
+        return
+
+    n = len(forecast)
+    margin = 30
+    usable_w = W - 2 * margin
+    col_w = usable_w // n
+
+    day_font = style.font_semibold(13)
+    hilo_font = style.font_regular(13)
+    precip_font = style.font_regular(11)
+    icon_size = 28
+
+    for i, fc in enumerate(forecast):
+        col_cx = x0 + margin + i * col_w + col_w // 2
+
+        # Day name
+        day_str = fc.date.strftime("%a")
+        dw = text_width(draw, day_str, day_font)
+        day_y = y0 + 8
+        draw.text((col_cx - dw // 2, day_y), day_str, font=day_font, fill=fg)
+
+        # Weather icon
+        icon_y = day_y + text_height(day_font) + 6
+        # Centre the icon glyph
+        icon_font = weather_icon_font(icon_size)
+        glyph = OWM_ICON_MAP.get(fc.icon, FALLBACK_ICON)
+        gbbox = draw.textbbox((0, 0), glyph, font=icon_font)
+        gw = gbbox[2] - gbbox[0]
+        draw.text(
+            (col_cx - gw // 2 - gbbox[0], icon_y - gbbox[1]),
+            glyph, font=icon_font, fill=fg,
+        )
+
+        # Hi / Lo
+        hilo_str = f"{fc.high:.0f}°/{fc.low:.0f}°"
+        hw = text_width(draw, hilo_str, hilo_font)
+        hilo_y = icon_y + icon_size + 6
+        draw.text((col_cx - hw // 2, hilo_y), hilo_str, font=hilo_font, fill=fg)
+
+        # Precipitation chance (only if >= 5%)
+        if fc.precip_chance is not None and fc.precip_chance >= 0.05:
+            precip_str = f"{fc.precip_chance:.0%}"
+            pw = text_width(draw, precip_str, precip_font)
+            precip_y = hilo_y + text_height(hilo_font) + 3
+            draw.text(
+                (col_cx - pw // 2, precip_y), precip_str,
+                font=precip_font, fill=fg,
+            )
+
+
+def _draw_unavailable(draw, region, style):
+    """Centred fallback when weather data is None."""
+    font = style.font_medium(18)
+    msg = "Weather Unavailable"
+    mw = text_width(draw, msg, font)
+    mh = text_height(font)
+    draw.text(
+        (region.x + (region.w - mw) // 2, region.y + (region.h - mh) // 2),
+        msg, font=font, fill=style.fg,
+    )
+
+
+def _fmt_time(dt) -> str:
+    """Format a datetime as a compact am/pm string, e.g. '6:24a'."""
+    s = dt.strftime("%-I:%M%p").lower().replace(":00", "")
+    return s.replace("am", "a").replace("pm", "p")

--- a/src/render/theme.py
+++ b/src/render/theme.py
@@ -67,6 +67,11 @@ class ThemeLayout:
     qotd: ComponentRegion = field(
         default_factory=lambda: ComponentRegion(0, 0, 800, 400, visible=False)
     )
+    # Used by the ``weather`` theme for the full-screen weather display.
+    # Hidden by default so existing themes are not affected.
+    weather_full: ComponentRegion = field(
+        default_factory=lambda: ComponentRegion(0, 0, 800, 480, visible=False)
+    )
     draw_order: list[str] = field(
         default_factory=lambda: ["header", "week_view", "weather", "birthdays", "info"]
     )
@@ -167,7 +172,7 @@ class Theme:
 AVAILABLE_THEMES: frozenset[str] = frozenset(
     {
         "default", "terminal", "minimalist", "old_fashioned", "today",
-        "fantasy", "qotd", "lcars", "random",
+        "fantasy", "qotd", "lcars", "weather", "random",
     }
 )
 
@@ -231,6 +236,9 @@ def load_theme(name: str) -> Theme:
     if name == "lcars":
         from src.render.themes.lcars import lcars_theme
         return lcars_theme()
+    if name == "weather":
+        from src.render.themes.weather import weather_theme
+        return weather_theme()
     raise ValueError(
         f"Unknown theme: {name!r}. Available: {', '.join(sorted(AVAILABLE_THEMES))}"
     )

--- a/src/render/themes/weather.py
+++ b/src/render/themes/weather.py
@@ -1,0 +1,68 @@
+"""Full-screen weather theme.
+
+Devotes the entire 800×480 canvas to a rich weather display inspired by
+iOS Weather and Foreca Weather.  The upper two-thirds show the current
+conditions at a glance — large icon, hero temperature, description, and
+a row of metric cards — while the lower third presents a clean five-day
+forecast grid.
+
+Layout (800 × 480):
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │                      [weather icon, 80px]                           │
+  │                           72°                                       │
+  │                      Partly Cloudy                                  │
+  │                     H: 78°  ·  L: 60°                              │
+  │                                                                     │
+  │   ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐          │
+  │   │ Feels 70°│  │Wind 5 NW │  │ Hum 45%  │  │  UV 3    │          │
+  │   └──────────┘  └──────────┘  └──────────┘  └──────────┘          │
+  │                                                                     │
+  │   ↑6:24a  ↓7:45p    ·    1013 hPa    ·    🌒 Waxing Crescent      │
+  │  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
+  │   Mon        Tue        Wed        Thu        Fri                   │
+  │  [icon]     [icon]     [icon]     [icon]     [icon]                │
+  │  58°/42°    62°/48°    55°/40°    60°/44°    57°/41°              │
+  │   10%        30%        60%         —          —                    │
+  └──────────────────────────────────────────────────────────────────────┘
+
+Font: DM Sans — geometric, modern, excellent legibility on eInk.
+"""
+
+from src.render.theme import ComponentRegion, Theme, ThemeLayout, ThemeStyle
+from src.render.fonts import dm_regular, dm_medium, dm_semibold, dm_bold
+
+
+def weather_theme() -> Theme:
+    """Return the full-screen weather theme."""
+    return Theme(
+        name="weather",
+        layout=ThemeLayout(
+            canvas_w=800,
+            canvas_h=480,
+            # Hide all standard components
+            header=ComponentRegion(0, 0, 800, 40, visible=False),
+            week_view=ComponentRegion(0, 0, 800, 320, visible=False),
+            weather=ComponentRegion(0, 0, 300, 120, visible=False),
+            birthdays=ComponentRegion(0, 0, 250, 120, visible=False),
+            info=ComponentRegion(0, 0, 250, 120, visible=False),
+            today_view=ComponentRegion(0, 0, 800, 280, visible=False),
+            qotd=ComponentRegion(0, 0, 800, 400, visible=False),
+            # Full-screen weather region
+            weather_full=ComponentRegion(0, 0, 800, 480),
+            draw_order=["weather_full"],
+        ),
+        style=ThemeStyle(
+            fg=0,   # black on white — optimal eInk contrast
+            bg=1,
+            invert_header=False,
+            invert_today_col=False,
+            invert_allday_bars=False,
+            show_borders=False,   # whitespace-defined layout
+            font_regular=dm_regular,
+            font_medium=dm_medium,
+            font_semibold=dm_semibold,
+            font_bold=dm_bold,
+            label_font_size=10,
+            label_font_weight="semibold",
+        ),
+    )

--- a/tests/test_weather_theme.py
+++ b/tests/test_weather_theme.py
@@ -1,0 +1,253 @@
+"""Tests for the full-screen weather theme and weather_full component."""
+
+from datetime import date, datetime, timedelta
+
+from PIL import Image, ImageDraw
+
+from src.config import DisplayConfig
+from src.data.models import (
+    DashboardData, DayForecast, WeatherAlert, WeatherData,
+)
+from src.render.canvas import render_dashboard
+from src.render.components.weather_full import draw_weather_full
+from src.render.theme import (
+    AVAILABLE_THEMES, ComponentRegion, ThemeLayout, load_theme,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_weather(**overrides) -> WeatherData:
+    defaults = dict(
+        current_temp=72.0,
+        current_icon="01d",
+        current_description="clear sky",
+        high=78.0,
+        low=60.0,
+        humidity=45,
+        forecast=[
+            DayForecast(
+                date=date(2024, 3, 16) + timedelta(days=i),
+                high=58.0 + i * 2,
+                low=42.0 + i,
+                icon="02d",
+                description="partly cloudy",
+                precip_chance=0.1 * i,
+            )
+            for i in range(5)
+        ],
+        feels_like=70.0,
+        wind_speed=5.0,
+        wind_deg=315.0,
+        pressure=1013.0,
+        uv_index=3.0,
+        sunrise=datetime(2024, 3, 15, 6, 24),
+        sunset=datetime(2024, 3, 15, 19, 45),
+    )
+    defaults.update(overrides)
+    return WeatherData(**defaults)
+
+
+def _make_data(weather=None) -> DashboardData:
+    today = date(2024, 3, 15)
+    now = datetime.combine(today, datetime.min.time().replace(hour=8))
+    return DashboardData(
+        fetched_at=now,
+        events=[],
+        weather=weather,
+        birthdays=[],
+    )
+
+
+def _draw_surface():
+    img = Image.new("1", (800, 480), 1)
+    return ImageDraw.Draw(img)
+
+
+# ---------------------------------------------------------------------------
+# Theme registration tests
+# ---------------------------------------------------------------------------
+
+class TestWeatherThemeRegistration:
+    def test_weather_in_available_themes(self):
+        assert "weather" in AVAILABLE_THEMES
+
+    def test_load_theme_returns_weather(self):
+        theme = load_theme("weather")
+        assert theme.name == "weather"
+
+    def test_weather_full_region_covers_canvas(self):
+        theme = load_theme("weather")
+        r = theme.layout.weather_full
+        assert r.x == 0
+        assert r.y == 0
+        assert r.w == 800
+        assert r.h == 480
+        assert r.visible is True
+
+    def test_standard_regions_hidden(self):
+        theme = load_theme("weather")
+        layout = theme.layout
+        assert not layout.header.visible
+        assert not layout.week_view.visible
+        assert not layout.birthdays.visible
+        assert not layout.info.visible
+        assert not layout.today_view.visible
+
+    def test_draw_order_uses_weather_full(self):
+        theme = load_theme("weather")
+        assert theme.layout.draw_order == ["weather_full"]
+
+    def test_style_borderless(self):
+        theme = load_theme("weather")
+        assert theme.style.show_borders is False
+
+    def test_style_black_on_white(self):
+        theme = load_theme("weather")
+        assert theme.style.fg == 0
+        assert theme.style.bg == 1
+
+    def test_weather_full_default_invisible_on_other_themes(self):
+        """The weather_full region should be hidden by default on non-weather themes."""
+        layout = ThemeLayout()
+        assert not layout.weather_full.visible
+
+
+# ---------------------------------------------------------------------------
+# Rendering integration tests
+# ---------------------------------------------------------------------------
+
+class TestWeatherThemeRendering:
+    def test_renders_valid_image_with_full_data(self):
+        theme = load_theme("weather")
+        data = _make_data(weather=_make_weather())
+        config = DisplayConfig()
+        img = render_dashboard(data, config, theme=theme)
+        assert isinstance(img, Image.Image)
+        assert img.size[0] > 0
+        assert img.size[1] > 0
+
+    def test_renders_with_none_weather(self):
+        theme = load_theme("weather")
+        data = _make_data(weather=None)
+        config = DisplayConfig()
+        img = render_dashboard(data, config, theme=theme)
+        assert isinstance(img, Image.Image)
+
+    def test_renders_with_alerts(self):
+        weather = _make_weather(
+            alerts=[WeatherAlert(event="Flood Watch"), WeatherAlert(event="Wind Advisory")],
+        )
+        theme = load_theme("weather")
+        data = _make_data(weather=weather)
+        config = DisplayConfig()
+        img = render_dashboard(data, config, theme=theme)
+        assert isinstance(img, Image.Image)
+
+    def test_renders_with_minimal_data(self):
+        weather = WeatherData(
+            current_temp=55.0,
+            current_icon="03d",
+            current_description="overcast",
+            high=60.0,
+            low=45.0,
+            humidity=80,
+        )
+        theme = load_theme("weather")
+        data = _make_data(weather=weather)
+        config = DisplayConfig()
+        img = render_dashboard(data, config, theme=theme)
+        assert isinstance(img, Image.Image)
+
+
+# ---------------------------------------------------------------------------
+# Component unit tests
+# ---------------------------------------------------------------------------
+
+class TestDrawWeatherFull:
+    def test_none_weather_does_not_crash(self):
+        draw = _draw_surface()
+        draw_weather_full(draw, None, today=date(2024, 3, 15))
+
+    def test_basic_weather(self):
+        draw = _draw_surface()
+        weather = _make_weather()
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_all_optional_fields(self):
+        draw = _draw_surface()
+        weather = _make_weather()
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_no_optional_fields(self):
+        draw = _draw_surface()
+        weather = WeatherData(
+            current_temp=55.0,
+            current_icon="01d",
+            current_description="clear",
+            high=60.0,
+            low=45.0,
+            humidity=50,
+        )
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_with_alerts(self):
+        draw = _draw_surface()
+        weather = _make_weather(
+            alerts=[WeatherAlert(event="Tornado Warning")],
+        )
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_empty_forecast(self):
+        draw = _draw_surface()
+        weather = _make_weather(forecast=[])
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_many_forecast_days_capped_at_five(self):
+        draw = _draw_surface()
+        forecast = [
+            DayForecast(
+                date=date(2024, 3, 16) + timedelta(days=i),
+                high=60.0 + i, low=40.0 + i,
+                icon="02d", description="cloudy",
+            )
+            for i in range(10)
+        ]
+        weather = _make_weather(forecast=forecast)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_wind_without_direction(self):
+        draw = _draw_surface()
+        weather = _make_weather(wind_speed=10.0, wind_deg=None)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_negative_temperature(self):
+        draw = _draw_surface()
+        weather = _make_weather(current_temp=-15.0, high=-5.0, low=-20.0)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_custom_region(self):
+        draw = _draw_surface()
+        weather = _make_weather()
+        region = ComponentRegion(10, 10, 780, 460)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15), region=region)
+
+    def test_no_today_date(self):
+        """Moon phase is skipped when today is None."""
+        draw = _draw_surface()
+        weather = _make_weather()
+        draw_weather_full(draw, weather, today=None)
+
+    def test_pressure_shown_in_detail_when_uv_in_cards(self):
+        """When UV is available, pressure appears in the detail strip."""
+        draw = _draw_surface()
+        weather = _make_weather(uv_index=5.0, pressure=1020.0)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+    def test_pressure_in_cards_when_no_uv(self):
+        """When UV is None, pressure takes the 4th card slot."""
+        draw = _draw_surface()
+        weather = _make_weather(uv_index=None, pressure=1015.0)
+        draw_weather_full(draw, weather, today=date(2024, 3, 15))


### PR DESCRIPTION
New theme devotes the entire 800x480 canvas to a rich weather display:
- Hero section: large 70px weather icon, 64pt temperature, condition text, H/L range
- Metric cards: four rounded-rect cards (feels like, wind, humidity, UV/pressure)
- Detail strip: sunrise/sunset, pressure, moon phase in a centered line
- 5-day forecast grid: day names, weather icons, hi/lo temps, precipitation chance
- Alert banner: inverted bar when weather alerts are present

Uses DM Sans font for a clean, modern, geometric aesthetic. Borderless
whitespace-defined layout. Handles graceful degradation for missing data,
fewer forecast days, and multiple alerts.

Files added:
- src/render/components/weather_full.py (full-screen weather component)
- src/render/themes/weather.py (theme factory)
- tests/test_weather_theme.py (22 tests)

Files modified:
- src/render/theme.py (weather_full region + AVAILABLE_THEMES + load_theme)
- src/render/canvas.py (weather_full dispatcher entry)

https://claude.ai/code/session_01QMDMdY3VEFwDCow2RejB5k