### PR TITLE
fix: make dashboard title visible on inverted header bar

### DIFF
--- a/src/render/components/header.py
+++ b/src/render/components/header.py
@@ -35,7 +35,10 @@ def draw_header(
     if style.invert_header:
         filled_rect(draw, (x, y, x + w - 1, y + h - 1), fill=style.fg)
         text_fill = style.bg
-        title_fill = style.primary_accent_fill()
+        _accent = style.primary_accent_fill()
+        # On non-Inky displays, accent_primary falls back to fg, which is invisible
+        # against the filled header bar. Use bg (contrasting) in that case.
+        title_fill = _accent if _accent != style.fg else style.bg
     else:
         text_fill = style.fg
         title_fill = style.primary_accent_fill()


### PR DESCRIPTION
On non-Inky displays, _resolve_style falls back accent_primary to fg (0/black).
draw_header was using primary_accent_fill() for title_fill even in the
invert_header=True branch where the bar background is already fg — rendering
the title in black-on-black (invisible). Fall back to bg when the accent
matches fg so the title is always legible.

https://claude.ai/code/session_01U7SLn1DUeMJoG658imf75Z