### PR TITLE
Catch up docs and add targeted tests for web routes, config schema, ICS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,17 +85,18 @@ src/
     ├── moon.py                # Moon phase calculator
     ├── primitives.py          # Shared draw utilities (truncation, wrapping, colors, fmt_time,
     │                          #   events_for_day, deg_to_compass)
-    ├── themes/                # themes (22): standard week-view (default, terminal,
+    ├── themes/                # themes (23): standard week-view (default, terminal,
     │                          #   minimalist, old_fashioned, today, fantasy); full-screen
     │                          #   focused (qotd, qotd_invert, fuzzyclock, fuzzyclock_invert,
     │                          #   weather, moonphase, moonphase_invert); specialized views
-    │                          #   (timeline, year_pulse, sunrise, air_quality, scorecard,
-    │                          #   tides); photo overlay (photo); utility (message, diags)
+    │                          #   (timeline, year_pulse, monthly, sunrise, air_quality,
+    │                          #   scorecard, tides); photo overlay (photo); utility (message, diags)
     └── components/            # One file per UI region: header, week_view, weather_panel,
                                #   weather_full, birthday_bar, today_view, info_panel, qotd_panel,
                                #   fuzzyclock_panel, diags_panel, air_quality_panel,
                                #   moonphase_panel, message_panel, timeline_panel,
-                               #   year_pulse_panel, sunrise_panel, scorecard_panel, tides_panel
+                               #   year_pulse_panel, monthly_panel, sunrise_panel,
+                               #   scorecard_panel, tides_panel
 └── web/                       # Optional Flask web UI (install: pip install -r requirements-web.txt)
     ├── __main__.py            # Entry point: python -m src.web [--config web.yaml] [--port 8080]
     ├── app.py                 # Flask application factory (create_app); registers all blueprints
@@ -149,7 +150,7 @@ Fetchers, caching, circuit breaking, and staleness are all per-source (calendar,
 ### Theme system
 Three-layer design: **ComponentRegion** (bounding box) → **ThemeLayout** (canvas + regions + draw order + `canvas_mode`) → **ThemeStyle** (colors, fonts, spacing). Components receive region + style and draw only within bounds. Themes are frozen dataclasses.
 
-`ThemeLayout.canvas_mode` is `"1"` (1-bit, default — all 22 built-in themes) or `"L"` (8-bit greyscale, opt-in for new themes). L-mode themes must use `fg=0, bg=255` in `ThemeStyle` (`bg=1` is near-black in L mode, not white). For Waveshare, the final L→`"1"` conversion is handled by `quantize_for_display()` in `render/quantize.py` and is controlled by `display.quantization_mode` (`threshold` / `floyd_steinberg` / `ordered`). For Inky, the final image is mapped to the limited Spectra 6 palette instead of being quantized to 1-bit.
+`ThemeLayout.canvas_mode` is `"1"` (1-bit, default — all 23 built-in themes) or `"L"` (8-bit greyscale, opt-in for new themes). L-mode themes must use `fg=0, bg=255` in `ThemeStyle` (`bg=1` is near-black in L mode, not white). For Waveshare, the final L→`"1"` conversion is handled by `quantize_for_display()` in `render/quantize.py` and is controlled by `display.quantization_mode` (`threshold` / `floyd_steinberg` / `ordered`). For Inky, the final image is mapped to the limited Spectra 6 palette instead of being quantized to 1-bit.
 
 Two rotation cadences are available: `theme: random_daily` (alias: `random`) picks once per day after midnight and persists to `state/random_theme_state.json`; `theme: random_hourly` picks once per hour and persists to `state/random_theme_hourly_state.json`. Both use the same `random_theme.include` / `random_theme.exclude` lists. The concrete theme name is resolved in `services/theme.py` before `load_theme()` is called — `load_theme()` itself never receives a pseudo-theme name.
 
@@ -229,6 +230,7 @@ Components are pure functions: `draw_*(draw, data, region, style) -> None`. No g
 |---|---|---|
 | `canvas_mode` | `"1"` | PIL image mode for the internal canvas. `"1"` = 1-bit bilevel (all built-in themes). `"L"` = 8-bit greyscale (opt-in for new themes). L-mode themes must use `fg=0, bg=255` in `ThemeStyle`. |
 | `background_fn` | `None` | Optional callable `(Image, ThemeLayout, ThemeStyle) -> None` executed BEFORE component rendering. Receives the raw PIL Image so it can paste photo/grayscale content beneath UI elements. Used by the `photo` theme to dither and paste a user photo onto the canvas. |
+| `prefer_color_on_inky` | `False` | When `True` AND `canvas_mode="L"` AND `display.provider: inky`, the canvas is rendered in RGB so the component can draw tuple-`fg`/`bg` colors directly (used by the `monthly` theme's heatmap palette). Ignored on Waveshare and on `"1"`-mode themes. |
 
 ### `ThemeStyle` fields
 
@@ -277,7 +279,7 @@ default to `None` and fall back gracefully so adding a new field never breaks ex
 - Inky Impression panels do not support partial refresh. For `display.provider: inky`, non-fuzzyclock themes are limited to one hardware refresh per hour; `fuzzyclock` and `fuzzyclock_invert` bypass that limit; `--force-full-refresh` also bypasses it
 - Default canvas: 800×480; scaled via LANCZOS to match display resolution
 - LANCZOS resize produces greyscale pixels; those are quantized to 1-bit by `quantize_for_display()`. The default `threshold` mode differs from the previous hard `.convert("1")` which used Floyd-Steinberg by Pillow default — set `display.quantization_mode: "floyd_steinberg"` to restore the old resize behavior if needed
-- `canvas_mode = "L"` themes must use `bg=255` (not `bg=1`) in `ThemeStyle`; `bg=1` is near-black in L mode. All 21 built-in themes use `canvas_mode="1"` (default) and are unaffected
+- `canvas_mode = "L"` themes must use `bg=255` (not `bg=1`) in `ThemeStyle`; `bg=1` is near-black in L mode. All 23 built-in themes use `canvas_mode="1"` (default) and are unaffected
 - Image hash comparison (`last_image_hash.txt`) skips eInk writes when content unchanged
 - Inky throttle state persists in `state/inky_refresh_state.json`
 - Health marker written to `output/last_success.txt` on every successful run (ISO timestamp)
@@ -329,3 +331,4 @@ default to `None` and fall back gracefully so adding a new field never breaks ex
 - `contacts_email` in `GoogleConfig` is required when `birthdays.source` is `"contacts"` — the service account must have domain-wide delegation, and this field specifies whose contacts to read via the People API
 - Inky Spectra 6 color mapping: `_INKY_THEME_KEY_COLORS` in `canvas.py` assigns a `(primary, secondary)` palette index pair to each theme. When `display.provider: inky`, `_resolve_style()` remaps `fg`/`bg` to Inky palette indices and fills unset accent roles (`accent_info` → blue, `accent_warn` → yellow, `accent_alert` → red, `accent_good` → green, `accent_primary`/`accent_secondary` → per-theme key colors). Palette indices: 0=black, 1=white, 2=red, 3=blue, 4=yellow, 5=green
 - `accent_primary` and `accent_secondary` on `ThemeStyle` are general-purpose accent fills; `primary_accent_fill()` and `secondary_accent_fill()` methods return `fg` when the accent is `None` (monochrome fallback). Components should call these methods rather than reading the fields directly
+- `monthly` theme uses the `monthly` region on `ThemeLayout` and dispatches via `draw_monthly()` in `monthly_panel.py`. The grid is Sunday-first and always renders a six-row layout (cells outside the current month are blanked). On Inky it opts into the RGB canvas path via `prefer_color_on_inky=True` and uses a 5-step heatmap palette (`(255,249,235)` → `(175,28,28)`); on Waveshare the same density is shown via a 1-bit outlined meter (`_draw_monochrome_density_indicator`). `monthly` is included in the random rotation pool. Typography: DM Sans family (`dm_bold`/`dm_semibold`/`dm_medium`/`dm_regular`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,12 +35,19 @@ google:
   calendar_id: "primary"
   additional_calendars: []
   # contacts_email: "you@yourdomain.com"  # required for birthdays.source: "contacts"
+                                          # — the user whose Google Contacts the
+                                          # service account reads via the People API
+                                          # (requires domain-wide delegation; see
+                                          # setup.md → Birthday Configuration)
   daily_quota_warning: 500         # log warning when daily API calls exceed this
 
   # ICS feed alternative — when set, service_account_path is ignored for events.
   # Get the URL: Google Calendar → Settings → [calendar] → "Secret address in iCal format"
   # ical_url: "https://calendar.google.com/calendar/ical/.../.../basic.ics"
-  # additional_ical_urls: []
+  # additional_ical_urls: []        # optional extra ICS URLs; events are merged
+                                    # with `ical_url`. Per-feed failure is non-fatal:
+                                    # any feed that returns an HTTP error is logged
+                                    # as a warning and skipped while the others render.
 
 weather:
   api_key: ""
@@ -65,6 +72,10 @@ schedule:
 timezone: "local"                  # IANA name or "local"
 title: "Home Dashboard"            # text shown in the header bar
 theme: "default"                   # default | terminal | minimalist | old_fashioned | today | fantasy | moonphase | moonphase_invert | qotd | qotd_invert | weather | fuzzyclock | fuzzyclock_invert | air_quality | message | diags | timeline | year_pulse | monthly | sunrise | scorecard | tides | photo | random | random_daily | random_hourly
+
+# photo:                           # only used when theme: photo (see setup.md → Photo theme)
+#   path: "/home/pi/wallpaper.jpg" # JPEG or PNG; converted to greyscale and dithered
+                                   # (Floyd-Steinberg on Waveshare; Spectra-6 palette mapping on Inky)
 
 random_theme:                      # only used when theme: random_daily or random_hourly
   include: []                      # allowlist (empty = all themes eligible)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,6 +6,7 @@
 - [ICS Feed (No GCP Required)](#ics-feed-no-gcp-required)
 - [Birthday Configuration](#birthday-configuration)
 - [PurpleAir Air Quality (Optional)](#purpleair-air-quality-optional)
+- [Photo Theme (Optional)](#photo-theme-optional)
 - [Raspberry Pi Reference](#raspberry-pi-reference)
 - [Web UI (Optional)](web-ui.md)
 - [Supported Displays](#supported-displays)
@@ -196,6 +197,57 @@ The sensor is polled at the interval set by `cache.air_quality_fetch_interval` (
 
 If either `api_key` or `sensor_id` is missing or empty, the source is silently skipped —
 no errors, no circuit breaker entry.
+
+---
+
+## Photo Theme (Optional)
+
+Display a custom image as a full-canvas wallpaper instead of dashboard data. Useful for
+ambient frames, art rotations, or seasonal wallpapers.
+
+### Step 1 — Pick an image
+
+Any JPEG or PNG works. Higher-resolution sources dither more cleanly than ones already
+near the display's native resolution. The image is automatically resized to fit the
+canvas (LANCZOS), so you do not need to pre-crop it.
+
+Copy the file somewhere persistent on the Pi, for example:
+
+```bash
+mkdir -p ~/dashboard-photos
+cp ~/Downloads/family-portrait.jpg ~/dashboard-photos/
+```
+
+### Step 2 — Enable the theme in config.yaml
+
+```yaml
+theme: photo
+photo:
+  path: "/home/pi/dashboard-photos/family-portrait.jpg"
+```
+
+That's it — the next refresh will paint the dithered photo across the full display. The
+photo theme renders edge-to-edge with no header bar.
+
+### How rendering works
+
+| Backend | Pipeline |
+|---|---|
+| `waveshare` | Greyscale → resize → Floyd-Steinberg dither to 1-bit black/white |
+| `inky` | Greyscale + saturation blending → resize → Spectra 6 palette mapping |
+
+Dark-canvas variants invert the greyscale source so bright regions of the photo stay
+white on the eInk panel rather than rendering as solid black.
+
+### Tips
+
+- Portraits and high-contrast scenes dither best on Waveshare's 1-bit panel.
+- For Inky Spectra 6, photos with naturally warm or limited palettes (sunsets, sepia
+  prints) match the panel's color gamut more faithfully than full-color modern photos.
+- Run `make dry --theme photo` (or `venv/bin/python -m src.main --dry-run --theme photo`)
+  to preview the dithered output in `output/latest.png` before deploying to the Pi.
+- The `photo` theme is **excluded** from the random rotation pool — pick it explicitly
+  via `theme: photo` rather than relying on randomization.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -244,8 +244,9 @@ white on the eInk panel rather than rendering as solid black.
 - Portraits and high-contrast scenes dither best on Waveshare's 1-bit panel.
 - For Inky Spectra 6, photos with naturally warm or limited palettes (sunsets, sepia
   prints) match the panel's color gamut more faithfully than full-color modern photos.
-- Run `make dry --theme photo` (or `venv/bin/python -m src.main --dry-run --theme photo`)
-  to preview the dithered output in `output/latest.png` before deploying to the Pi.
+- Run `venv/bin/python -m src.main --dry-run --dummy --theme photo` to preview the
+  dithered output in `output/latest.png` before deploying to the Pi. (`make dry` does
+  not pass through `--theme`, so invoke the module directly when overriding the theme.)
 - The `photo` theme is **excluded** from the random rotation pool — pick it explicitly
   via `theme: photo` rather than relying on randomization.
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -267,6 +267,31 @@ make web-logs           # tail -f output/dashboard-web.log
 make web-status         # systemd status + recent log tail
 ```
 
+### Event store (`state/web_events.jsonl`)
+
+`state/web_events.jsonl` is an append-only audit log written by `src/web/event_store.py`.
+It records every UI-initiated action — manual refresh requests, config saves, breaker
+resets, cache clears, and config restores — one JSON object per line.
+
+```json
+{"timestamp": "2026-04-20T15:32:11+00:00", "kind": "config_saved",
+ "message": "Saved 3 changes from /config", "details": {"fields": ["theme", "title"]}}
+```
+
+A few operator notes:
+
+- **Retention is unbounded.** The file only grows. Rotate or truncate it manually if it
+  becomes unwieldy. `state/` is on the same disk as the rest of the project, so a runaway
+  log can fill the SD card on small Pi installs.
+- **It is sensitive.** The file logs *what* changed (e.g. "saved theme: minimalist") and
+  *who* made the change in multi-user setups (via the authenticated username). Treat it
+  with the same care as `web.yaml`: do not commit it, do not paste it into bug reports
+  without redaction.
+- **It is best-effort.** Write failures are logged at DEBUG level and silently swallowed
+  so a missing/unwritable `state/` directory never breaks the UI.
+- **It is read-truncated.** The status page's "Recent Events" card only loads the most
+  recent ~20 entries; the full file is preserved untouched.
+
 ---
 
 ## Running without systemd
@@ -299,3 +324,4 @@ venv/bin/python -m src.web --port 9000
 - **The Refresh Now button triggers a dashboard run.** It cannot execute arbitrary commands.
 - **No HTTPS.** Traffic is unencrypted. For remote access outside your LAN, use an SSH tunnel or a reverse proxy with TLS (for example nginx + Let's Encrypt).
 - **`config/web.yaml` contains your password hash and possibly your session secret.** The file is git-ignored. Do not commit it.
+- **`state/web_events.jsonl` is an unbounded audit log.** It records every UI action and grows forever; rotate it manually if it gets large. Treat it as sensitive — see [Event store](#event-store-stateweb_eventsjsonl).

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -283,10 +283,12 @@ A few operator notes:
 - **Retention is unbounded.** The file only grows. Rotate or truncate it manually if it
   becomes unwieldy. `state/` is on the same disk as the rest of the project, so a runaway
   log can fill the SD card on small Pi installs.
-- **It is sensitive.** The file logs *what* changed (e.g. "saved theme: minimalist") and
-  *who* made the change in multi-user setups (via the authenticated username). Treat it
-  with the same care as `web.yaml`: do not commit it, do not paste it into bug reports
-  without redaction.
+- **It is sensitive but not user-attributed.** The file logs *what* changed (e.g.
+  "saved theme: minimalist") and the field set involved, but it does **not** record
+  the authenticated username — basic-auth gates access at the request boundary and
+  is not threaded into `append_event`. Don't rely on this log for per-user
+  accountability in shared deployments. Treat it with the same care as `web.yaml`:
+  do not commit it, do not paste it into bug reports without redaction.
 - **It is best-effort.** Write failures are logged at DEBUG level and silently swallowed
   so a missing/unwritable `state/` directory never breaks the UI.
 - **It is read-truncated.** The status page's "Recent Events" card only loads the most

--- a/tests/test_ical_edge_cases.py
+++ b/tests/test_ical_edge_cases.py
@@ -186,6 +186,86 @@ class TestFetchFromIcalEdgeCases:
         assert events == []
 
     @patch("src.fetchers.calendar_ical.requests.get")
+    def test_multiple_feeds_are_merged_and_sorted(self, mock_get):
+        """Events from multiple ICS URLs should be merged and sorted by start time."""
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        early_day = monday + timedelta(days=1)
+        late_day = monday + timedelta(days=3)
+
+        feed_a = _make_ical_response(
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART:{late_day.strftime('%Y%m%d')}T140000Z\r\n"
+            f"DTEND:{late_day.strftime('%Y%m%d')}T150000Z\r\n"
+            "SUMMARY:Late From Feed A\r\nUID:a-late\r\n"
+            "END:VEVENT\r\n",
+            cal_name="Feed A",
+        )
+        feed_b = _make_ical_response(
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART:{early_day.strftime('%Y%m%d')}T100000Z\r\n"
+            f"DTEND:{early_day.strftime('%Y%m%d')}T110000Z\r\n"
+            "SUMMARY:Early From Feed B\r\nUID:b-early\r\n"
+            "END:VEVENT\r\n",
+            cal_name="Feed B",
+        )
+
+        def get_side_effect(url, *args, **kwargs):
+            if "feed-a" in url:
+                return _mock_response(feed_a)
+            return _mock_response(feed_b)
+
+        mock_get.side_effect = get_side_effect
+
+        events = fetch_from_ical(
+            ["https://example.com/feed-a.ics", "https://example.com/feed-b.ics"]
+        )
+        summaries = [e.summary for e in events]
+        assert "Early From Feed B" in summaries, "Feed B event missing"
+        assert "Late From Feed A" in summaries, "Feed A event missing"
+        # Sorted ascending by start
+        starts = [e.start for e in events]
+        assert starts == sorted(starts), "Merged events not sorted by start time"
+        # Calendar-name attribution preserved per feed
+        by_summary = {e.summary: e.calendar_name for e in events}
+        assert by_summary["Early From Feed B"] == "Feed B"
+        assert by_summary["Late From Feed A"] == "Feed A"
+
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_one_feed_failing_does_not_block_others(self, mock_get):
+        """A single ICS URL HTTP failure must not prevent other feeds from rendering."""
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        event_day = monday + timedelta(days=2)
+
+        good_feed = _make_ical_response(
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART:{event_day.strftime('%Y%m%d')}T120000Z\r\n"
+            f"DTEND:{event_day.strftime('%Y%m%d')}T130000Z\r\n"
+            "SUMMARY:Survived\r\nUID:survived-1\r\n"
+            "END:VEVENT\r\n",
+            cal_name="Good Feed",
+        )
+
+        def get_side_effect(url, *args, **kwargs):
+            if "broken" in url:
+                return _mock_response("", status_code=500)
+            return _mock_response(good_feed)
+
+        mock_get.side_effect = get_side_effect
+
+        events = fetch_from_ical(
+            [
+                "https://example.com/broken.ics",
+                "https://example.com/working.ics",
+            ]
+        )
+        summaries = [e.summary for e in events]
+        assert summaries == ["Survived"], (
+            f"Working feed lost when sibling failed: got {summaries!r}"
+        )
+
+    @patch("src.fetchers.calendar_ical.requests.get")
     def test_mixed_tz_events_in_single_feed(self, mock_get):
         """Events with different timezones in same feed should all parse."""
         today = date.today()

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -93,6 +93,112 @@ def test_all_editable_fields_have_yaml_paths():
         assert isinstance(path, tuple) and len(path) >= 1, f"Invalid path for {key!r}"
 
 
+# YAML key path → dataclass attribute path on Config. Most entries map directly
+# (e.g. ("display", "show_weather") → cfg.display.show_weather). Exceptions are
+# listed explicitly. theme_schedule is verified separately because it's a list.
+_YAML_TO_ATTR_OVERRIDES: dict[tuple, tuple] = {
+    ("logging", "level"): ("log_level",),
+}
+
+# Sample values used to write each editable field and read it back. The values
+# are intentionally distinct from the dataclass defaults so a silent dropout is
+# detectable.
+_SAMPLE_VALUES: dict[str, object] = {
+    "title": "ZZZ-roundtrip-title",
+    "theme": "minimalist",
+    "timezone": "America/Los_Angeles",
+    "log_level": "DEBUG",
+    "display.show_weather": False,
+    "display.show_birthdays": False,
+    "display.show_info_panel": False,
+    "display.week_days": 5,
+    "display.enable_partial_refresh": True,
+    "display.max_partials_before_full": 99,
+    "schedule.quiet_hours_start": 21,
+    "schedule.quiet_hours_end": 7,
+    "weather.latitude": 37.7749,
+    "weather.longitude": -122.4194,
+    "weather.units": "metric",
+    "birthdays.source": "calendar",
+    "birthdays.lookahead_days": 60,
+    "birthdays.calendar_keyword": "ZZZ-Birthday-Marker",
+    "filters.exclude_calendars": ["ZZZ-cal-a"],
+    "filters.exclude_keywords": ["ZZZ-kw-a"],
+    "filters.exclude_all_day": True,
+    "cache.weather_ttl_minutes": 11,
+    "cache.events_ttl_minutes": 12,
+    "cache.birthdays_ttl_minutes": 13,
+    "cache.weather_fetch_interval": 14,
+    "cache.events_fetch_interval": 15,
+    "cache.birthdays_fetch_interval": 16,
+    "cache.air_quality_ttl_minutes": 17,
+    "cache.air_quality_fetch_interval": 18,
+    "cache.max_failures": 19,
+    "cache.cooldown_minutes": 20,
+    "cache.quote_refresh": "hourly",
+    "random_theme.include": ["minimalist"],
+    "random_theme.exclude": ["fantasy"],
+}
+
+
+def _resolve_attr_path(yaml_path: tuple) -> tuple:
+    return _YAML_TO_ATTR_OVERRIDES.get(yaml_path, yaml_path)
+
+
+def _read_attr(cfg, attr_path: tuple):
+    obj = cfg
+    for segment in attr_path:
+        obj = getattr(obj, segment)
+    return obj
+
+
+def test_editable_fields_round_trip_through_load_config(tmp_path):
+    """Every EDITABLE_FIELD_PATHS entry must write to a YAML key that
+    load_config() reads back into the corresponding dataclass attribute.
+
+    Catches: a config field rename that leaves a stale entry pointing at an
+    ignored YAML key (the silent-write-no-effect bug).
+    """
+    from src.config import load_config
+
+    # Sanity: every editable field has a sample value (theme_schedule is special).
+    skip_keys = {"theme_schedule"}
+    missing = set(EDITABLE_FIELD_PATHS) - skip_keys - set(_SAMPLE_VALUES)
+    assert not missing, f"Sample values missing for: {sorted(missing)}"
+
+    p = tmp_path / "config.yaml"
+    raw = _apply_to_raw({}, _SAMPLE_VALUES)
+    p.write_text(yaml.dump(raw, default_flow_style=False, sort_keys=False))
+
+    cfg = load_config(str(p))
+
+    for api_path, value in _SAMPLE_VALUES.items():
+        yaml_path = EDITABLE_FIELD_PATHS[api_path]
+        attr_path = _resolve_attr_path(yaml_path)
+        actual = _read_attr(cfg, attr_path)
+        assert actual == value, (
+            f"{api_path!r} did not round-trip: wrote {value!r} via YAML "
+            f"path {yaml_path}, read {actual!r} from cfg.{'.'.join(attr_path)}"
+        )
+
+
+def test_editable_field_theme_schedule_round_trips(tmp_path):
+    """theme_schedule is a list-of-dicts and is handled separately by load_config."""
+    from src.config import load_config
+
+    p = tmp_path / "config.yaml"
+    raw = _apply_to_raw(
+        {},
+        {"theme_schedule": [{"time": "06:00", "theme": "default"}]},
+    )
+    p.write_text(yaml.dump(raw, default_flow_style=False, sort_keys=False))
+
+    cfg = load_config(str(p))
+    assert len(cfg.theme_schedule.entries) == 1
+    assert cfg.theme_schedule.entries[0].time == "06:00"
+    assert cfg.theme_schedule.entries[0].theme == "default"
+
+
 # ---------------------------------------------------------------------------
 # _load_raw_yaml
 # ---------------------------------------------------------------------------

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -191,6 +191,45 @@ def test_image_theme_404_when_missing(client):
     assert resp.status_code == 404
 
 
+def test_image_theme_serves_existing_preview(client, app, tmp_path):
+    output_dir = Path(app.config["OUTPUT_DIR"])
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00"
+        b"\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    (output_dir / "theme_monthly.png").write_bytes(png_bytes)
+    resp = client.get("/image/theme/monthly")
+    assert resp.status_code == 200
+    assert resp.content_type == "image/png"
+    # Theme previews are cacheable (max_age=3600).
+    assert "max-age=3600" in resp.headers.get("Cache-Control", "")
+
+
+def test_image_theme_rejects_uppercase_name(client):
+    """The allowlist is lowercase-only — uppercase characters must be rejected."""
+    resp = client.get("/image/theme/Default")
+    assert resp.status_code == 404
+
+
+def test_image_theme_rejects_special_chars(client):
+    """Hyphens and dots are not in the [a-z0-9_] allowlist."""
+    for name in ("foo-bar", "foo.bar", "foo bar"):
+        resp = client.get(f"/image/theme/{name}")
+        assert resp.status_code in (404, 400), f"Should reject {name!r}"
+
+
+def test_image_theme_does_not_serve_outside_output_dir(client, app, tmp_path):
+    """A file matching the theme_<name>.png pattern outside OUTPUT_DIR must
+    not be served, even if the safe-name check passes."""
+    # Place a PNG one level above OUTPUT_DIR to confirm the route does not
+    # accidentally read from a sibling directory.
+    sibling_png = tmp_path / "theme_evil.png"
+    sibling_png.write_bytes(b"\x89PNG\r\n\x1a\n")
+    resp = client.get("/image/theme/evil")
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Log routes
 # ---------------------------------------------------------------------------

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -219,15 +219,26 @@ def test_image_theme_rejects_special_chars(client):
         assert resp.status_code in (404, 400), f"Should reject {name!r}"
 
 
-def test_image_theme_does_not_serve_outside_output_dir(client, app, tmp_path):
-    """A file matching the theme_<name>.png pattern outside OUTPUT_DIR must
-    not be served, even if the safe-name check passes."""
-    # Place a PNG one level above OUTPUT_DIR to confirm the route does not
-    # accidentally read from a sibling directory.
-    sibling_png = tmp_path / "theme_evil.png"
-    sibling_png.write_bytes(b"\x89PNG\r\n\x1a\n")
-    resp = client.get("/image/theme/evil")
-    assert resp.status_code == 404
+def test_image_theme_rejects_encoded_path_traversal(client, app, tmp_path):
+    """URL-encoded traversal segments (..%2F) must not escape OUTPUT_DIR.
+
+    The literal `..` form is covered by test_image_theme_rejects_path_traversal;
+    this case ensures Werkzeug normalization + the safe-name regex together
+    reject percent-encoded variants before they reach the filesystem.
+    """
+    # Drop a real PNG one level above OUTPUT_DIR. If the route ever resolved
+    # `..%2Fsibling` to that file, this test would surface it as a 200.
+    sibling_png = tmp_path / "theme_sibling.png"
+    sibling_png.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00"
+        b"\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    for encoded in ("..%2Fsibling", "%2E%2E%2Fsibling", "..%5Csibling"):
+        resp = client.get(f"/image/theme/{encoded}")
+        assert resp.status_code in (404, 400), (
+            f"Encoded traversal {encoded!r} returned {resp.status_code}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Docs: refresh CLAUDE.md theme count to 23, document the monthly theme
gotchas and prefer_color_on_inky field, expand setup.md with a Photo
Theme section, document additional_ical_urls and contacts_email, and
describe the web event store in web-ui.md.

Tests: add image-route edge cases (missing files, path traversal,
allowlist enforcement, sibling-dir isolation), an EDITABLE_FIELD_PATHS
schema-consistency round-trip test, and multi-ICS merging tests covering
chronological ordering and one-feed-failing graceful degradation.