### PR TITLE
[codex] simplify docs structure and add validation guardrails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,138 +1,118 @@
 # Contributing to Dashboard-v4
 
+Audience: contributors changing code, tests, or documentation.
+
+Use this page for contribution workflow and guardrails. For architecture details, see [docs/architecture.md](docs/architecture.md). For day-to-day dev commands and repo layout, see [docs/development.md](docs/development.md).
+
 ## Local Setup
 
 ```bash
 git clone <repo-url> && cd Dashboard-v4
-make setup              # creates venv, installs deps, copies config template
-make dry                # preview with dummy data → output/latest.png
+make setup
+make dry
 ```
 
-## Development Commands
+## Core Commands
 
 ```bash
-make test               # run pytest
-make lint               # ruff check src/ tests/
-make fmt                # ruff format src/ tests/
-make dry                # preview with dummy data
-make previews           # generate all theme previews
-make check              # validate config/config.yaml
+make test         # run pytest
+make lint         # ruff check src/ tests/
+make fmt          # ruff format src/ tests/
+make dry          # preview with dummy data
+make previews     # generate theme previews
+make check        # validate config/config.yaml
+make docs-check   # validate markdown links and theme inventories
 ```
 
-## Code Style
+## Contribution Rules
 
-- **Max line length**: 100 characters
-- **Formatter**: ruff format (configured in `pyproject.toml`)
-- **Linter**: ruff check with rules E, F, W, I (isort), UP (pyupgrade)
-- **Imports**: stdlib → third-party → local (`src.*`), sorted by ruff
-- **Type annotations**: use `from __future__ import annotations` for forward refs; prefer `X | None` over `Optional[X]`
+- Keep docs aligned with user-facing behavior when themes, setup flow, or config shape change.
+- Prefer updating canonical docs instead of duplicating explanations across pages.
+- Run `make lint`, `make test`, and `make docs-check` before opening a PR when your change touches code or docs.
+- Do not document removed themes, deprecated config fields, or speculative behavior.
 
-Run `make lint` and `make fmt` before committing.
+## Adding a Theme
 
-## Project Structure
+1. Create `src/render/themes/my_theme.py`.
+2. Return a `Theme` built from the current theme API:
 
-```
-src/
-├── main.py                     # CLI entry point
-├── app.py                      # DashboardApp orchestrator
-├── config.py                   # YAML config → dataclasses
-├── data_pipeline.py            # Concurrent fetch orchestration
-├── data/models.py              # Pure dataclasses (no I/O)
-├── fetchers/                   # Data source adapters
-│   ├── calendar.py             # Dispatcher + birthday extraction
-│   ├── calendar_google.py      # Google Calendar API + sync
-│   ├── calendar_ical.py        # ICS feed fetching
-│   ├── weather.py              # OpenWeatherMap
-│   ├── purpleair.py            # PurpleAir sensor
-│   ├── host.py                 # System metrics
-│   ├── cache.py                # Per-source JSON cache
-│   ├── circuit_breaker.py      # Per-source circuit breaker
-│   └── quota_tracker.py        # Daily API call counter
-├── services/                   # Orchestration policy
-│   ├── run_policy.py           # Quiet hours, morning startup
-│   ├── theme.py                # Theme name resolution
-│   └── output.py               # Publish image, health marker
-├── display/                    # Display hardware abstraction
-│   ├── driver.py               # DryRunDisplay, WaveshareDisplay
-│   └── refresh_tracker.py      # Partial/full refresh tracking
-└── render/                     # Rendering system
-    ├── canvas.py               # Top-level render orchestrator
-    ├── theme.py                # Theme registry + dataclasses
-    ├── themes/                 # One file per theme
-    ├── components/             # One file per UI region
-    ├── random_theme.py         # Daily/hourly random selection
-    ├── fonts.py                # Font loader
-    ├── primitives.py           # Shared draw utilities
-    └── icons.py                # Weather icon mapping
+```python
+from src.render.theme import ComponentRegion, Theme, ThemeLayout, ThemeStyle
 
-tests/                          # pytest tests (mirrors src/ structure)
-state/                          # Runtime state (gitignored)
-output/                         # PNGs, logs (gitignored except latest.png)
+
+def my_theme() -> Theme:
+    style = ThemeStyle(
+        fg=0,
+        bg=1,
+        invert_header=True,
+        show_borders=True,
+    )
+    layout = ThemeLayout(
+        header=ComponentRegion(0, 0, 800, 40),
+        week_view=ComponentRegion(0, 40, 800, 320),
+        weather=ComponentRegion(0, 360, 300, 120),
+        birthdays=ComponentRegion(300, 360, 250, 120),
+        info=ComponentRegion(550, 360, 250, 120),
+        draw_order=["header", "week_view", "weather", "birthdays", "info"],
+    )
+    return Theme(name="my_theme", style=style, layout=layout)
 ```
 
-See [docs/architecture.md](docs/architecture.md) for detailed data flow and design decisions.
+3. Register the theme in `src/render/theme.py` by adding it to `_THEME_REGISTRY`.
+4. If it should never appear in rotation, add it to `_EXCLUDED_FROM_POOL` in `src/render/random_theme.py`.
+5. If the theme is user-facing, update:
+   - `docs/themes.md`
+   - `docs/color-themes.md` if it has a gallery preview
+   - any theme lists in config or setup docs that are intended to be exhaustive
+6. Generate previews and confirm they render cleanly:
 
-## How to Add a Theme
+```bash
+venv/bin/python -m src.main --dry-run --dummy --theme my_theme
+```
 
-1. Create `src/render/themes/my_theme.py`
-2. Implement a factory function:
-   ```python
-   from src.render.theme import ComponentRegion, Theme, ThemeLayout, ThemeStyle
+For greyscale custom themes, set `ThemeLayout.canvas_mode = "L"` and use `fg=0, bg=255` in `ThemeStyle`.
 
-   def my_theme() -> Theme:
-       style = ThemeStyle(bg_color="white", fg_color="black", ...)
-       layout = ThemeLayout(
-           canvas_width=800, canvas_height=480,
-           header=ComponentRegion(0, 0, 800, 40),
-           week=ComponentRegion(0, 40, 560, 380),
-           weather=ComponentRegion(560, 40, 240, 200),
-           info=ComponentRegion(560, 240, 240, 180),
-           draw_order=["header", "week", "weather", "info"],
-       )
-       return Theme(name="my_theme", style=style, layout=layout)
-   ```
-3. Register in `src/render/theme.py`:
-   ```python
-   _THEME_REGISTRY["my_theme"] = ("src.render.themes.my_theme", "my_theme")
-   ```
-4. Add to `AVAILABLE_THEMES` (automatic from registry)
-5. To exclude from random rotation, add to `_EXCLUDED_FROM_POOL` in `random_theme.py`
-6. Run `make dry -- --theme my_theme` to preview
+## Adding a Fetcher or Data Source
 
-## How to Add a Fetcher/Data Source
+1. Create the fetcher module in `src/fetchers/`.
+2. Return typed data models from `src/data/models.py`.
+3. Add cache serialization support in `src/fetchers/cache.py`.
+4. Integrate the source into `src/data_pipeline.py`.
+5. Extend `DashboardData` if the source becomes part of the render pipeline.
+6. Add tests that mock all external I/O.
+7. Update operator docs if the source introduces new config or new UI behavior.
 
-1. Create `src/fetchers/my_source.py`
-   - Use `requests` with a timeout for external APIs
-   - Return a dataclass from `data/models.py`
-2. Add the model to `data/models.py` if needed
-3. Add cache serialization in `cache.py` (`save_source`/`load_cached_source`)
-4. Integrate into `data_pipeline.py`:
-   - Add TTL/interval to `__init__`
-   - Add to `_launch_fetches` and `_resolve_source` flow
-5. Add to `DashboardData` if it's a new field
-6. See `purpleair.py` as a reference implementation
+## Adding a Config Option
 
-## How to Add a Config Option
+1. Add the field to the relevant dataclass in `src/config.py`.
+2. Parse the YAML key in `load_config()` if needed.
+3. Add validation in `validate_config()` when invalid input should be surfaced clearly.
+4. Update `config/config.example.yaml`.
+5. Update `docs/configuration.md` if the field is operator-facing.
+6. Update any setup or web UI docs that depend on that field.
 
-1. Add field to the relevant dataclass in `config.py` (with a default)
-2. Add parsing in `load_config()` if the YAML key differs from the field name
-3. Add validation in `validate_config()` if applicable
-4. Add to `config/config.example.yaml` with a comment
-5. Use in the relevant module
+## Docs Update Policy
+
+When changing any of these areas, update the canonical docs in the same PR:
+
+- Theme inventory or behavior: `docs/themes.md`
+- Preview gallery content: `docs/color-themes.md`
+- Config schema or defaults: `docs/configuration.md`
+- Setup, install, auth, or recovery flow: `README.md`, `docs/setup.md`, or `docs/web-ui.md`
+- Contributor workflow or architecture: `docs/development.md`, `docs/architecture.md`, or `CLAUDE.md`
 
 ## Testing
 
-- Tests use `pytest` with `unittest.mock.patch`
-- Each public function should have at least one test
-- Use `tmp_path` fixture for files, not real directories
-- Mock external APIs — never make real network calls in tests
-- Run `make test` to verify all tests pass
+- Use `pytest` with mocks for external APIs and file I/O.
+- Use `tmp_path` for temporary files.
+- Do not make real network calls in tests.
+- Add or update documentation checks when you introduce a new exhaustive list.
 
 ## PR Checklist
 
-- [ ] `make test` passes (all tests green)
-- [ ] `make lint` passes (no ruff errors)
-- [ ] `make fmt` produces no changes (code formatted)
-- [ ] New features have tests
-- [ ] CLAUDE.md updated if module structure changed
-- [ ] `config.example.yaml` updated if new config options added
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] `make fmt` leaves no changes
+- [ ] `make docs-check` passes when docs or user-facing behavior changed
+- [ ] Tests were added or updated for behavior changes
+- [ ] Canonical docs were updated for any user-facing change

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dry test deploy setup install check previews version lint fmt \
+.PHONY: dry test deploy setup install check previews version lint fmt docs-check \
         pi-install install-display-drivers pi-enable pi-status pi-logs configure \
         web-enable web-status web-logs
 
@@ -44,6 +44,9 @@ fmt: _check-venv
 
 check: _check-venv
 	$(VENV) -m src.main --check-config
+
+docs-check:
+	python3 scripts/check_docs.py
 
 PI_USER ?= pi
 PI_HOST ?= dashboard

--- a/README.md
+++ b/README.md
@@ -1,189 +1,77 @@
 # Home Dashboard
 
-Home Dashboard is a low-maintenance eInk wall display for family logistics: calendar,
-weather, birthdays, and other glanceable daily context on a Raspberry Pi with a supported
-eInk display. It's designed to be calm, readable, and reliable for unattended use, with quiet
-hours, caching, graceful fallback behavior, and a handful of well-designed themes. Advanced
-customization is available, but the default setup is optimized to get something useful on
-the wall fast.
-
-- Weekly calendar view — works via ICS feed (no GCP account needed) or Google Calendar API
-- Current weather, forecast, and optional air quality (OpenWeatherMap + PurpleAir)
-- Upcoming birthdays from Google Contacts, a flat file, or a calendar feed
-- Daily quote from a bundled library
-- 20 built-in themes with random daily/hourly rotation and a schedule override
-- Graceful degradation: stale-cache fallback, circuit breakers, staleness indicators
-- Optional web UI — health dashboard, safe config editor, recent events, integration diagnostics, and one-click refresh from any browser on your network
+Home Dashboard is a low-maintenance eInk wall display for family logistics on a Raspberry Pi. It shows calendar events, weather, birthdays, quotes, and optional diagnostics on supported Waveshare and Inky displays, with graceful fallback behavior for unattended use.
 
 ![Default theme preview](output/theme_default.png)
 
----
+## Start Here
 
-## Choose Your Path
-
-- **First install on a Raspberry Pi:** start with [Quick Start](#quick-start).
-- **Setting up calendar (recommended for most):** use [ICS Feed (No GCP Required)](docs/setup.md#ics-feed-no-gcp-required)
-  — paste one URL from Google Calendar settings, no credentials file or GCP project needed.
-- **Need contacts-based birthdays or incremental sync?** Follow [Google Calendar Setup](docs/setup.md#google-calendar-setup)
-  to configure a service account instead.
-- **Upgrading from an older release:** go to [Upgrading from v3](docs/upgrading-from-v3.md).
-- **Want a browser-based status page and config editor?** See [Web UI](docs/web-ui.md) — install in four steps with `make web-enable`.
-- **Local dev / preview only:** jump to [Development](docs/development.md) and run `make setup`
-  + `make dry` (no hardware required).
-
-## Documentation
-
-- [Setup Guide](docs/setup.md) — Google Calendar, ICS feed, birthdays, Raspberry Pi setup, hardware
-- [Web UI](docs/web-ui.md) — browser-based status page, config editor, manual refresh, authentication
-- [Themes](docs/themes.md) — all 20 built-in themes, random rotation, schedule, creating your own
-- [Color Themes](docs/color-themes.md) — customer-facing gallery of the current theme preview images
-- [Color Theme Previews](docs/color-theme-previews.md) — generate standard and Inky-color preview PNGs
-- [Configuration Reference](docs/configuration.md) — full config.yaml, cache tuning, filtering, circuit breaker
-- [Development](docs/development.md) — Makefile targets, CLI flags, project structure, dependencies
-- [Architecture](docs/architecture.md) — data flow, module layers, key design decisions
-- [Contributing](CONTRIBUTING.md) — local setup, code style, how to add themes/fetchers, PR checklist
-- [FAQ](docs/faq.md) — quiet hours, troubleshooting, common questions
-- [Upgrading from v3](docs/upgrading-from-v3.md) — migration paths and what's new
-
----
-
-## Quick Start
-
-SSH into your Pi, then run these commands from the project directory:
+For a first install on a Raspberry Pi:
 
 ```bash
 git clone https://github.com/gkoch02/Dashboard-v4.git ~/home-dashboard
 cd ~/home-dashboard
-make pi-install    # apt deps, SPI, Python venv, display drivers — all in one
-make configure     # interactive prompts fill in your API keys and settings
-make dry           # render a preview with dummy data — no hardware needed
-make pi-enable     # install and start the systemd refresh timer
-make pi-status     # confirm the timer is active and healthy
+make pi-install
+make configure
+make dry
+make pi-enable
+make pi-status
 ```
 
-That's it. The dashboard starts refreshing every 5 minutes automatically.
-
-> **Note:** `make pi-install` enables SPI via `raspi-config`. If SPI was not previously
-> enabled on your Pi, reboot once before running on real hardware (`sudo reboot`).
-> `make configure` and `make dry` work fine before the reboot.
->
-> **Next:** if you use Google Calendar or Google Contacts birthdays, complete
-> [Google Calendar Setup](docs/setup.md#google-calendar-setup) before your first live run.
-
----
-
-## make configure
-
-`make configure` is an interactive wizard that writes your settings directly into
-`config/config.yaml`. Run it after `make pi-install`.
-
-```
-Display provider [waveshare]:
-Display model [epd7in5_V2]:
-OpenWeatherMap API key:
-Latitude:
-Longitude:
-Units (imperial/metric) [imperial]:
-Google Calendar ID:
-Timezone [America/New_York]:
-PurpleAir API key (optional, press Enter to skip):
-PurpleAir sensor ID (optional, press Enter to skip):
-```
-
-Existing values are shown as defaults — it is safe to re-run at any time to change a
-setting. The wizard ends by running `make check` to validate your configuration.
-
-For the Inky Impression 7.3" 2025 Edition, choose `display.provider: inky` and
-`display.model: impression_7_3_2025`.
-
-**Google service account JSON** cannot be fetched automatically — it requires a
-one-time browser download from Google Cloud Console. The wizard guides you through
-placing it at `credentials/service_account.json` and links to the
-[Google Calendar Setup](docs/setup.md#google-calendar-setup) instructions.
-
----
-
-For supported display models and hardware recommendations, see the
-[Setup Guide](docs/setup.md#supported-displays).
-
----
-
-## Prerequisites
-
-- **Hardware**: Raspberry Pi 3, 4, or 5 with a [supported eInk display](docs/setup.md#supported-displays)
-- **Software**: Raspberry Pi OS (Bookworm or later), Python 3.9+
-- **Network**: Internet connection for API calls (weather, calendar)
-- **Accounts**: Free [OpenWeatherMap API key](https://openweathermap.org/api) for weather; Google Calendar (ICS feed or service account) for events
-
----
-
-## First-Run Checklist
-
-After completing [Quick Start](#quick-start), verify everything is working:
-
-1. `make check` -- validates your config file (API keys, paths, coordinates)
-2. `make dry` -- renders a preview with dummy data to `output/latest.png`
-3. Open `output/latest.png` on your computer to confirm the layout looks right
-4. `make pi-enable` -- installs and starts the systemd refresh timer
-5. `make pi-status` -- confirms the timer is active and shows recent logs
-
-If anything looks wrong, see [Troubleshooting](#troubleshooting) below.
-
----
-
-## Reliability
-
-The dashboard is designed to run unattended for months. When things go wrong,
-it degrades gracefully instead of showing a blank screen:
-
-- **Cached data**: If an API call fails, the last successful response is used.
-  A small `!` badge appears on stale panels so you know the data isn't fresh.
-- **Staleness levels**: Data progresses through Fresh -> Aging -> Stale -> Expired
-  based on age relative to the configured TTL. Expired data (older than 4x TTL)
-  is discarded entirely.
-- **Circuit breaker**: After 3 consecutive failures for a source (configurable),
-  the dashboard stops attempting that API call for a cooldown period (default 30
-  minutes), then probes once to see if it has recovered.
-- **Independent sources**: A weather API outage doesn't affect calendar display.
-  Each data source fetches, caches, and fails independently.
-
----
-
-## Web UI
-
-The optional web interface runs on the Pi and is accessible from any browser on your network at `http://<pi-hostname>:8080`.
-
-| Page | What it does |
-|---|---|
-| **Status** (`/`) | System health, active/effective theme, live image preview, source diagnostics, integration readiness, recent events, system metrics, log tail |
-| **Config** (`/config`) | Edit `config.yaml` in the browser with Basic/Advanced modes, change summary, backup restore, and review-before-save |
-| **Refresh Now** | Triggers an immediate dashboard run without SSH |
-
-Install in four steps:
+If SPI was enabled for the first time during `make pi-install`, reboot once before your first live hardware refresh:
 
 ```bash
-venv/bin/pip install -r requirements-web.txt   # install Flask + Waitress
-cp config/web.example.yaml config/web.yaml     # create web config
-venv/bin/python -m src.web.auth --set-password # set a login password
-# also set web.secret_key in config/web.yaml for CSRF/session integrity
-make web-enable                                 # install + start systemd service
+sudo reboot
 ```
 
-See [Web UI](docs/web-ui.md) for full setup details, current feature set, SSH tunnel access, and security notes.
+## Choose Your Path
 
----
+| If you want to... | Read this |
+|---|---|
+| Install on a Pi and get the first render working | [Setup Guide](docs/setup.md) |
+| Choose between ICS and Google service-account calendar setup | [Setup Guide](docs/setup.md#ics-feed-no-gcp-required) |
+| Enable the optional browser control panel | [Web UI](docs/web-ui.md) |
+| Pick or schedule themes | [Themes](docs/themes.md) |
+| See the full `config.yaml` reference | [Configuration Reference](docs/configuration.md) |
+| Preview themes or regenerate gallery images | [Color Theme Previews](docs/color-theme-previews.md) |
+| Upgrade from an older install | [Upgrading from v3](docs/upgrading-from-v3.md) |
+| Develop locally without hardware | [Development](docs/development.md) |
+| Contribute code or docs | [Contributing](CONTRIBUTING.md) |
 
-## Troubleshooting
+## What You Get
 
-| Symptom | Likely cause | Fix |
-|---------|-------------|-----|
-| Blank/white display | SPI not enabled, or display cable loose | Run `sudo raspi-config` -> Interface Options -> SPI -> Enable, then `sudo reboot` |
-| Display shows old data | API fetch failing, using stale cache | Run `make pi-logs` to check for errors; verify API keys with `make check` |
-| Calendar events missing | Service account not shared, or wrong calendar ID | Verify `calendar_id` in config; ensure the service account email has read access to your calendar |
-| Weather showing wrong location | Coordinates still set to defaults | Check `weather.latitude` and `weather.longitude` in `config/config.yaml` |
-| `make dry` works but display stays blank | Hardware issue or wrong display model | Verify `display.model` in config matches your Waveshare model |
-| Timer not running | systemd units not installed | Run `make pi-enable` and check `make pi-status` |
-| Web UI not loading | Service not installed or wrong port | Run `make web-enable`, then `make web-status` to check for errors |
+- Weekly calendar via Google Calendar API or private ICS feed
+- Current weather, forecast, and optional PurpleAir air quality
+- Birthdays from a file, calendar events, or Google Contacts
+- 21 built-in themes plus scheduled and random rotation modes
+- Optional Web UI for status, config editing, and manual refresh
+- Per-source caching, circuit breakers, stale-data indicators, and quiet hours
 
-For logs, run `make pi-logs` to tail the dashboard log, or check
-`output/dashboard.log` directly. See also the [FAQ](docs/faq.md).
+## Documentation Map
+
+### Operator docs
+
+- [Setup Guide](docs/setup.md) for install, Pi setup, calendar setup, and recovery
+- [Web UI](docs/web-ui.md) for browser access, auth, and service setup
+- [Configuration Reference](docs/configuration.md) for every `config.yaml` field
+- [Themes](docs/themes.md) for the live theme catalog and scheduling behavior
+- [FAQ](docs/faq.md) for common operational questions
+
+### Contributor docs
+
+- [Development](docs/development.md) for commands, local workflow, and repo layout
+- [Architecture](docs/architecture.md) for internals and design decisions
+- [Contributing](CONTRIBUTING.md) for contribution-specific guidance
+
+## Quick Checks
+
+After setup, these are the main operator commands:
+
+```bash
+make check      # validate config/config.yaml
+make dry        # render output/latest.png with dummy data
+make pi-status  # inspect timer/service status on the Pi
+make pi-logs    # tail renderer logs
+```
+
+If something looks off, go to [docs/setup.md](docs/setup.md#troubleshooting-and-recovery) and [docs/faq.md](docs/faq.md).

--- a/docs/color-theme-previews.md
+++ b/docs/color-theme-previews.md
@@ -83,7 +83,7 @@ cp output/latest.png output/theme_fuzzyclock_inky.png
 Example full batch for all concrete themes:
 
 ```bash
-for theme in air_quality default diags fantasy fuzzyclock fuzzyclock_invert graphite \
+for theme in air_quality default diags fantasy fuzzyclock fuzzyclock_invert \
              message minimalist moonphase moonphase_invert old_fashioned photo qotd \
              qotd_invert scorecard sunrise terminal tides timeline today weather year_pulse; do
   if [ "$theme" = "message" ]; then

--- a/docs/color-themes.md
+++ b/docs/color-themes.md
@@ -2,7 +2,9 @@
 
 # Color Themes
 
-This page is a visual gallery of the current dry-run theme previews. Click any preview to open the full PNG.
+Audience: operators browsing the current preview gallery.
+
+This page is gallery-only. For theme behavior, random rotation, and configuration, use [Themes](themes.md). For preview generation workflows, use [Color Theme Previews](color-theme-previews.md).
 
 - [Air Quality](#air-quality)
 - [Default](#default)
@@ -10,7 +12,6 @@ This page is a visual gallery of the current dry-run theme previews. Click any p
 - [Fantasy](#fantasy)
 - [Fuzzyclock](#fuzzyclock)
 - [Fuzzyclock Invert](#fuzzyclock-invert)
-- [Graphite](#graphite)
 - [Message](#message)
 - [Minimalist](#minimalist)
 - [Moonphase](#moonphase)
@@ -53,10 +54,6 @@ This page is a visual gallery of the current dry-run theme previews. Click any p
 ## Fuzzyclock Invert
 
 [![Fuzzyclock Invert preview](../output/theme_fuzzyclock_invert_inky.png)](../output/theme_fuzzyclock_invert_inky.png)
-
-## Graphite
-
-[![Graphite preview](../output/theme_graphite_inky.png)](../output/theme_graphite_inky.png)
 
 ## Message
 
@@ -121,9 +118,3 @@ This page is a visual gallery of the current dry-run theme previews. Click any p
 ## Year Pulse
 
 [![Year Pulse preview](../output/theme_year_pulse_inky.png)](../output/theme_year_pulse_inky.png)
-
----
-
-For preview generation details, file naming, and batch workflows, see
-[Color Theme Previews](color-theme-previews.md). For theme descriptions and configuration, see
-[Themes](themes.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ schedule:
 
 timezone: "local"                  # IANA name or "local"
 title: "Home Dashboard"            # text shown in the header bar
-theme: "default"                   # default | terminal | minimalist | old_fashioned | today | fantasy | moonphase | moonphase_invert | qotd | qotd_invert | weather | fuzzyclock | fuzzyclock_invert | air_quality | message | diags | timeline | year_pulse | sunrise | scorecard | tides | random | random_daily | random_hourly
+theme: "default"                   # default | terminal | minimalist | old_fashioned | today | fantasy | moonphase | moonphase_invert | qotd | qotd_invert | weather | fuzzyclock | fuzzyclock_invert | air_quality | message | diags | timeline | year_pulse | sunrise | scorecard | tides | photo | random | random_daily | random_hourly
 
 random_theme:                      # only used when theme: random_daily or random_hourly
   include: []                      # allowlist (empty = all themes eligible)

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,12 +2,15 @@
 
 # Development
 
+Audience: contributors and maintainers.
+
+Use this page for local workflow, dev commands, and repo orientation. For architecture details, see [Architecture](architecture.md). For contribution rules, see [Contributing](../CONTRIBUTING.md).
+
 - [Prerequisites](#prerequisites)
-- [Makefile targets](#makefile-targets)
+- [Core Commands](#core-commands)
 - [CLI flags](#cli-flags)
 - [Offline development](#offline-development)
-- [Color preview workflow](#color-preview-workflow)
-- [Linting](#linting)
+- [Preview workflow](#preview-workflow)
 - [Project structure](#project-structure)
 - [Dependencies](#dependencies)
 
@@ -15,42 +18,27 @@
 
 ## Prerequisites
 
-- **Python 3.9+**
-- **git**
-- **make** (pre-installed on macOS/Linux; use WSL on Windows)
+- Python 3.9+
+- `git`
+- `make`
 
 ---
 
-## Makefile targets
-
-### On-Pi targets
+## Core Commands
 
 | Command | What it does |
 |---|---|
-| `make pi-install` | apt deps, SPI enable, Python venv, Inky + Waveshare display drivers — full Pi setup in one command |
-| `make install-display-drivers` | Reinstall/verify the hardware driver libraries inside the current venv |
-| `make configure` | Interactive wizard: fills `config/config.yaml` with your API keys and settings |
-| `make pi-enable` | Generate and install systemd service (with correct paths) + enable timer |
-| `make pi-status` | Show timer status, last service run, and recent log tail |
-| `make pi-logs` | `tail -f output/dashboard.log` |
-| `make web-enable` | Install and start the web UI systemd service + trigger path unit |
-| `make web-status` | Show web service status and recent web log tail |
-| `make web-logs` | `tail -f output/dashboard-web.log` |
+| `make setup` | create venv, install deps, create config from template |
+| `make dry` | render `output/latest.png` with dummy data |
+| `make previews` | generate standard theme preview PNGs |
+| `make test` | run the full pytest suite |
+| `make lint` | run `ruff check src/ tests/` |
+| `make fmt` | run `ruff format src/ tests/` |
+| `make check` | validate `config/config.yaml` |
+| `make docs-check` | validate markdown links and doc theme inventories |
+| `make version` | print the app version |
 
-### Dev targets
-
-| Command | What it does |
-|---|---|
-| `make setup` | Create venv, install dependencies, create config from template |
-| `make dry` | Render with dummy data to `output/latest.png` |
-| `make previews` | Generate preview PNGs for all themes to `output/theme_*.png` |
-| `make test` | Run `pytest tests/ -v` across the full suite |
-| `make lint` | Run `ruff check src/ tests/` |
-| `make fmt` | Run `ruff format src/ tests/` |
-| `make check` | Validate config file and exit |
-| `make version` | Print the current version (e.g. `main.py 4.3.1`) |
-| `make deploy` | rsync project to Raspberry Pi (`PI_USER`, `PI_HOST`, `PI_DIR` configurable) |
-| `make install` | Copy systemd timer/service to Pi and enable (legacy remote path) |
+Pi/operator commands such as `make pi-install`, `make pi-enable`, and `make web-enable` are documented for operators in [Setup Guide](setup.md) and [Web UI](web-ui.md).
 
 ---
 
@@ -58,16 +46,16 @@
 
 | Flag | Description |
 |---|---|
-| `--dry-run` | Save to PNG instead of writing to display |
-| `--dummy` | Use built-in dummy data (no API calls needed) |
-| `--config PATH` | Config file path (default: `config/config.yaml`) |
-| `--theme THEME` | Override the theme set in `config.yaml`. Choices: `default`, `terminal`, `minimalist`, `old_fashioned`, `today`, `fantasy`, `moonphase`, `moonphase_invert`, `qotd`, `qotd_invert`, `weather`, `air_quality`, `fuzzyclock`, `fuzzyclock_invert`, `diags`, `message`, `random`, `random_daily`, `random_hourly` |
-| `--message TEXT` | Text to display when using the `message` theme |
-| `--date YYYY-MM-DD` | Override today's date for the dry-run preview (requires `--dry-run`) |
-| `--force-full-refresh` | Force full eInk refresh and bypass fetch intervals |
-| `--ignore-breakers` | Ignore OPEN circuit breakers for this run and attempt fetches anyway |
-| `--check-config` | Validate config and exit |
-| `--version` | Print version and exit |
+| `--dry-run` | save to PNG instead of writing to display |
+| `--dummy` | use built-in dummy data |
+| `--config PATH` | custom config file path |
+| `--theme THEME` | override the configured theme |
+| `--message TEXT` | text for the `message` theme |
+| `--date YYYY-MM-DD` | override the render date for dry runs |
+| `--force-full-refresh` | bypass normal refresh suppression |
+| `--ignore-breakers` | bypass OPEN circuit breakers for one run |
+| `--check-config` | validate config and exit |
+| `--version` | print version and exit |
 
 ---
 
@@ -77,133 +65,63 @@
 venv/bin/python -m src.main --dry-run --dummy
 ```
 
-No API keys, credentials, or hardware needed. Renders to `output/latest.png`.
+This path needs no hardware, API keys, or credentials.
 
 ---
 
-## Color preview workflow
+## Preview workflow
 
-For standard theme batches and Inky-color preview batches, see
-[Color Theme Previews](color-theme-previews.md).
-
-Use this when you need the final Spectra 6 palette output rather than the normal
-black-and-white dry-run images.
-
----
-
-## Linting and formatting
-
-```bash
-make lint               # ruff check src/ tests/
-make fmt                # ruff format src/ tests/
-```
-
-Ruff is configured in `pyproject.toml` with rules E, F, W, I (isort), and UP (pyupgrade).
-Max line length is 100. Pre-commit hooks are available via `.pre-commit-config.yaml`.
+- Use `make dry` for the default dummy preview.
+- Use `make previews` for the batch of standard preview PNGs.
+- Use [Color Theme Previews](color-theme-previews.md) when you need the Inky-specific palette preview workflow.
 
 ---
 
 ## Project structure
 
-```
+```text
 Dashboard-v4/
-├── config/
-│   ├── config.example.yaml       # Configuration template
-│   └── quotes.json               # Daily quote pool (144 entries)
-├── credentials/                  # Git-ignored -- Google service account JSON
-├── deploy/
-│   ├── dashboard.service         # Systemd service template (paths filled by make pi-enable)
-│   ├── dashboard.timer           # Systemd timer (fires every 5 min)
-│   ├── dashboard.logrotate       # Logrotate config template (paths filled by make pi-enable)
-│   └── configure.sh              # Interactive config wizard (invoked by make configure)
-├── fonts/                        # Bundled TTF fonts
-├── state/                        # Git-ignored -- runtime state (cache, breaker, quota, sync tokens)
-├── output/                       # Git-ignored (except latest.png) -- PNGs, logs, health marker
-│   └── latest.png                # Latest dry-run preview (tracked)
-├── src/
-│   ├── main.py                   # Thin CLI entry point: parse args, load config, launch app
-│   ├── app.py                    # Top-level dashboard run orchestration
-│   ├── data_pipeline.py          # Live data fetching, cache fallback, breakers, quotas
-│   ├── services/
-│   │   ├── run_policy.py         # Quiet hours + morning full-refresh decisions
-│   │   ├── theme.py              # Theme resolution (including random theme selection)
-│   │   └── output.py             # Dry-run writes, display refresh decisions, health marker
-│   ├── _version.py               # Version constant (__version__ = "4.1.3")
-│   ├── config.py                 # YAML -> typed Config dataclass + validation
-│   ├── dummy_data.py             # Realistic dummy data for --dummy / dev previews
-│   ├── filters.py                # Event filtering (calendar, keyword, all-day)
-│   ├── data/
-│   │   └── models.py             # Pure dataclasses (no I/O)
-│   ├── display/
-│   │   ├── driver.py             # DisplayDriver ABC, DryRunDisplay, WaveshareDisplay
-│   │   └── refresh_tracker.py    # Partial vs full refresh state
-│   ├── fetchers/
-│   │   ├── calendar.py           # Dispatcher: routes to Google API or ICS; birthday extraction
-│   │   ├── calendar_google.py    # Google Calendar API -- full sync, incremental sync, sync state
-│   │   ├── calendar_ical.py      # ICS feed fetching and parsing
-│   │   ├── weather.py            # OpenWeatherMap (current + forecast + alerts)
-│   │   ├── purpleair.py          # PurpleAir sensor → PM1 / PM2.5 / PM10 / AQI
-│   │   ├── host.py               # System metrics via /proc (uptime, load, RAM, disk, CPU temp, IP)
-│   │   ├── cache.py              # Per-source JSON cache with TTL staleness
-│   │   ├── circuit_breaker.py    # Per-source circuit breaker
-│   │   └── quota_tracker.py      # Daily API call counter
-│   └── render/
-│       ├── canvas.py             # Top-level render orchestrator (theme-driven)
-│       ├── theme.py              # Theme system (ComponentRegion, ThemeLayout, ThemeStyle)
-│       ├── quantize.py           # Final L→"1" quantization (threshold / floyd_steinberg / ordered)
-│       ├── random_theme.py       # Daily/hourly random theme selection + persistence
-│       ├── layout.py             # Default pixel geometry constants
-│       ├── fonts.py              # Font loader with @lru_cache
-│       ├── icons.py              # OWM icon code -> Weather Icons glyph
-│       ├── moon.py               # Pure-math moon phase calculator
-│       ├── primitives.py         # Shared draw helpers (truncation, wrapping, fmt_time, events_for_day, deg_to_compass)
-│       ├── themes/               # Built-in theme factories
-│       └── components/           # One file per UI region
-├── tests/                        # Full test suite (1580+ tests)
-├── docs/                         # User and contributor documentation
-│   ├── architecture.md           # Data flow, module layers, design decisions
-│   └── ...
-├── CONTRIBUTING.md               # Local setup, code style, how to add themes/fetchers
-├── pyproject.toml                # Project metadata, dependencies, tool config (ruff, pytest, mypy)
+├── config/          # example config, web config template, bundled quotes
+├── deploy/          # systemd units and setup helpers
+├── docs/            # operator and contributor docs
+├── fonts/           # bundled fonts
+├── output/          # previews and logs
+├── src/             # application code
+├── tests/           # pytest suite
+├── CONTRIBUTING.md
+├── CLAUDE.md
 ├── Makefile
-├── requirements.txt              # Core dependencies (kept for Pi deployment compat)
-└── requirements-pi.txt           # Raspberry Pi hardware dependencies
+└── pyproject.toml
 ```
 
-For a detailed walkthrough of data flow and module boundaries, see [Architecture](architecture.md).
+Key code areas:
+
+- `src/config.py` for config parsing and validation
+- `src/data_pipeline.py` for fetch orchestration
+- `src/services/` for runtime policy
+- `src/render/` for theme registry, rendering, and preview output
+- `src/web/` for the optional Web UI
 
 ---
 
 ## Dependencies
 
-### Core (all platforms)
+### Core
 
-- [Pillow](https://pillow.readthedocs.io/) -- image rendering
-- [google-api-python-client](https://googleapis.github.io/google-api-python-client/) -- Google Calendar and Contacts APIs
-- [google-auth](https://google-auth.readthedocs.io/) -- service account authentication
-- [requests](https://requests.readthedocs.io/) -- OpenWeatherMap API and ICS feed fetching
-- [icalendar](https://icalendar.readthedocs.io/) -- ICS feed parsing (used when `ical_url` is set)
-- [PyYAML](https://pyyaml.org/) -- configuration parsing
+- Pillow
+- google-api-python-client
+- google-auth
+- requests
+- icalendar
+- PyYAML
 
 ### Development
 
-- [ruff](https://docs.astral.sh/ruff/) -- linting and formatting
-- [pytest](https://docs.pytest.org/) -- test framework
-- [mypy](https://mypy-lang.org/) -- optional static type checking
+- ruff
+- pytest
+- mypy
 
-Install dev tools with: `pip install -e ".[dev]"` (uses `pyproject.toml` optional deps).
+### Optional
 
-### Raspberry Pi only
-
-- [RPi.GPIO](https://pypi.org/project/RPi.GPIO/) -- GPIO pin control
-- [spidev](https://pypi.org/project/spidev/) -- SPI communication with display
-- [lgpio](https://pypi.org/project/lgpio/) -- Linux GPIO interface (required by modern Pi OS)
-- [gpiozero](https://pypi.org/project/gpiozero/) -- GPIO zero abstraction layer (pin factory set to lgpio)
-
-### Web UI (optional)
-
-- [Flask](https://flask.palletsprojects.com/) 3.x -- web framework
-- [Waitress](https://docs.pylonsproject.org/projects/waitress/) -- pure-Python WSGI server (Pi-friendly, no C extensions)
-
-Install with `pip install -r requirements-web.txt` or `pip install -e ".[web]"`.
-For current setup, remember that `config/web.yaml` should now include a `secret_key` in addition to any optional Basic Auth credentials. See [Web UI](web-ui.md) for current setup and security instructions.
+- Flask and Waitress for the Web UI
+- Raspberry Pi display dependencies from `requirements-pi.txt`

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,14 +2,17 @@
 
 # Themes
 
+Audience: operators choosing a display style, and contributors verifying the live theme inventory.
+
+Use this page for:
+- picking a theme
+- understanding random rotation and scheduled switching
+- checking which built-in themes are currently available
+
 - [Switching themes](#switching-themes)
 - [Random rotation](#random-rotation)
 - [Time-of-day theme schedule](#time-of-day-theme-schedule)
-- [Built-in themes](#built-in-themes) — 21 themes plus pseudo-themes
-  - **Standard week-view**: [default](#default), [graphite](#graphite), [terminal](#terminal), [minimalist](#minimalist), [old\_fashioned](#old_fashioned), [today](#today), [fantasy](#fantasy)
-  - **Full-screen focused**: [qotd](#qotd), [qotd\_invert](#qotd_invert), [fuzzyclock](#fuzzyclock), [fuzzyclock\_invert](#fuzzyclock_invert), [weather](#weather), [moonphase](#moonphase), [moonphase\_invert](#moonphase_invert)
-  - **Specialized views**: [timeline](#timeline), [year\_pulse](#year_pulse), [sunrise](#sunrise), [air\_quality](#air_quality), [scorecard](#scorecard), [tides](#tides)
-  - **Utility**: [message](#message), [diags](#diags)
+- [Built-in themes](#built-in-themes)
 - [Creating your own theme](#creating-your-own-theme)
 - [Color Themes](color-themes.md)
 - [Color Theme Previews](color-theme-previews.md)
@@ -19,81 +22,54 @@
 
 ## Switching themes
 
-Switch the entire dashboard layout and visual style with one line in `config.yaml`:
+Set one concrete theme in `config.yaml`:
 
 ```yaml
-theme: terminal   # default | graphite | terminal | minimalist | old_fashioned | today | fantasy | moonphase | moonphase_invert | qotd | qotd_invert | weather | fuzzyclock | fuzzyclock_invert | air_quality | message | diags | timeline | year_pulse | sunrise | scorecard | tides | random | random_daily | random_hourly
+theme: terminal   # default | terminal | minimalist | old_fashioned | today | fantasy | moonphase | moonphase_invert | qotd | qotd_invert | weather | fuzzyclock | fuzzyclock_invert | air_quality | message | diags | timeline | year_pulse | sunrise | scorecard | tides | photo | random | random_daily | random_hourly
 ```
 
-Or override it from the command line without editing your config:
+Or override it from the CLI:
 
 ```bash
 venv/bin/python -m src.main --dry-run --dummy --theme terminal
 ```
 
-The `--theme` flag takes precedence over `config.yaml`. All values are accepted,
-including `random_daily` and `random_hourly` (which trigger the rotation logic as normal).
+The `--theme` flag takes precedence over `config.yaml`.
 
-Themes control component positions, proportions, fonts, and visual style -- not just
-colors. Each theme can hide sections, rearrange panels, or use entirely different fonts.
+Themes control layout, font system, panel visibility, and rendering style. Some are week-view layouts, some are full-screen focused displays, and some are operator utilities.
 
-To generate gallery-style PNGs for every theme, including the Inky Spectra 6 color path, see
-[Color Theme Previews](color-theme-previews.md). For a customer-facing gallery of the current
-preview images, see [Color Themes](color-themes.md).
+For preview-generation workflow, see [Color Theme Previews](color-theme-previews.md). For a gallery-only view, see [Color Themes](color-themes.md).
 
 ---
 
 ## Random rotation
 
-Two rotation cadences are available:
+Three theme values trigger rotation logic:
 
 | Theme value | Rotates | State file |
 |---|---|---|
 | `random_daily` | Once per day, at first refresh after midnight | `state/random_theme_state.json` |
 | `random_hourly` | Once per hour, at first refresh after the hour turns | `state/random_theme_hourly_state.json` |
-| `random` | Alias for `random_daily` (backwards compatible) | `state/random_theme_state.json` |
+| `random` | Alias for `random_daily` | `state/random_theme_state.json` |
 
 ```yaml
-theme: random_daily    # or random_hourly
+theme: random_daily
+random_theme:
+  include: []
+  exclude: []
 ```
 
-The selected theme is persisted to the state file so restarts within the same
-bucket (day or hour) do not re-roll the theme.
-
-Use `random_theme` to control which themes are in the rotation — the same
-`include`/`exclude` lists apply to both cadences:
-
-```yaml
-theme: random_daily    # or random_hourly
-random_theme:
-  include: []          # allowlist — only these themes rotate (empty = all themes)
-  exclude: []          # denylist — never use these themes
-```
-
-**Examples:**
-
-```yaml
-# Only rotate among calm, readable themes
-random_theme:
-  include: ["default", "minimalist", "terminal"]
-
-# Rotate everything except the full-screen quote theme
-random_theme:
-  exclude: ["qotd"]
-```
-
-- `include` is applied first; `exclude` is applied after.
-- If both are empty, all standard themes are eligible (`diags` and `message` are always
-  excluded from the pool — `diags` is a utility/diagnostic view; `message` requires a
-  `--message` argument and is intended for manual runs only).
-- If the pool is empty after filtering, the dashboard falls back to `"default"`.
-- Run `make check` to catch invalid theme names in either list.
+- `include` is an allowlist. Empty means all eligible themes.
+- `exclude` is a denylist applied after `include`.
+- `diags`, `message`, and `photo` are excluded from the random pool by design.
+- If the pool ends up empty, the app falls back to `default`.
+- Run `make check` to validate theme names.
 
 ---
 
 ## Time-of-day theme schedule
 
-Automatically switch themes at specific times of day without any manual intervention:
+Use `theme_schedule` to switch themes at specific local times:
 
 ```yaml
 theme_schedule:
@@ -105,412 +81,194 @@ theme_schedule:
     theme: "fuzzyclock_invert"
 ```
 
-The active theme is determined by the last entry whose `time` (HH:MM, 24-hour) is ≤ the
-current local time. Before the first entry fires — e.g. at 4 AM when the first entry is
-`06:00` — the normal `theme:` / random logic applies.
+Priority order:
+1. `--theme`
+2. `theme_schedule`
+3. `theme` in `config.yaml`
 
-**Priority order (highest → lowest):**
-1. `--theme` CLI flag — always wins; schedule is never consulted.
-2. `theme_schedule` — the matching time window.
-3. `theme:` in `config.yaml` (may be `random_daily`, `random_hourly`, or `random`).
-
-The schedule works alongside random rotation: if no schedule entry matches, the dashboard
-falls through to `theme: random_daily` / `random_hourly` as usual. `make check` validates
-all time strings and theme names in the schedule.
+The active entry is the last row whose `time` is less than or equal to the current local time. When no row applies yet, normal fixed or random theme selection runs.
 
 ---
 
 ## Built-in themes
 
-### default
+### Week-view themes
 
-Classic layout. Black text on white. Filled black header, today column, and all-day
-event bars. 7-day calendar grid with weather/birthdays/quote along the bottom.
+| Theme | Best for | Notes |
+|---|---|---|
+| `default` | general family wall display | Classic 7-day layout with bottom weather, birthdays, and quote panels |
+| `terminal` | high-contrast retro look | Inverted black canvas with a distinct multi-font system |
+| `minimalist` | clean editorial layout | Border-light, dense, hides birthdays |
+| `old_fashioned` | decorative print-inspired display | Serif-heavy broadsheet layout |
+| `today` | single-day focus | Large date panel and spacious agenda |
+| `fantasy` | stylized themed display | Ornamental black-canvas week layout |
+
+### Full-screen focused themes
+
+| Theme | Best for | Notes |
+|---|---|---|
+| `qotd` | quote-first display | Full-screen quote plus compact weather strip |
+| `qotd_invert` | dark quote display | Inverted variant of `qotd` |
+| `weather` | weather station view | Current conditions, forecast, alerts, optional AQI |
+| `fuzzyclock` | glanceable clock | Natural-language time plus weather strip |
+| `fuzzyclock_invert` | dark clock display | Inverted variant of `fuzzyclock` |
+| `moonphase` | moon and sky display | Moon progression, illumination, weather, quote |
+| `moonphase_invert` | bright moon display | Inverted variant of `moonphase` |
+| `photo` | custom photo background | Full-canvas image with a bottom header bar; requires `photo.path` |
+
+### Specialized themes
+
+| Theme | Best for | Notes |
+|---|---|---|
+| `air_quality` | indoor/outdoor AQI dashboard | PurpleAir-first full-screen layout |
+| `timeline` | busy-day planning | Single-day hourly timeline |
+| `year_pulse` | longer-horizon planning | Year progress plus upcoming events and birthdays |
+| `sunrise` | daylight-oriented planning | Sun arc, day/night split, compact footer metrics |
+| `scorecard` | big-number metrics | KPI tiles for weather, AQI, calendar, and system data |
+| `tides` | maximum information density | Alternating horizontal bands spanning many data sources |
+
+### Utility themes
+
+| Theme | Best for | Notes |
+|---|---|---|
+| `message` | one-off reminders | Requires `--message`; excluded from random rotation |
+| `diags` | debugging and validation | Structured data readout; excluded from random rotation |
+
+### Theme details and previews
+
+#### default
+
+Classic layout. Black text on white with a 7-day calendar grid and three bottom panels.
 
 ![Default theme](../output/theme_default.png)
 
-### graphite
+#### terminal
 
-The default layout rendered in native **8-bit greyscale** (`canvas_mode="L"`). The structural
-layout is identical to `default` — 40px header, 320px week grid, 120px three-panel bottom bar
-— but three greyscale-exclusive techniques add tonal depth impossible in strict 1-bit mode:
-
-- **Date cell wash**: the combined Sat/Sun date cell (the large "APRIL / 7" zone in the
-  lower-right of the week view) receives a medium-grey fill before the calendar component
-  renders. The inverted APRIL band and the large day numeral are drawn on top; the grey shows
-  through in the open space framing the date.
-- **Tonal panel washes**: the weather, birthdays, and info panels each receive a distinct
-  grey fill (weather: darkest ~37%, birthdays: ~31%, info: ~25%) before components render.
-  Where components leave whitespace — around labels, between quote lines, beside the weather
-  icon — the underlying grey tint shows through, visually separating the info zone from the
-  clean white calendar above.
-- **Soft structural borders**: after all components have drawn their solid-black lines, the
-  overlay repaints those dividers with graduated grey values (two-tone shadow at the
-  week-view/bottom-bar boundary; mid-grey vertical panel separators), so borders read as
-  shadows rather than hard edges.
-
-The full effect requires dithering. Set `display.quantization_mode` in `config.yaml`:
-
-| Mode | Effect |
-|---|---|
-| `threshold` (default) | All grey zones collapse to white (>128); theme degrades gracefully to match default |
-| `floyd_steinberg` | Recommended — clearly visible error-diffusion halftone on the date cell and all three panels |
-| `ordered` | Bayer dot-matrix texture — regular, mechanical, distinctly greyscale |
-
-Font: DM Sans geometric variable sans (same as `minimalist`, `weather`, and `fuzzyclock`).
-
-![Graphite theme](../output/theme_graphite.png)
-
-### terminal
-
-Inverted canvas: **black background** with white text. Compact 34px header. Tighter event
-spacing (0.85× scale). Today's column and all-day event bars both pop as white-fill/black-text
-blocks. Multi-font typographic system: Share Tech Mono for event body text; Maratype for the
-dashboard title, day column headers, and quote body; UESC Display for the month band, section
-labels (WEATHER / BIRTHDAYS / QUOTE OF THE DAY), and quote attribution; Synthetic Genesis for
-the large today date numeral. The month band font scales down automatically so long names
-(FEBRUARY, SEPTEMBER) always fit the cell.
+High-contrast inverted week view with compact spacing and a retro terminal-inspired type system.
 
 ![Terminal theme](../output/theme_terminal.png)
 
-### minimalist
+#### minimalist
 
-Bauhaus editorial: form follows function. Ultra-slim 22px header with no fill or border.
-The week grid dominates at 358px. Today's column is marked with a subtle outline (no fill).
-All-day event bars are outlined, not filled. Events pack to a tight 1.0× grid. A 100px
-bottom strip splits asymmetrically: weather at 500px, quote at 300px (labelled with a
-single em dash). Section labels are 8pt regular — data leads. No structural borders or
-separator lines. DM Sans font. Birthdays panel hidden.
+Border-light editorial layout focused on the calendar and weather, with birthdays hidden.
 
 ![Minimalist theme](../output/theme_minimalist.png)
 
-### old_fashioned
+#### old_fashioned
 
-Victorian broadsheet layout. A 70px inverted masthead with white corner-bracket ornaments
-and a thin inner frame rule. A triple-rule band separates the masthead from the body. The
-left column (490px) shows today's schedule with Playfair Display serif body text. The right
-sidebar (310px) stacks three panels — **The Weather**, **Social Notices**, and **Words of
-Wisdom** — divided by double horizontal rules with diamond dingbats. A double vertical
-column rule with a centre diamond separates the two columns. Cinzel Black Roman caps for
-section labels. Double-rule bottom border.
+Victorian broadsheet layout with serif typography and decorative rules.
 
 ![Old Fashioned theme](../output/theme_old_fashioned.png)
 
-### today
+#### today
 
-Single-day focused view. Large inverted date panel on the left, spacious event list on the
-right with full time ranges and locations. 60px header, 140px bottom strip. Ideal for a
-desk display.
+Single-day agenda with a large date panel and roomy event list.
 
 ![Today theme](../output/theme_today.png)
 
-### fantasy
+#### fantasy
 
-D&D-inspired aesthetic. Black canvas with Cinzel Bold headers and sword-glyph accents in
-the masthead. A 240px left sidebar ("Arcane Tower") stacks three panels — **The Oracle's
-Omen** (weather), **The Fellowship** (birthdays), and **Ancient Wisdom** (quote). The
-**Quest Log** (week view) fills the right 560px. A thick ornamental double-frame border runs
-the full canvas, with concentric diamond corner ornaments at every inner-frame corner.
-Triple-line vertical divider between sidebar and quest log with diamond ticks at 1/3, 1/2,
-and 2/3 of the body height. Plus Jakarta Sans for event body text.
+Ornamental black-canvas week view with a fantasy-inspired visual system.
 
 ![Fantasy theme](../output/theme_fantasy.png)
 
-### moonphase
+#### qotd
 
-Celestial moon phase display. The current moon phase is rendered as a large 140px Weather
-Icons glyph at the centre of the canvas, flanked by three days on each side at graduated
-sizes (42/36/30px) showing the lunar progression from past to future. Below the moon arc
-sits the illumination percentage, sunrise and sunset times, moon age in days, and a compact
-weather strip with current conditions and hi/lo temperatures. A small centered daily quote
-fills the bottom. The entire canvas is framed by a whimsical vine border with triangular
-leaf buds along each edge, concentric-arc corner flourishes, and scattered stars in the
-upper corners. Dark canvas (white on black) for a night-sky aesthetic. Fonts: Cinzel Bold
-for the date and phase name, Playfair Display for body text and quote.
-
-![Moonphase theme](../output/theme_moonphase.png)
-
-### moonphase_invert
-
-Same layout as `moonphase` — central hero moon glyph, flanking day moons, celestial info
-strip, weather, and quote — but with the color scheme inverted: black on white for a
-parchment / fairy-tale illustrated-manuscript feel. The vine border, leaf buds, corner
-flourishes, and star scatter adapt automatically to the inverted palette. Maximum eInk
-contrast.
-
-![Moonphase Invert theme](../output/theme_moonphase_invert.png)
-
-### qotd
-
-Quote of the day, full screen. Forgoes the calendar, birthdays, and info panel entirely.
-The display is devoted to a single quote in large Playfair Display Bold, centered
-typographically. Font size scales automatically — from 64px down to 20px — so the full
-quote always fits without truncation. A compact full-width weather banner runs across the
-bottom 80px: current conditions, hi/lo, feels-like, wind, a 3-day forecast strip, and
-moon phase.
+Full-screen quote layout with a compact weather strip across the bottom.
 
 ![QOTD theme](../output/theme_qotd.png)
 
-### qotd_invert
+#### qotd_invert
 
-Same layout as `qotd` — full-screen centered quote with compact weather banner — but with the
-color scheme inverted: white Playfair Display text on a black canvas. The high-contrast strokes
-of this transitional serif read especially well reversed out of a dark ground.
+Inverted version of `qotd` with white quote text on black.
 
 ![QOTD Invert theme](../output/theme_qotd_invert.png)
 
-### weather
+#### weather
 
-Full-screen weather station. Devotes the entire 800×480 canvas to a rich weather display
-inspired by iOS Weather and Foreca Weather. The upper two-thirds show current conditions at
-a glance — an 80px weather icon, hero temperature in bold 72px DM Sans, description, and
-hi/lo line. Below the hero sits a row of metric cards: feels-like, wind speed and direction,
-humidity, UV index, and — when a PurpleAir sensor is configured — an AQI card showing the
-EPA air quality index and category (Good / Moderate / Unhealthy / etc.). A details bar spans
-the full width with sunrise/sunset times, barometric pressure, and moon phase; when a
-PurpleAir sensor is present this bar also shows a PM1 · PM2.5 · PM10 µg/m³ breakdown. If an
-active weather alert is present it appears as a prominent inverted full-width banner. The
-lower third shows a clean five-day forecast grid with icon, hi/lo temperatures, and
-precipitation probability for each day. All standard components (header, calendar, birthdays,
-quote) are hidden — the display is weather only. Font: DM Sans throughout.
+Full-screen weather dashboard with current conditions, alerts, forecast, and optional AQI.
 
 ![Weather theme](../output/theme_weather.png)
 
-### fuzzyclock
+#### fuzzyclock
 
-Natural-language clock. The current time is expressed as a human-readable phrase —
-"half past seven", "quarter to nine", "twenty five past eleven" — rendered large and
-centred in DM Sans Bold. The day name and date sit below in smaller regular weight. A
-compact full-width weather banner fills the bottom 80px (identical to the `qotd` strip:
-current conditions, hi/lo, feels-like, wind, 3-day forecast, moon phase). The calendar,
-birthdays, and quote panels are hidden entirely.
-
-Time phrases snap to the nearest 5-minute boundary, so the display changes at most twelve
-times per hour. The default systemd timer runs every 5 minutes; the image-hash check
-ensures no eInk refresh occurs when the phrase hasn't changed.
+Natural-language clock with a compact weather strip and no calendar panels.
 
 ![Fuzzyclock theme](../output/theme_fuzzyclock.png)
 
-### fuzzyclock_invert
+#### fuzzyclock_invert
 
-Same layout as `fuzzyclock` — full-screen natural-language clock phrase with compact weather
-banner — but with the color scheme inverted: white DM Sans text on a black canvas. The geometric
-shapes of this screen-optimised sans-serif hold up well at large sizes when reversed out of a
-dark background.
+Inverted version of `fuzzyclock`.
 
 ![Fuzzyclock Invert theme](../output/theme_fuzzyclock_invert.png)
 
-### air_quality
+#### moonphase
 
-Full-screen environmental health dashboard. Devotes the entire 800×480 canvas to PurpleAir
-sensor data, organised into four horizontal zones:
+Full-screen moon display with phase progression, sunrise/sunset, compact weather, and quote.
 
-- **AQI hero** (top 38%): the EPA Air Quality Index number in large bold type on the left,
-  with the category label (Good / Moderate / Unhealthy for Sensitive Groups / Unhealthy /
-  Very Unhealthy / Hazardous) below. On the right, a 6-zone health scale bar fills
-  progressively from left to the current reading, with a triangle position indicator and
-  zone labels.
-- **Particulate matter row** (15%): PM1.0 · PM2.5 · PM10 readings in µg/m³, centred in
-  three equal columns. Only fields returned by the sensor are shown.
-- **Ambient sensor cards** (21%): up to three rounded-rect cards for sensor temperature (°F),
-  relative humidity (%), and barometric pressure (hPa). PurpleAir sensor readings are used
-  when available; for any field the sensor does not report, the corresponding OWM value is
-  used as a fallback. The temperature card is hidden when both sources lack the value.
-- **Weather + forecast strip** (bottom 27%): current conditions (icon, temperature,
-  description, hi/lo) on the left; a 4-day forecast grid (day name, icon, hi/lo, precipitation
-  probability) on the right.
+![Moonphase theme](../output/theme_moonphase.png)
 
-Requires a configured PurpleAir sensor (`purpleair.api_key` + `purpleair.sensor_id` in
-`config.yaml`). Weather data is optional — the strip degrades gracefully if unavailable.
-Font: Space Grotesk — a proportional sans derived from Space Mono whose quirky
-letterforms (a, G, R, t) give the data-dashboard layout personality while remaining legible
-at all eInk display sizes.
+#### moonphase_invert
+
+Inverted version of `moonphase`.
+
+![Moonphase Invert theme](../output/theme_moonphase_invert.png)
+
+#### photo
+
+Full-canvas photo theme driven by `photo.path`. Intended for custom-image displays rather than calendar-heavy use.
+
+![Photo theme](../output/theme_photo.png)
+
+#### air_quality
+
+Full-screen PurpleAir-oriented AQI dashboard with particulate, ambient, weather, and forecast sections.
 
 ![Air Quality theme](../output/theme_air_quality.png)
 
-### timeline
+#### timeline
 
-Hourly day-view that makes free time and busy stretches immediately obvious. The standard
-7-day week grid is replaced by a single-day vertical timeline running from **7 AM to 9 PM**
-(14 visible hours).
-
-- **Left axis (52px):** Hour labels right-aligned against the axis (7a, 8a … 12p … 9p).
-  Subtle horizontal grid lines cross the timeline area at every hour boundary.
-
-- **Event blocks:** Each timed event is rendered as a filled inverted rectangle spanning its
-  start-to-end time proportionally. Event titles are drawn in white inside the block.
-  Overlapping events are automatically placed in adjacent columns using a greedy column
-  assignment algorithm — no two overlapping events share a column.
-
-- **Now line:** When today's date matches the display date, a dashed horizontal line
-  (4px-on / 3px-off, 2px thick) marks the current time. It moves every 5-minute timer tick
-  and the image-hash check prevents needless eInk refreshes when nothing has changed.
-
-- **All-day strip (top):** If there are any all-day events, a narrow 14px strip runs across
-  the full width above the hourly grid, dividing available horizontal space equally between
-  events.
-
-- **Weather strip (bottom 100px):** A compact full-width weather banner shows current
-  conditions, hi/lo, UV index, feels-like, and wind speed/direction. The four detail rows
-  are spread evenly across the strip height; no forecast grid is shown.
-
-Font: DM Sans throughout — the same screen-optimised geometric sans used by `minimalist`,
-`weather`, and `fuzzyclock`.
+Single-day hourly timeline that makes free blocks and overlaps easy to spot.
 
 ![Timeline theme](../output/theme_timeline.png)
 
-### year_pulse
+#### year_pulse
 
-Zooms out from the usual week-at-a-glance to show **where you are in the year**. Useful as
-a periodic big-picture check-in alongside the regular weekly themes.
-
-- **Year stats (top ~120px):** A large **year number** in bold (56px) anchors the top-left.
-  The current **week number** appears right-aligned at the same vertical position. Below both
-  sits a full-width **year progress bar**: the outline rect spans the whole content width;
-  the filled portion corresponds to the fraction of the year elapsed. A label beneath the bar
-  reads "Day X of Y · Z% complete" in regular weight.
-
-- **Countdown list (bottom ~200px):** After a horizontal rule and a "COMING UP" section
-  label, a list of upcoming items appears — one row per item. Each row shows a right-arrow
-  glyph, a bold days-until indicator (`3d`, `23d`, `today`), and the event or birthday name
-  truncated to the available width. The list merges:
-    - **Calendar events** from the next 14 days (first occurrence per summary/date pair)
-    - **Birthdays** from the next 120 days (next annual occurrence; age at next birthday
-      shown in parentheses when known)
-  
-  Items are sorted by days-until ascending. Up to five items are shown; the list truncates
-  cleanly when the region fills.
-
-- **Weather strip (bottom 100px):** Same compact weather banner as `timeline` — current conditions, hi/lo, UV index, feels-like, and wind. No forecast grid.
-
-Feb 29 birthdays in non-leap years are gracefully shifted to Feb 28 of the next year, so
-they always appear in the countdown without crashing.
-
-Font: Space Grotesk — the same data-dashboard sans used by `air_quality` and `message`. Its
-quirky proportional letterforms (a, G, R, t) suit numeric data display at all eInk sizes.
+Year progress plus a compact upcoming-items list for longer-horizon planning.
 
 ![Year Pulse theme](../output/theme_year_pulse.png)
 
-### sunrise
+#### sunrise
 
-Sun-centric daylight dashboard that organises the day around the sun's arc across the sky.
-A semicircular arc at the top of the canvas shows the sun's calculated position between
-sunrise and sunset — the glyph moves along the arc proportionally with time. Before sunrise
-or after sunset, the moon phase glyph replaces the sun. A dashed horizon line marks the
-transition between sky and ground, with sunrise/sunset times as labels. Below the horizon,
-a stippled dot-pattern fill creates a textured "ground" — a unique visual technique not
-used by any other theme.
-
-Today's events are split into two columns by sunset time: **DAYLIGHT** events (before
-sunset) on the left and **TONIGHT** events (after sunset) on the right. When evening events
-are sparse, the moon phase name and illumination percentage appear in the bottom of the
-right column. A compact full-width footer packs weather conditions (icon, temperature,
-description, hi/lo), air quality (AQI + category), and year progress (Day X/365) into a
-single dense strip, with a second row showing a 4-day forecast with weather icons.
-
-Font: NuCore Condensed for the header and section labels (the first theme to use this
-previously unused bundled font); Plus Jakarta Sans for event text.
+Sun arc and day/night split layout organized around daylight.
 
 ![Sunrise theme](../output/theme_sunrise.png)
 
-### scorecard
+#### scorecard
 
-At-a-glance numeric dashboard inspired by sports scoreboards and financial tickers.
-Everything is reduced to **big hero numbers** in a 4-column, 3-row tile grid — each tile
-is a large centred numeral (Space Grotesk Bold, 42px) with a small ALL CAPS label and a
-context sub-line beneath.
-
-**Row 1 — primary metrics:**
-- Events today (with "X this week" context)
-- Outdoor temperature (with hi/lo)
-- Air quality index (with category)
-- Week number and year (with year-progress percentage)
-
-**Row 2 — computed metrics (unique to this theme):**
-- Daylight remaining (percentage of time between sunrise and sunset)
-- Sunset countdown (hours and minutes until sunset)
-- Next birthday (days until, with name and age)
-- CPU temperature or system load (from host data)
-
-**Row 3 — moon + quote:**
-- 4-day moon phase glyph progression (yesterday, today, tomorrow, day after) showing the
-  lunar cycle animation in Weather Icons glyphs
-- Daily quote filling the remaining space
-
-Tiles gracefully show "—" when their data source is unavailable (no AQI configured, no
-host data, etc.). Font: Space Grotesk throughout for labels and context lines.
+Big-number tile dashboard for weather, AQI, calendar, and system metrics.
 
 ![Scorecard theme](../output/theme_scorecard.png)
 
-### tides
+#### tides
 
-Maximum information density in a striking zebra-stripe layout. The entire canvas is divided
-into **eight full-width horizontal bands** that flow top to bottom, alternating between
-inverted (white text on black fill) and normal (black text on white). This exploits eInk's
-strength — crisp high-contrast black/white — for a visually distinctive result.
-
-| Band | Style | Content |
-|------|-------|---------|
-| 1 | Inverted | Date (day, month, year) + fuzzy clock phrase (e.g. "ten to one") |
-| 2 | Normal | Today's events as flowing inline text with `·` separators |
-| 3 | Inverted | Current weather: icon, temperature, description, hi/lo, feels-like, humidity |
-| 4 | Normal | 5-day forecast inline with weather icons |
-| 5 | Inverted | AQI + category + PM2.5, sunrise/sunset arrows, moon phase glyph + illumination |
-| 6 | Normal | Birthday countdowns inline with `·` separators |
-| 7 | Inverted | Daily quote (largest band for visual breathing room) |
-| 8 | Normal | Host diagnostics: hostname, uptime, load, RAM%, CPU temp, IP address |
-
-This is the only theme that displays **all eight data sources** on a single screen. It also
-uniquely combines the fuzzy clock with other data — no other theme does this. Bands with
-missing data (no weather, no AQI, no host) are dynamically skipped and remaining bands
-expand to fill the canvas.
-
-Fonts: NuCore Condensed for inverted bands; Share Tech Mono for the host diagnostics band
-(terminal aesthetic); Plus Jakarta Sans for normal bands.
+Alternating horizontal bands with the densest multi-source layout in the theme set.
 
 ![Tides theme](../output/theme_tides.png)
 
-### message
+#### message
 
-Custom message display. Forgoes the calendar, birthdays, and info panel entirely.
-The display is devoted to a single user-supplied message in large Space Grotesk Bold,
-centered typographically. Font size scales automatically — from 64px down to 20px — so
-the full message always fits without truncation. Decorative oversized quotation marks frame
-the text as corner accents. A compact full-width weather banner runs across the bottom 80px
-(identical to the `qotd` strip: current conditions, hi/lo, feels-like, wind, 3-day
-forecast, and moon phase).
-
-Intended for manual one-off runs — pipe a reminder, announcement, or note to the display
-without touching `config.yaml`. Use `--message` to provide the text:
+Manual message display for reminders or announcements. Use:
 
 ```bash
 venv/bin/python -m src.main --dry-run --dummy --theme message --message "Dentist at 3pm"
 ```
 
-This theme is excluded from random rotation (`random_daily` / `random_hourly`) and must
-always be specified explicitly via `--theme message`.
-
 ![Message theme](../output/theme_message.png)
 
-### diags
+#### diags
 
-Diagnostic text readout. Devotes the entire 800×480 canvas to a structured two-column
-key-value display of every available data field. No icons, no decorations — only labeled
-sections rendered in a clean monospace font (Share Tech Mono for data rows, DM Sans Bold for
-section labels).
-
-**Left column:** WEATHER (condition, temperature, hi/lo, feels-like, humidity, wind speed and
-direction, barometric pressure, UV index, sunrise/sunset, active alerts) followed by a
-FORECAST strip (up to six days of date, hi/lo, description, and precipitation probability).
-
-**Right column (top-to-bottom):** CALENDAR (per-day event counts for the current Mon–Sun week),
-AIR QUALITY (AQI, PM2.5, PM1.0, PM10, plus PurpleAir ambient temperature/humidity/pressure
-when configured), BIRTHDAYS (name, date, and age for upcoming birthdays), and STATUS (data
-freshness level per source: Fresh / Aging / Stale / Expired).
-
-Each section label includes a right-aligned source attribution (`OpenWeatherMap`, `Google
-Calendar`, `PurpleAir`). `diags` is intentionally excluded from the random rotation pool —
-it is a utility/sanity-check view, not a daily aesthetic.
+Structured diagnostic readout for validating live data and system state.
 
 ![Diags theme](../output/theme_diags.png)
 
@@ -518,128 +276,23 @@ it is a utility/sanity-check view, not a daily aesthetic.
 
 ## Creating your own theme
 
-Two steps -- no changes to any component code:
+Contributor-facing implementation details live in [CONTRIBUTING.md](../CONTRIBUTING.md) and [CLAUDE.md](../CLAUDE.md). The operator-facing rule is simple: custom themes must be registered in the theme registry before they can be referenced from `config.yaml`.
 
-**1. Create `src/render/themes/<name>.py`:**
-
-```python
-from src.render.theme import ComponentRegion, Theme, ThemeLayout, ThemeStyle
-
-def retro_theme() -> Theme:
-    return Theme(
-        name="retro",
-        layout=ThemeLayout(
-            canvas_w=800, canvas_h=480,
-            header=ComponentRegion(0, 0, 800, 48),
-            week_view=ComponentRegion(0, 48, 540, 432),
-            weather=ComponentRegion(540, 48, 260, 144),
-            birthdays=ComponentRegion(540, 192, 260, 144),
-            info=ComponentRegion(540, 336, 260, 144),
-        ),
-        style=ThemeStyle(
-            invert_header=True,
-            invert_today_col=True,
-            invert_allday_bars=False,
-            spacing_scale=1.1,
-        ),
-    )
-```
-
-**2. Register in `src/render/theme.py`:**
-
-Add a clause to `load_theme()` and add the name to `AVAILABLE_THEMES`. New themes are
-automatically included in the random rotation pool. To exclude a theme from the pool (e.g.
-utility or diagnostic views), add its name to `_EXCLUDED_FROM_POOL` in
-`src/render/random_theme.py`.
-
-Then preview:
-
-```bash
-venv/bin/python -m src.main --dry-run --dummy --config /dev/stdin <<'EOF'
-theme: retro
-display:
-  model: "epd7in5_V2"
-weather:
-  api_key: "dummy"
-  latitude: 40.7
-  longitude: -74.0
-google:
-  service_account_path: "credentials/service_account.json"
-  calendar_id: "dummy@group.calendar.google.com"
-EOF
-```
-
-See the theme reference tables and font customization guide in [`CLAUDE.md`](../CLAUDE.md).
-
----
-
-## Greyscale themes (opt-in)
-
-All 20 built-in themes render in strict black/white (1-bit canvas).  For themes that need
-intermediate grey values — photo backgrounds, gradients, soft shadows — you can opt in to
-greyscale rendering by setting `canvas_mode = "L"` on `ThemeLayout`:
-
-```python
-from src.render.theme import ComponentRegion, Theme, ThemeLayout, ThemeStyle
-
-def soft_theme() -> Theme:
-    return Theme(
-        name="soft",
-        layout=ThemeLayout(
-            canvas_w=800, canvas_h=480,
-            canvas_mode="L",          # ← opt in to 8-bit greyscale canvas
-            header=ComponentRegion(0, 0, 800, 40),
-            week_view=ComponentRegion(0, 40, 800, 440),
-        ),
-        style=ThemeStyle(
-            fg=0,    # black  (0 in L mode — same as always)
-            bg=255,  # white  (255 in L mode — must be 255, not 1)
-            invert_header=True,
-        ),
-    )
-```
-
-**Rules for L-mode themes:**
-
-| Rule | Reason |
-|---|---|
-| Use `fg=0, bg=255` (not `bg=1`) | In L mode, `1` is near-black (1/255 grey), not white. Existing themes use `bg=1` which is only correct in 1-bit mode. |
-| Inverted palette: `fg=255, bg=0` | `255` is white in L mode. |
-| Components draw with 0–255 fill values | Full greyscale range is available; use any value 0–255. |
-
-**How the final output is produced:**
-
-The L canvas is quantized to 1-bit at the very end of `render_dashboard()`, using the
-`display.quantization_mode` setting from `config.yaml` (default: `threshold`).  Choose
-`floyd_steinberg` or `ordered` for better apparent grey rendering:
-
-```yaml
-display:
-  quantization_mode: "floyd_steinberg"  # or "ordered" for Bayer halftone
-```
-
-See [Quantization mode](configuration.md#quantization-mode) for mode descriptions.
-
-The output contract is unchanged: `render_dashboard()` always returns a 1-bit PIL Image.
-Existing display drivers, image hashing, and dry-run preview all work without modification.
+If you are authoring a greyscale custom theme, set `ThemeLayout.canvas_mode = "L"` and use `fg=0, bg=255` in `ThemeStyle`.
 
 ---
 
 ## Typography
 
-| Font | Used for |
-|---|---|
-| [Plus Jakarta Sans](https://fonts.google.com/specimen/Plus+Jakarta+Sans) | Default UI text (all themes) |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/) | Weather condition icons + moon phase glyphs |
-| [Share Tech Mono](https://fonts.google.com/specimen/Share+Tech+Mono) | `terminal` theme — event body text; `diags` theme — all data rows |
-| Maratype | `terminal` theme — dashboard title, day column headers, quote body |
-| UESC Display | `terminal` theme — month band, section labels, quote attribution |
-| Synthetic Genesis | `terminal` theme — large today date numeral |
-| [DM Sans](https://fonts.google.com/specimen/DM+Sans) | `graphite` theme; `minimalist` theme; `weather` theme; `fuzzyclock` theme; `timeline` theme; `diags` theme — section labels |
-| [Playfair Display](https://fonts.google.com/specimen/Playfair+Display) | `old_fashioned` theme; `qotd` quote text; `moonphase` body text and quote |
-| [Cinzel](https://fonts.google.com/specimen/Cinzel) | `fantasy` theme; `old_fashioned` section labels; `moonphase` date and phase name |
-| [Space Grotesk](https://fonts.google.com/specimen/Space+Grotesk) | `air_quality` theme; `message` theme; `year_pulse` theme; `scorecard` theme — hero numbers, labels, and context |
-| NuCore / NuCore Condensed | `sunrise` theme — header and section labels; `tides` theme — inverted band text |
+Bundled font families used by the current built-in themes:
 
-Custom fonts can be added per-theme via `ThemeStyle` font callables — see
-[Creating your own theme](#creating-your-own-theme) and [`CLAUDE.md`](../CLAUDE.md).
+| Font | Used by |
+|---|---|
+| Plus Jakarta Sans | default and general fallback |
+| DM Sans | `minimalist`, `weather`, `fuzzyclock`, `timeline`, `diags` |
+| Playfair Display | `old_fashioned`, `qotd`, `moonphase` |
+| Cinzel | `fantasy`, `old_fashioned`, `moonphase` accents |
+| Space Grotesk | `air_quality`, `message`, `year_pulse`, `scorecard` |
+| Share Tech Mono / terminal fonts | `terminal`, `diags`, select utility text |
+
+For the live gallery, see [Color Themes](color-themes.md). For batch preview generation and Inky-specific previews, see [Color Theme Previews](color-theme-previews.md).

--- a/docs/upgrading-from-v3.md
+++ b/docs/upgrading-from-v3.md
@@ -148,7 +148,7 @@ Your existing config is fully compatible. These are opt-in additions:
 | Feature | How to enable |
 |---|---|
 | **Versioning** (`--version` flag) | Run `python -m src.main --version` or `make version` to print the current version |
-| **Themes** (built-in layouts) | Add `theme: terminal` (or `minimalist`, `old_fashioned`, `today`, `fantasy`, `moonphase`, `moonphase_invert`, `qotd`, `qotd_invert`, `weather`, `air_quality`, `fuzzyclock`, `fuzzyclock_invert`, `diags`) to `config.yaml`, or pass `--theme THEME` on the command line |
+| **Themes** (built-in layouts) | Set `theme: <theme_name>` in `config.yaml`, or pass `--theme THEME` on the command line. See [Themes](themes.md) for the current live theme catalog. |
 | **Random theme rotation** | Set `theme: random_daily` (once per day) or `theme: random_hourly` (once per hour); optionally add a `random_theme:` block to include/exclude specific themes |
 | **Event filtering** | Add a `filters:` block — hide events by calendar name, keyword, or all-day status |
 | **Configurable cache TTLs** | Add a `cache:` block to tune per-source TTL and fetch intervals |

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Validate markdown links and canonical theme inventories."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_FILES = [ROOT / "README.md", ROOT / "CONTRIBUTING.md"] + sorted((ROOT / "docs").glob("*.md"))
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+HEADING_RE = re.compile(r"^##+\s+(.+)$", re.MULTILINE)
+
+
+def load_theme_names() -> set[str]:
+    text = (ROOT / "src" / "render" / "theme.py").read_text()
+    names = set(re.findall(r'"([a-z_]+)":\s+\("src\.render\.themes\.', text))
+    names.add("default")
+    return names
+
+
+def check_links() -> list[str]:
+    errors: list[str] = []
+    for doc in DOC_FILES:
+        text = doc.read_text()
+        for raw_target in LINK_RE.findall(text):
+            target = raw_target.strip()
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            path = target.split("#", 1)[0]
+            resolved = (doc.parent / path).resolve()
+            if not resolved.exists():
+                errors.append(f"{doc.relative_to(ROOT)}: missing link target {target}")
+    return errors
+
+
+def check_theme_gallery(theme_names: set[str]) -> list[str]:
+    errors: list[str] = []
+
+    themes_doc = (ROOT / "docs" / "themes.md").read_text()
+    headings = {h.strip("` ").lower().replace(" ", "_") for h in HEADING_RE.findall(themes_doc)}
+    detail_headings = {
+        name
+        for name in headings
+        if name in theme_names
+    }
+    missing_in_themes = sorted(theme_names - detail_headings)
+    extra_in_themes = sorted(detail_headings - theme_names)
+    for name in missing_in_themes:
+        errors.append(f"docs/themes.md: missing heading for theme '{name}'")
+    for name in extra_in_themes:
+        errors.append(f"docs/themes.md: unexpected theme heading '{name}'")
+
+    gallery_doc = (ROOT / "docs" / "color-themes.md").read_text()
+    gallery_headings = {
+        h.strip("` ").lower().replace(" ", "_")
+        for h in HEADING_RE.findall(gallery_doc)
+        if h.strip() not in {"Color Themes"}
+    }
+    missing_in_gallery = sorted(theme_names - gallery_headings)
+    extra_in_gallery = sorted(gallery_headings - theme_names)
+    for name in missing_in_gallery:
+        errors.append(f"docs/color-themes.md: missing gallery entry for theme '{name}'")
+    for name in extra_in_gallery:
+        errors.append(f"docs/color-themes.md: unexpected gallery entry '{name}'")
+
+    return errors
+
+
+def main() -> int:
+    theme_names = load_theme_names()
+    errors = check_links()
+    errors.extend(check_theme_gallery(theme_names))
+    if errors:
+        for err in errors:
+            print(err)
+        return 1
+    print("docs-check: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -10,7 +10,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DOC_FILES = [ROOT / "README.md", ROOT / "CONTRIBUTING.md"] + sorted((ROOT / "docs").glob("*.md"))
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
-HEADING_RE = re.compile(r"^##+\s+(.+)$", re.MULTILINE)
+THEME_DETAIL_RE = re.compile(r"^####\s+(.+)$", re.MULTILINE)
+GALLERY_ENTRY_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+
+
+def normalize_heading(heading: str) -> str:
+    return heading.strip("` ").lower().replace(" ", "_")
 
 
 def load_theme_names() -> set[str]:
@@ -39,12 +44,7 @@ def check_theme_gallery(theme_names: set[str]) -> list[str]:
     errors: list[str] = []
 
     themes_doc = (ROOT / "docs" / "themes.md").read_text()
-    headings = {h.strip("` ").lower().replace(" ", "_") for h in HEADING_RE.findall(themes_doc)}
-    detail_headings = {
-        name
-        for name in headings
-        if name in theme_names
-    }
+    detail_headings = {normalize_heading(h) for h in THEME_DETAIL_RE.findall(themes_doc)}
     missing_in_themes = sorted(theme_names - detail_headings)
     extra_in_themes = sorted(detail_headings - theme_names)
     for name in missing_in_themes:
@@ -54,8 +54,8 @@ def check_theme_gallery(theme_names: set[str]) -> list[str]:
 
     gallery_doc = (ROOT / "docs" / "color-themes.md").read_text()
     gallery_headings = {
-        h.strip("` ").lower().replace(" ", "_")
-        for h in HEADING_RE.findall(gallery_doc)
+        normalize_heading(h)
+        for h in GALLERY_ENTRY_RE.findall(gallery_doc)
         if h.strip() not in {"Color Themes"}
     }
     missing_in_gallery = sorted(theme_names - gallery_headings)


### PR DESCRIPTION
## Summary

This PR tightens the project documentation around an operator-first flow while reducing duplication and stale inventories.

## What changed

- rewrote `README.md` into a short landing page and routing hub
- aligned public theme docs with the live theme registry
- removed stale `graphite` references and fixed preview-gallery drift
- tightened contributor docs so they reflect the current theme API and canonical doc ownership
- added `scripts/check_docs.py` plus `make docs-check` to validate markdown links and theme inventories

## Why

Recent project churn had left the docs surface inconsistent:

- README was acting as both landing page and manual
- public theme inventories had drifted from the actual registry
- contributor guidance included outdated theme examples
- there was no lightweight check to catch future doc drift

## Impact

- operators get a clearer entrypoint and better routing to the right docs
- contributors have a more accurate doc ownership model and theme-extension example
- future doc regressions are easier to catch in review with `make docs-check`

## Validation

- `python3 scripts/check_docs.py`
