### PR TITLE
Update docs for breaker override and AQI/retry behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ Components are pure functions: `draw_*(draw, data, region, style) -> None`. No g
 --dummy                Use built-in dummy data (no API keys needed)
 --config PATH          Custom config file path
 --date YYYY-MM-DD      Override today's date for dry-run previews (requires --dry-run)
---force-full-refresh   Bypass fetch intervals and circuit breaker
+--force-full-refresh   Force full eInk refresh and bypass fetch intervals
+--ignore-breakers      Ignore OPEN circuit breakers for this run
 --check-config         Validate config and exit
 --version              Print version and exit (e.g. "main.py 4.1.0")
 ```
@@ -171,7 +172,8 @@ default to `None` and fall back gracefully so adding a new field never breaks ex
 - `fuzzyclock` component uses `style.font_bold` / `style.font_medium` for the phrase / date — font-agnostic so the theme can be re-skinned by swapping the style callables
 - Theme preview PNGs (`output/theme_*.png`) are git-ignored by `.gitignore` (`output/*.png`) but tracked as exceptions; use `git add -f output/theme_<name>.png` when adding a new one
 - PurpleAir AQI card only appears in the `weather` theme; other themes have access to `DashboardData.air_quality` for future use
-- `_pm25_to_aqi()` in `purpleair.py` implements the EPA AQI piecewise linear formula with standard breakpoints; it is applied to the 60-minute PM2.5 average (`pm2.5_60minute`) for a smoother, less noisy reading — the result is stored on `AirQualityData.aqi` at fetch time; `AirQualityData` also carries `pm1` (PM1.0) and `pm10` (PM10) for display in the `weather` theme detail strip
+- `_pm25_to_aqi()` in `purpleair.py` implements the EPA AQI piecewise linear formula with standard breakpoints; PM2.5 is truncated (not rounded) to one decimal before lookup, and AQI is applied to the 60-minute PM2.5 average (`pm2.5_60minute`) for a smoother, less noisy reading — the result is stored on `AirQualityData.aqi` at fetch time; `AirQualityData` also carries `pm1` (PM1.0) and `pm10` (PM10) for display in the `weather` theme detail strip
 - When `purpleair.api_key` or `purpleair.sensor_id` is `0`/`""`, the source is skipped silently (no circuit breaker entry, no cache miss); validation emits warnings only when one is set without the other
 - `AirQualityData` now includes optional `temperature` (°F), `humidity` (%), and `pressure` (hPa) fields populated from the PurpleAir sensor's ambient readings; these appear in the `diags` panel alongside particulate data; old cache entries missing these fields deserialize safely as `None`
 - `diags` theme is a utility/diagnostic view and is permanently excluded from the `random` rotation pool via `_EXCLUDED_FROM_POOL` in `random_theme.py`; it cannot be added via `random_theme.include` — use `theme: diags` directly instead
+- `_retry_fetch()` retries only likely transient failures and does not retry likely permanent config/data errors (`RuntimeError`, `ValueError`, `TypeError`, `KeyError`)

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ Your existing config is fully compatible. These are opt-in additions:
 | **Circuit breaker tuning** | `cache.max_failures` and `cache.cooldown_minutes` |
 | **API quota warnings** | `google.daily_quota_warning: 500` logs a warning when calls exceed the threshold |
 | **`--check-config` flag** | Validate config and exit without running the dashboard |
-| **`--force-full-refresh` flag** | Bypass fetch intervals and circuit breaker for a one-off forced refresh |
+| **`--force-full-refresh` flag** | Bypass fetch intervals and force a full eInk refresh for a one-off run |
+| **`--ignore-breakers` flag** | Ignore OPEN circuit breakers for one run and attempt live fetches anyway |
 
 ---
 
@@ -744,6 +745,8 @@ After 3 consecutive failures (configurable), a source is "tripped" and goes stra
 cache on subsequent runs. After the cooldown period, a single probe request is sent. If it
 succeeds, normal fetching resumes.
 
+Use `--ignore-breakers` to bypass OPEN breaker state for one run (useful for manual recovery checks).
+
 ### Conditional display refresh
 
 The dashboard computes a SHA-256 hash of each rendered image and compares it to the
@@ -800,7 +803,8 @@ to `output/calendar_sync_state.json`.
 | `--config PATH` | Config file path (default: `config/config.yaml`) |
 | `--theme THEME` | Override the theme set in `config.yaml`. Choices: `default`, `terminal`, `minimalist`, `old_fashioned`, `today`, `fantasy`, `qotd`, `weather`, `fuzzyclock`, `diags`, `random` |
 | `--date YYYY-MM-DD` | Override today's date for the dry-run preview (requires `--dry-run`) |
-| `--force-full-refresh` | Force full eInk refresh; bypasses fetch intervals and circuit breaker |
+| `--force-full-refresh` | Force full eInk refresh and bypass fetch intervals |
+| `--ignore-breakers` | Ignore OPEN circuit breakers for this run and attempt fetches anyway |
 | `--check-config` | Validate config and exit |
 | `--version` | Print version and exit |
 


### PR DESCRIPTION
## Summary
- update `README.md` to clarify `--force-full-refresh` semantics (force full refresh + bypass fetch intervals)
- document new `--ignore-breakers` CLI flag in feature table, circuit-breaker section, and CLI flags table
- update `CLAUDE.md` CLI flags to include `--ignore-breakers`
- add internal notes in `CLAUDE.md` for PM2.5 AQI truncation behavior and `_retry_fetch` permanent-error handling

## Notes
- docs-only change; no runtime code changes
