### PR TITLE
Add breaker bypass flag and tighten retry/AQI handling

### DIFF
--- a/src/fetchers/purpleair.py
+++ b/src/fetchers/purpleair.py
@@ -13,6 +13,7 @@ API reference: https://community.purpleair.com/t/making-api-calls/180
 """
 
 import logging
+import math
 from typing import Any
 
 import requests
@@ -62,7 +63,7 @@ _AQI_CATEGORIES = [
 
 def _pm25_to_aqi(pm25: float) -> tuple[int, str]:
     """Compute EPA AQI integer and category string from a PM2.5 µg/m³ reading."""
-    pm25 = round(pm25, 1)  # EPA truncates to 1 decimal place before lookup
+    pm25 = math.floor(pm25 * 10) / 10  # EPA truncates to 1 decimal place before lookup
     for c_lo, c_hi, i_lo, i_hi in _PM25_BP:
         if c_lo <= pm25 <= c_hi:
             aqi = round((i_hi - i_lo) / (c_hi - c_lo) * (pm25 - c_lo) + i_lo)

--- a/src/main.py
+++ b/src/main.py
@@ -35,10 +35,12 @@ def _resolve_tz(tz_name: str) -> tzinfo:
 
 
 def _retry_fetch(label: str, fn):
-    """Attempt fn() twice immediately to handle transient network errors."""
+    """Attempt fn() twice only for likely transient failures."""
     try:
         return fn()
     except Exception as exc:
+        if isinstance(exc, (RuntimeError, ValueError, TypeError, KeyError)):
+            raise
         logger.warning("%s failed, retrying: %s", label, exc)
     return fn()  # let the exception propagate on second failure
 
@@ -65,6 +67,7 @@ def _is_morning_startup(now: datetime, quiet_hours_end: int) -> bool:
 def fetch_live_data(
     cfg, cache_dir: str, tz: tzinfo | None = None,
     force_refresh: bool = False,
+    ignore_breakers: bool = False,
 ) -> DashboardData:
     """Fetch live data from all APIs in parallel, falling back to per-source cache on failure.
 
@@ -149,7 +152,7 @@ def fetch_live_data(
         if recent:
             return data, True
         # Check circuit breaker
-        if not breaker.should_attempt(source):
+        if not ignore_breakers and not breaker.should_attempt(source):
             logger.info("Circuit breaker OPEN for %s, using cache", source)
             cached_data = _use_cache(source)
             return cached_data, True
@@ -317,6 +320,11 @@ def main():
         "--force-full-refresh", action="store_true", help="Force a full display refresh",
     )
     parser.add_argument(
+        "--ignore-breakers",
+        action="store_true",
+        help="Ignore circuit breaker OPEN state for this run and attempt fetches anyway",
+    )
+    parser.add_argument(
         "--dummy", action="store_true",
         help="Use dummy data instead of fetching from APIs",
     )
@@ -413,6 +421,7 @@ def main():
         data = fetch_live_data(
             cfg, cache_dir=cfg.output_dir, tz=tz,
             force_refresh=force_full,
+            ignore_breakers=args.ignore_breakers,
         )
 
     # Apply event filters

--- a/tests/test_fetch_live_data.py
+++ b/tests/test_fetch_live_data.py
@@ -283,6 +283,29 @@ class TestCircuitBreakerOpenPath:
         # Cached weather should have been used
         assert data.weather is not None and data.weather.current_temp == 55.0
 
+    def test_ignore_breakers_fetches_even_when_open(self):
+        from src.fetchers.circuit_breaker import CircuitBreaker
+        cfg = Config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _make_cached(tmpdir)
+            breaker = CircuitBreaker(
+                max_failures=3,
+                cooldown_minutes=60,
+                state_dir=tmpdir,
+            )
+            for source in ("events", "weather", "birthdays"):
+                for _ in range(3):
+                    breaker.record_failure(source)
+
+            with patch("src.main.fetch_events", return_value=[]) as mock_events, \
+                 patch("src.main.fetch_weather", return_value=_make_weather()) as mock_weather, \
+                 patch("src.main.fetch_birthdays", return_value=[]) as mock_bdays:
+                fetch_live_data(cfg, tmpdir, ignore_breakers=True)
+
+        mock_events.assert_called_once()
+        mock_weather.assert_called_once()
+        mock_bdays.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Birthday cache fallback — lines 421-422

--- a/tests/test_main_entry.py
+++ b/tests/test_main_entry.py
@@ -277,6 +277,22 @@ class TestMainLiveDataPath:
         mock_fetch.assert_called_once()
         assert (tmp_path / "latest.png").exists()
 
+    def test_ignore_breakers_flag_passed_to_fetch_live_data(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        _write_minimal_config(config_path)
+
+        from src.main import generate_dummy_data
+        fake_data = generate_dummy_data()
+
+        with patch("sys.argv", [
+            "main", "--dry-run", "--ignore-breakers", "--config", str(config_path),
+        ]):
+            from src.main import main
+            with patch("src.main.fetch_live_data", return_value=fake_data) as mock_fetch:
+                main()
+
+        assert mock_fetch.call_args.kwargs["ignore_breakers"] is True
+
     def test_image_unchanged_skips_hardware_refresh(self, tmp_path):
         """When image_changed returns False, the display refresh is skipped (lines 528-529)."""
         import yaml

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -19,20 +19,26 @@ class TestRetryFetch:
         assert fn.call_count == 1
 
     def test_retries_on_first_failure(self):
-        fn = MagicMock(side_effect=[ValueError("oops"), 99])
+        fn = MagicMock(side_effect=[Exception("oops"), 99])
         result = _retry_fetch("test", fn)
         assert result == 99
         assert fn.call_count == 2
 
     def test_raises_on_second_failure(self):
-        fn = MagicMock(side_effect=ValueError("always fails"))
-        with pytest.raises(ValueError, match="always fails"):
+        fn = MagicMock(side_effect=Exception("always fails"))
+        with pytest.raises(Exception, match="always fails"):
             _retry_fetch("test", fn)
         assert fn.call_count == 2
 
+    def test_does_not_retry_on_runtime_error(self):
+        fn = MagicMock(side_effect=RuntimeError("permanent failure"))
+        with pytest.raises(RuntimeError, match="permanent failure"):
+            _retry_fetch("test", fn)
+        assert fn.call_count == 1
+
     def test_label_included_in_warning_log(self, caplog):
         import logging
-        fn = MagicMock(side_effect=[RuntimeError("boom"), "ok"])
+        fn = MagicMock(side_effect=[Exception("boom"), "ok"])
         with caplog.at_level(logging.WARNING, logger="src.main"):
             _retry_fetch("MyLabel", fn)
         assert "MyLabel" in caplog.text

--- a/tests/test_purpleair_fetcher.py
+++ b/tests/test_purpleair_fetcher.py
@@ -68,10 +68,12 @@ class TestPm25ToAqi:
 
     def test_truncates_to_one_decimal(self):
         # EPA requires truncation to 1dp before lookup
-        aqi1, _ = _pm25_to_aqi(12.049)  # rounds to 12.0 → Good
-        aqi2, _ = _pm25_to_aqi(12.099)  # rounds to 12.1 → Moderate
+        aqi1, _ = _pm25_to_aqi(12.049)  # truncates to 12.0 → Good
+        aqi2, _ = _pm25_to_aqi(12.099)  # truncates to 12.0 → Good
+        aqi3, _ = _pm25_to_aqi(12.199)  # truncates to 12.1 → Moderate
         assert aqi1 == 50
-        assert aqi2 == 51
+        assert aqi2 == 50
+        assert aqi3 == 51
 
 
 class TestAqiCategory:


### PR DESCRIPTION
## Summary
- add a one-run CLI override (`--ignore-breakers`) that bypasses OPEN circuit breakers and attempts live fetches
- stop immediate retries for likely permanent failures in `_retry_fetch` (`RuntimeError`, `ValueError`, `TypeError`, `KeyError`)
- make PM2.5 AQI conversion use true one-decimal truncation (matching EPA behavior and code comments)
- update tests for retry semantics, AQI truncation, and breaker bypass behavior

## Validation
- `venv/bin/python -m src.main --help`
- `venv/bin/python -m src.main --dry-run --theme diags --ignore-breakers`
- `venv/bin/python -m pytest -q tests/test_main_utils.py tests/test_purpleair_fetcher.py tests/test_fetch_live_data.py tests/test_main_entry.py` *(fails in this venv: `No module named pytest`)*
