### PR TITLE
docs: add PurpleAir API key to the configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ weather:
   longitude: -74.0060
   units: "imperial"             # "imperial" (F) or "metric" (C)
 
+purpleair:                      # optional — adds AQI card to the weather theme
+  api_key: "your-purpleair-key" # free key at develop.purpleair.com
+  sensor_id: 12345              # find at map.purpleair.com (click sensor → URL)
+
 timezone: "America/New_York"    # IANA timezone, or "local" for system clock
 ```
 
 See [Google Calendar Setup](#google-calendar-setup) for how to get a service account and
 calendar ID. Get a free weather API key at [openweathermap.org](https://openweathermap.org/api).
+Get a free PurpleAir API key at [develop.purpleair.com](https://develop.purpleair.com).
 
 ### 3. Preview with dummy data
 


### PR DESCRIPTION
The step-2 config snippet in the README was missing the purpleair
block. Added api_key and sensor_id with inline comments and a link
to develop.purpleair.com, matching the style of the rest of the
quick-start section.

https://claude.ai/code/session_01TthQD4Kjpof42WrCRrBjyR