### PR TITLE
Update repository name from Dashboard-v4 to HomeDashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Home Dashboard is a low-maintenance eInk wall display for family logistics on a 
 For a first install on a Raspberry Pi:
 
 ```bash
-git clone https://github.com/gkoch02/Dashboard-v4.git ~/home-dashboard
+git clone https://github.com/gkoch02/HomeDashboard.git ~/home-dashboard
 cd ~/home-dashboard
 make pi-install
 make configure

--- a/docs/upgrading-from-v3.md
+++ b/docs/upgrading-from-v3.md
@@ -19,7 +19,7 @@ SSH into your Pi. Your v3 installation is likely in `~/home-dashboard`.
 
 ```bash
 # On the Pi
-git clone https://github.com/gkoch02/Dashboard-v4.git ~/home-dashboard-v4
+git clone https://github.com/gkoch02/HomeDashboard.git ~/home-dashboard-v4
 ```
 
 ### 2. Copy your config and credentials from v3
@@ -85,8 +85,8 @@ All commands below run on your **dev machine** unless noted otherwise.
 ### 1. Clone v4
 
 ```bash
-git clone https://github.com/gkoch02/Dashboard-v4.git
-cd Dashboard-v4
+git clone https://github.com/gkoch02/HomeDashboard.git
+cd HomeDashboard
 ```
 
 ### 2. Copy your config and credentials from v3


### PR DESCRIPTION
## Summary
Updates all documentation references to reflect the repository name change from `Dashboard-v4` to `HomeDashboard`.

## Changes
- Updated git clone URLs in README.md installation instructions
- Updated git clone URLs and directory references in upgrading-from-v3.md documentation
- Changed repository references from `gkoch02/Dashboard-v4` to `gkoch02/HomeDashboard` across all setup guides

## Details
This change updates the documentation to point to the new repository name. All installation and upgrade instructions now reference the correct repository URL, ensuring users clone from the right location regardless of whether they're doing a fresh install or upgrading from v3.

https://claude.ai/code/session_011dDdyg7a4uUU3UYsAmG7CV