### PR TITLE
Add rock-solid Pi install path: make pi-install, configure, pi-enable, pi-status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dry test deploy setup install check previews version
+.PHONY: dry test deploy setup install check previews version \
+        pi-install pi-enable pi-status pi-logs configure
 
 VENV = venv/bin/python
 
@@ -45,6 +46,75 @@ install:
 		sudo systemctl enable --now dashboard.timer && \
 		echo 'Timer enabled. Status:' && \
 		sudo systemctl status dashboard.timer --no-pager"
+
+pi-install:
+	@echo "==> Installing system dependencies..."
+	@if ! grep -q "Raspberry Pi" /proc/device-tree/model 2>/dev/null; then \
+		echo "WARNING: This does not appear to be a Raspberry Pi. Continuing anyway."; \
+	fi
+	sudo apt-get update -qq
+	sudo apt-get install -y python3-dev python3-venv libopenjp2-7 libtiff5 git swig liblgpio-dev
+	@echo ""
+	@echo "==> Enabling SPI interface..."
+	sudo raspi-config nonint do_spi 0
+	@echo ""
+	@echo "==> Creating Python virtual environment..."
+	python3 -m venv venv
+	venv/bin/pip install --quiet --upgrade pip
+	venv/bin/pip install -r requirements.txt -r requirements-pi.txt
+	@echo ""
+	@echo "==> Installing Waveshare EPD library..."
+	git clone --depth=1 https://github.com/waveshare/e-Paper /tmp/waveshare-epd
+	venv/bin/pip install --quiet /tmp/waveshare-epd/RaspberryPi_JetsonNano/python/
+	rm -rf /tmp/waveshare-epd
+	venv/bin/python -c "import waveshare_epd; print('  Waveshare EPD: OK')"
+	@echo ""
+	@mkdir -p credentials output
+	@if [ ! -f config/config.yaml ]; then \
+		cp config/config.example.yaml config/config.yaml; \
+	fi
+	@echo "============================================"
+	@echo "  pi-install complete!"
+	@echo ""
+	@echo "  NOTE: If SPI was just enabled for the first"
+	@echo "  time, reboot before running on real hardware:"
+	@echo "    sudo reboot"
+	@echo ""
+	@echo "  Next steps:"
+	@echo "    make configure   -- fill in your API keys"
+	@echo "    make dry         -- preview with dummy data"
+	@echo "    make pi-enable   -- start the refresh timer"
+	@echo "============================================"
+
+pi-enable:
+	@echo "==> Installing systemd units with current paths..."
+	@INSTALL_DIR="$$(pwd)"; USER_NAME="$$(whoami)"; \
+	sed -e "s|__INSTALL_DIR__|$$INSTALL_DIR|g" \
+	    -e "s|__USER__|$$USER_NAME|g" \
+	    deploy/dashboard.service | sudo tee /etc/systemd/system/dashboard.service > /dev/null; \
+	sudo cp deploy/dashboard.timer /etc/systemd/system/dashboard.timer; \
+	sudo systemctl daemon-reload; \
+	sudo systemctl enable --now dashboard.timer
+	@echo ""
+	@$(MAKE) pi-status
+
+pi-status:
+	@echo "=== Timer ==="
+	@sudo systemctl status dashboard.timer --no-pager || true
+	@echo ""
+	@echo "=== Last service run ==="
+	@sudo systemctl status dashboard.service --no-pager || true
+	@if [ -f output/dashboard.log ]; then \
+		echo ""; \
+		echo "=== Recent log (last 20 lines) ==="; \
+		tail -20 output/dashboard.log; \
+	fi
+
+pi-logs:
+	tail -f output/dashboard.log
+
+configure:
+	@deploy/configure.sh
 
 setup:
 	python3 -m venv venv

--- a/README.md
+++ b/README.md
@@ -10,69 +10,50 @@ display.
 
 ## Quick Start
 
-### 1. Clone and install
+SSH into your Pi, then run these commands from the project directory:
 
 ```bash
-git clone https://github.com/gkoch02/Dashboard-v4.git
-cd Dashboard-v4
-make setup
+git clone https://github.com/gkoch02/Dashboard-v4.git ~/home-dashboard
+cd ~/home-dashboard
+make pi-install    # apt deps, SPI, Python venv, Waveshare drivers — all in one
+make configure     # interactive prompts fill in your API keys and settings
+make dry           # render a preview with dummy data — no hardware needed
+make pi-enable     # install and start the systemd refresh timer
+make pi-status     # confirm the timer is active and healthy
 ```
 
-This creates a virtual environment, installs dependencies, and copies the config template
-to `config/config.yaml`.
+That's it. The dashboard starts refreshing every 5 minutes automatically.
 
-### 2. Configure
+> **Note:** `make pi-install` enables SPI via `raspi-config`. If SPI was not previously
+> enabled on your Pi, reboot once before running on real hardware (`sudo reboot`).
+> `make configure` and `make dry` work fine before the reboot.
 
-Open `config/config.yaml` and fill in the required fields:
+---
 
-```yaml
-display:
-  model: "epd7in5_V2"          # your Waveshare model (see supported list below)
+## make configure
 
-google:
-  service_account_path: "credentials/service_account.json"
-  calendar_id: "abc123@group.calendar.google.com"
+`make configure` is an interactive wizard that writes your settings directly into
+`config/config.yaml`. Run it after `make pi-install`.
 
-weather:
-  api_key: "your-openweathermap-key"
-  latitude: 40.7128
-  longitude: -74.0060
-  units: "imperial"             # "imperial" (F) or "metric" (C)
-
-purpleair:                      # optional — adds AQI card to the weather theme
-  api_key: "your-purpleair-key" # free key at develop.purpleair.com
-  sensor_id: 12345              # find at map.purpleair.com (click sensor → URL)
-
-timezone: "America/New_York"    # IANA timezone, or "local" for system clock
+```
+Display model [epd7in5_V2]:
+OpenWeatherMap API key:
+Latitude:
+Longitude:
+Units (imperial/metric) [imperial]:
+Google Calendar ID:
+Timezone [America/New_York]:
+PurpleAir API key (optional, press Enter to skip):
+PurpleAir sensor ID (optional, press Enter to skip):
 ```
 
-See [Google Calendar Setup](#google-calendar-setup) for how to get a service account and
-calendar ID. Get a free weather API key at [openweathermap.org](https://openweathermap.org/api).
-Get a free PurpleAir API key at [develop.purpleair.com](https://develop.purpleair.com).
+Existing values are shown as defaults — it is safe to re-run at any time to change a
+setting. The wizard ends by running `make check` to validate your configuration.
 
-### 3. Preview with dummy data
-
-```bash
-make dry
-```
-
-Opens `output/latest.png` with realistic dummy data. No API keys or hardware needed.
-
-### 4. Preview with live data
-
-```bash
-venv/bin/python -m src.main --dry-run --config config/config.yaml
-```
-
-Fetches real calendar/weather data and renders to `output/latest.png`.
-
-### 5. Validate your config
-
-```bash
-make check
-```
-
-Reports errors (must fix) and warnings (may cause issues) in your configuration.
+**Google service account JSON** cannot be fetched automatically — it requires a
+one-time browser download from Google Cloud Console. The wizard guides you through
+placing it at `credentials/service_account.json` and links to the
+[Google Calendar Setup](#google-calendar-setup) instructions.
 
 ---
 
@@ -521,63 +502,59 @@ birthdays:
 
 ---
 
-## Raspberry Pi Deployment
+## Raspberry Pi Reference
+
+> The steps below are what `make pi-install`, `make configure`, and `make pi-enable` do
+> under the hood. Use this section for troubleshooting or if you prefer a manual setup.
 
 ### Step 1 -- Enable SPI
 
 ```bash
-sudo raspi-config
-# Interface Options > SPI > Yes > reboot
+sudo raspi-config nonint do_spi 0
+sudo reboot
 ```
 
-### Step 2 -- Deploy the project
+Or interactively: **Interface Options > SPI > Yes > reboot**.
 
-From your development machine:
+### Step 2 -- System dependencies
 
 ```bash
-make deploy
+sudo apt-get install -y python3-dev python3-venv libopenjp2-7 libtiff5 git swig liblgpio-dev
 ```
 
-Rsyncs to `~/home-dashboard/` on `pi@raspberrypi.local` by default. Override
-the target via Make variables:
+### Step 3 -- Python environment
 
 ```bash
-make deploy PI_USER=myuser PI_HOST=mypi.local PI_DIR=~/dashboard
+python3 -m venv venv
+venv/bin/pip install -r requirements.txt -r requirements-pi.txt
 ```
 
-### Step 3 -- Set up on the Pi
+### Step 4 -- Waveshare display drivers
 
 ```bash
-sudo apt install swig liblgpio-dev
-cd ~/home-dashboard
-make setup
-venv/bin/pip install -r requirements-pi.txt
-```
-
-### Step 4 -- Install Waveshare display drivers
-
-```bash
-git clone https://github.com/waveshare/e-Paper ~/e-Paper
-cd ~/home-dashboard
-venv/bin/pip install ~/e-Paper/RaspberryPi_JetsonNano/python/
+git clone --depth=1 https://github.com/waveshare/e-Paper /tmp/waveshare-epd
+venv/bin/pip install /tmp/waveshare-epd/RaspberryPi_JetsonNano/python/
 venv/bin/python -c "import waveshare_epd; print('OK')"
 ```
 
-### Step 5 -- Test
+### Step 5 -- Configure and test
 
 ```bash
+cp config/config.example.yaml config/config.yaml
+# edit config/config.yaml and place credentials/service_account.json
+make check
+make dry
 venv/bin/python -m src.main --config config/config.yaml
 ```
 
 ### Step 6 -- Install the systemd timer
 
-> **Note:** The `deploy/dashboard.service` file contains hardcoded paths
-> (`/home/pi/home-dashboard`). Edit them if your Pi user or install directory
-> differs from the defaults.
+`make pi-enable` generates the service file with the correct paths for your user and
+install directory automatically:
 
 ```bash
-make install
-ssh pi@raspberrypi.local "systemctl status dashboard.timer"
+make pi-enable
+make pi-status
 ```
 
 The timer fires every 5 minutes. The app handles scheduling internally:
@@ -595,6 +572,18 @@ schedule:
   quiet_hours_start: 23   # 11 PM
   quiet_hours_end: 6      # 6 AM
 ```
+
+### Remote deploy (dev machine → Pi)
+
+If you prefer to develop on a separate machine and push to the Pi via rsync:
+
+```bash
+make deploy                                          # rsync to pi@raspberrypi.local:~/home-dashboard
+make deploy PI_USER=myuser PI_HOST=mypi.local        # override target
+```
+
+After deploying, SSH to the Pi and run `make pi-install` once to install system
+dependencies, then `make pi-enable` to start the timer.
 
 ---
 
@@ -780,6 +769,18 @@ to `output/calendar_sync_state.json`.
 
 ### Makefile targets
 
+#### On-Pi targets
+
+| Command | What it does |
+|---|---|
+| `make pi-install` | apt deps, SPI enable, Python venv, Waveshare drivers — full Pi setup in one command |
+| `make configure` | Interactive wizard: fills `config/config.yaml` with your API keys and settings |
+| `make pi-enable` | Generate and install systemd service (with correct paths) + enable timer |
+| `make pi-status` | Show timer status, last service run, and recent log tail |
+| `make pi-logs` | `tail -f output/dashboard.log` |
+
+#### Dev targets
+
 | Command | What it does |
 |---|---|
 | `make setup` | Create venv, install dependencies, create config from template |
@@ -788,7 +789,7 @@ to `output/calendar_sync_state.json`.
 | `make check` | Validate config file and exit |
 | `make version` | Print the current version (e.g. `main.py 4.1.0`) |
 | `make deploy` | rsync project to Raspberry Pi (`PI_USER`, `PI_HOST`, `PI_DIR` configurable) |
-| `make install` | Copy systemd timer/service to Pi and enable |
+| `make install` | Copy systemd timer/service to Pi and enable (legacy remote path) |
 
 ### CLI flags
 
@@ -828,8 +829,9 @@ Dashboard-v4/
 │   └── quotes.json               # Daily quote pool (125 entries)
 ├── credentials/                  # Git-ignored -- Google service account JSON
 ├── deploy/
-│   ├── dashboard.service         # Systemd service unit
-│   └── dashboard.timer           # Systemd timer (fires every 5 min)
+│   ├── dashboard.service         # Systemd service template (paths filled by make pi-enable)
+│   ├── dashboard.timer           # Systemd timer (fires every 5 min)
+│   └── configure.sh              # Interactive config wizard (invoked by make configure)
 ├── fonts/                        # Bundled TTF fonts
 ├── output/                       # Mostly git-ignored
 │   └── latest.png                # Latest dry-run preview (tracked)

--- a/deploy/configure.sh
+++ b/deploy/configure.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Interactive configuration wizard for Home Dashboard.
+# Run via: make configure
+# Safe to re-run — existing values are shown as defaults.
+
+set -euo pipefail
+
+CONFIG="config/config.yaml"
+
+if [ ! -f "$CONFIG" ]; then
+  cp config/config.example.yaml "$CONFIG"
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: read current value from config, strip quotes
+# ---------------------------------------------------------------------------
+current() {
+  local key="$1"
+  grep -m1 "^\s*${key}:" "$CONFIG" 2>/dev/null \
+    | sed 's/.*:\s*//' | tr -d '"' | xargs || true
+}
+
+prompt() {
+  local label="$1" default="$2" varname="$3"
+  if [ -n "$default" ]; then
+    read -rp "  ${label} [${default}]: " val
+    val="${val:-$default}"
+  else
+    read -rp "  ${label}: " val
+  fi
+  eval "$varname=\$val"
+}
+
+echo ""
+echo "======================================"
+echo "  Home Dashboard — Configuration"
+echo "======================================"
+echo ""
+echo "Press Enter to keep the current value shown in [brackets]."
+echo ""
+
+# --- Display model ---
+echo "--- Display ---"
+echo "  Supported models: epd7in5 epd7in5_V2 epd7in5_V3 epd7in5b_V2 epd7in5_HD epd9in7 epd13in3k"
+prompt "Display model" "$(current model)" DISPLAY_MODEL
+echo ""
+
+# --- Weather ---
+echo "--- Weather (openweathermap.org — free API key) ---"
+prompt "OpenWeatherMap API key" "$(current api_key)" WEATHER_KEY
+prompt "Latitude" "$(current latitude)" LAT
+prompt "Longitude" "$(current longitude)" LON
+prompt "Units (imperial/metric)" "$(current units)" UNITS
+echo ""
+
+# --- Timezone ---
+echo "--- Timezone ---"
+echo "  Use an IANA name (e.g. America/New_York) or \"local\" for system clock."
+prompt "Timezone" "$(current timezone)" TIMEZONE
+echo ""
+
+# --- Google Calendar ---
+echo "--- Google Calendar ---"
+echo "  Calendar ID looks like: abc123@group.calendar.google.com"
+echo "  See README > Google Calendar Setup for service account instructions."
+prompt "Calendar ID" "$(current calendar_id)" CALENDAR_ID
+echo ""
+
+# --- PurpleAir (optional) ---
+echo "--- PurpleAir AQI (optional — press Enter to skip) ---"
+echo "  Free API key at develop.purpleair.com"
+echo "  Find sensor ID at map.purpleair.com (click sensor → check URL)"
+prompt "PurpleAir API key" "$(current purpleair_api_key 2>/dev/null || true)" PA_KEY
+prompt "PurpleAir sensor ID" "$(current sensor_id 2>/dev/null || true)" PA_SENSOR
+echo ""
+
+# ---------------------------------------------------------------------------
+# Write values into config.yaml using Python for reliable YAML editing
+# ---------------------------------------------------------------------------
+venv/bin/python - <<PYEOF
+import re, sys
+
+with open("$CONFIG") as f:
+    text = f.read()
+
+def set_scalar(text, key, value, section=None):
+    """Replace the first occurrence of 'key: <anything>' (optionally under section)."""
+    pattern = r'(?m)^(\s*{key}:\s*).*$'.format(key=re.escape(key))
+    replacement = r'\g<1>{value}'.format(value=value)
+    new_text, n = re.subn(pattern, replacement, text, count=1)
+    if n == 0:
+        # Append if not found (shouldn't happen with a valid template)
+        new_text = text.rstrip() + "\n{key}: {value}\n".format(key=key, value=value)
+    return new_text
+
+# Quote strings, leave numbers bare
+def q(v):
+    try:
+        float(v)
+        return v
+    except (ValueError, TypeError):
+        return '"{}"'.format(v) if v else '""'
+
+text = set_scalar(text, "model", q("$DISPLAY_MODEL"))
+
+# Weather section — api_key appears multiple times; target only the weather one
+# We look for the first api_key after the 'weather:' header
+lines = text.splitlines(keepends=True)
+in_weather = False
+for i, line in enumerate(lines):
+    stripped = line.strip()
+    if stripped == "weather:":
+        in_weather = True
+    elif in_weather and re.match(r"^\S", line) and not line.startswith(" ") and stripped != "weather:":
+        in_weather = False
+    if in_weather and re.match(r"^\s+api_key:", line):
+        lines[i] = re.sub(r"(api_key:\s*).*", r"\g<1>" + q("$WEATHER_KEY"), line)
+        in_weather = False
+text = "".join(lines)
+
+text = set_scalar(text, "latitude", "$LAT")
+text = set_scalar(text, "longitude", "$LON")
+text = set_scalar(text, "units", q("$UNITS"))
+text = set_scalar(text, "timezone", q("$TIMEZONE"))
+text = set_scalar(text, "calendar_id", q("$CALENDAR_ID"))
+
+# PurpleAir — only write if provided
+pa_key = "$PA_KEY"
+pa_sensor = "$PA_SENSOR"
+if pa_key:
+    # api_key under purpleair section
+    lines = text.splitlines(keepends=True)
+    in_pa = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "purpleair:":
+            in_pa = True
+        elif in_pa and re.match(r"^\S", line) and stripped != "purpleair:":
+            in_pa = False
+        if in_pa and re.match(r"^\s+api_key:", line):
+            lines[i] = re.sub(r"(api_key:\s*).*", r"\g<1>" + q(pa_key), line)
+            in_pa = False
+    text = "".join(lines)
+
+if pa_sensor:
+    text = set_scalar(text, "sensor_id", pa_sensor)
+
+with open("$CONFIG", "w") as f:
+    f.write(text)
+
+print("  config/config.yaml updated.")
+PYEOF
+
+echo ""
+echo "--- Google service account credentials ---"
+echo ""
+echo "  The service account JSON must be downloaded manually from Google Cloud Console."
+echo "  See README > Google Calendar Setup for step-by-step instructions."
+echo ""
+echo "  Expected path: credentials/service_account.json"
+echo ""
+if [ -f "credentials/service_account.json" ]; then
+  echo "  ✓ credentials/service_account.json already present."
+else
+  read -rp "  Press Enter when the file is in place (or Ctrl-C to do it later)..." _
+  if [ -f "credentials/service_account.json" ]; then
+    echo "  ✓ Found credentials/service_account.json"
+  else
+    echo "  WARNING: credentials/service_account.json not found."
+    echo "  Calendar data will not load until it is added."
+  fi
+fi
+
+echo ""
+echo "==> Validating configuration..."
+make check && echo "" && echo "Configuration looks good. Run 'make dry' to preview the dashboard."

--- a/deploy/dashboard.service
+++ b/deploy/dashboard.service
@@ -5,10 +5,10 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-# Customize User and WorkingDirectory for your Pi setup.
-# Default assumes user "pi" with the repo at ~/home-dashboard.
-User=pi
-WorkingDirectory=/home/pi/home-dashboard
-ExecStart=/home/pi/home-dashboard/venv/bin/python -m src.main --config config/config.yaml
-StandardOutput=append:/home/pi/home-dashboard/output/dashboard.log
-StandardError=append:/home/pi/home-dashboard/output/dashboard.log
+# These values are filled in automatically by `make pi-enable`.
+# __USER__ and __INSTALL_DIR__ are substituted with the current user and repo path.
+User=__USER__
+WorkingDirectory=__INSTALL_DIR__
+ExecStart=__INSTALL_DIR__/venv/bin/python -m src.main --config config/config.yaml
+StandardOutput=append:__INSTALL_DIR__/output/dashboard.log
+StandardError=append:__INSTALL_DIR__/output/dashboard.log


### PR DESCRIPTION
Replaces the 6-step manual Pi setup with four make targets that handle
everything from a single clone:

- make pi-install: apt deps, SPI enable, Python venv, Waveshare drivers
- make configure: interactive wizard fills config.yaml with API keys;
  guided pause for Google service account JSON
- make pi-enable: generates systemd service with correct paths (no more
  hardcoded /home/pi) and enables the timer
- make pi-status / make pi-logs: live status and log tail

Also fixes deploy/dashboard.service to use __USER__/__INSTALL_DIR__
placeholders substituted at install time rather than hardcoded paths.

README Quick Start is now the canonical Pi flow (5 commands). The old
step-by-step walkthrough moves to a "Raspberry Pi Reference" section
for troubleshooting.

https://claude.ai/code/session_017ifQEpPZmxg82Zyukdo2Y7