### PR TITLE
Fix event overlap from multiline location fields

### DIFF
--- a/src/render/components/today_view.py
+++ b/src/render/components/today_view.py
@@ -181,7 +181,9 @@ def _draw_event_list(
 
             # Location (first segment only)
             if event.location:
-                loc_text = event.location.split(",")[0].strip()
+                # Normalize location to a single visual line (collapse newlines/extra spaces)
+                # so y-advance stays consistent with measured single-line font height.
+                loc_text = " ".join(event.location.split(",")[0].split())
                 if loc_text and y + text_height(loc_font) <= bottom:
                     y += 2
                     draw_text_truncated(draw, (x, y), loc_text, loc_font, max_w, fill=style.fg)

--- a/src/render/components/week_view.py
+++ b/src/render/components/week_view.py
@@ -448,7 +448,9 @@ def _draw_day_events(
             y += max(used_h, title_h)
 
             if show_location and event.location:
-                loc_text = event.location.split(",")[0].strip()
+                # Normalize location to a single visual line (collapse newlines/extra spaces)
+                # so y-advance stays consistent with measured single-line font height.
+                loc_text = " ".join(event.location.split(",")[0].split())
                 if loc_text and y - y_start + loc_h <= max_h - PAD:
                     y += 1
                     draw_text_truncated(

--- a/tests/test_today_view.py
+++ b/tests/test_today_view.py
@@ -1,6 +1,7 @@
 """Tests for src/render/components/today_view.py."""
 
 from datetime import date, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from PIL import Image, ImageDraw
@@ -232,6 +233,22 @@ class TestDrawToday:
         evt = _timed(TODAY, 9, 10, "Doctor Visit", location="123 Medical Center, Suite 4")
         draw_today(draw, [evt], TODAY)
         assert img.getbbox() is not None
+
+    def test_location_newlines_are_normalized_before_truncation(self):
+        img, draw = _make_draw()
+        evt = _timed(TODAY, 9, 10, "Visit", location="123 Main St\nSuite 200, Springfield")
+        seen_texts: list[str] = []
+
+        def _capture_text(*args, **kwargs):
+            # signature: (draw, xy, text, font, max_width, fill=...)
+            seen_texts.append(args[2])
+            return 0
+
+        with patch("src.render.components.today_view.draw_text_truncated", side_effect=_capture_text):
+            draw_today(draw, [evt], TODAY)
+
+        assert any("Suite 200" in t for t in seen_texts)
+        assert all("\n" not in t for t in seen_texts)
 
     def test_smoke_event_with_long_title(self):
         img, draw = _make_draw()

--- a/tests/test_week_view.py
+++ b/tests/test_week_view.py
@@ -1,6 +1,7 @@
 """Tests for src/render/components/week_view.py."""
 
 from datetime import date, datetime, timedelta
+from unittest.mock import patch
 
 from PIL import Image, ImageDraw
 
@@ -141,6 +142,30 @@ class TestDrawWeek:
         ]
         draw_week(draw, events, today)
         assert img.getbbox() is not None
+
+    def test_location_newlines_are_normalized_before_truncation(self):
+        img, draw = self._make_draw()
+        today = date(2024, 3, 15)
+        events = [
+            CalendarEvent(
+                summary="Client Meeting",
+                start=datetime.combine(today, datetime.min.time().replace(hour=9)),
+                end=datetime.combine(today, datetime.min.time().replace(hour=10)),
+                location="123 Main St\nSuite 200, Springfield",
+            ),
+        ]
+        seen_texts: list[str] = []
+
+        def _capture_text(*args, **kwargs):
+            # signature: (draw, xy, text, font, max_width, fill=...)
+            seen_texts.append(args[2])
+            return 0
+
+        with patch("src.render.components.week_view.draw_text_truncated", side_effect=_capture_text):
+            draw_week(draw, events, today)
+
+        assert any("Suite 200" in t for t in seen_texts)
+        assert all("\n" not in t for t in seen_texts)
 
     def test_smoke_with_all_day_event(self):
         img, draw = self._make_draw()


### PR DESCRIPTION
## Summary
- fix calendar/today event-row overlap when an event location contains newline characters
- normalize location text to a single visual line before drawing in:
  - `src/render/components/week_view.py`
  - `src/render/components/today_view.py`
- add regression tests to verify newline-containing locations are normalized before truncation:
  - `tests/test_week_view.py`
  - `tests/test_today_view.py`

## Why
Some real-world location fields include embedded newlines (e.g., two-line street address + suite). The renderer advanced `y` as if only one line was drawn, so the next event's time could overlap prior location text.

## Validation
- `venv/bin/python -m src.main --dry-run --theme today`
