### PR TITLE
Expand test coverage across web UI, fetchers, and render layers

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -497,6 +497,158 @@ class TestLoadCachedSourceUnknownSourcePaths:
             assert result is None
 
 
+class TestLoadCachedSourceWithMetadata:
+    """Cover the branches of load_cached_source_with_metadata()."""
+
+    def test_returns_none_when_file_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert load_cached_source_with_metadata("weather", tmpdir) is None
+
+    def test_returns_none_on_unreadable_json(self, caplog):
+        import logging
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "dashboard_cache.json").write_text("{not valid json")
+            with caplog.at_level(logging.WARNING, logger="src.fetchers.cache"):
+                result = load_cached_source_with_metadata("weather", tmpdir)
+        assert result is None
+        assert "Cache read failed" in caplog.text
+
+    def test_events_block_returns_metadata(self):
+        """v2 events block with extra metadata returns (events, fetched_at, metadata)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v2 = {
+                "schema_version": 2,
+                "events": {
+                    "fetched_at": "2024-03-15T08:00:00",
+                    "data": [],
+                    "sync_token": "token-abc",
+                },
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v2))
+            result = load_cached_source_with_metadata("events", tmpdir)
+        assert result is not None
+        events, fetched_at, metadata = result
+        assert events == []
+        assert fetched_at == datetime(2024, 3, 15, 8, 0, 0)
+        assert metadata == {"sync_token": "token-abc"}
+
+    def test_weather_empty_block_returns_none_metadata(self):
+        """A v2 weather block with no data → (None, ...) with empty metadata."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v2 = {
+                "schema_version": 2,
+                "weather": {"fetched_at": "2024-03-15T08:00:00", "data": None},
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v2))
+            result = load_cached_source_with_metadata("weather", tmpdir)
+        assert result is not None
+        data, _, metadata = result
+        assert data is None
+        assert metadata == {}
+
+    def test_air_quality_block_round_trips(self):
+        """Covers the air_quality deserialisation branch in load_cached_source_with_metadata."""
+        from src.data.models import AirQualityData
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            aq = AirQualityData(aqi=42, category="Good", pm25=9.0, pm10=12.0, sensor_id=123)
+            save_source("air_quality", aq, datetime(2024, 3, 15, 8, 0, 0), tmpdir)
+            result = load_cached_source_with_metadata("air_quality", tmpdir)
+        assert result is not None
+        loaded, _, _ = result
+        assert loaded.aqi == 42
+        assert loaded.category == "Good"
+
+    def test_air_quality_empty_data_branch(self):
+        """The ``if block.get('data') else None`` branch for air_quality."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v2 = {
+                "schema_version": 2,
+                "air_quality": {"fetched_at": "2024-03-15T08:00:00", "data": None},
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v2))
+            result = load_cached_source_with_metadata("air_quality", tmpdir)
+        assert result is not None
+        data, _, _ = result
+        assert data is None
+
+    def test_unknown_source_in_v2_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v2 = {
+                "schema_version": 2,
+                "custom": {"fetched_at": "2024-03-15T08:00:00", "data": []},
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v2))
+            result = load_cached_source_with_metadata("custom", tmpdir)
+        assert result is None
+
+    def test_block_with_bad_timestamp_logs_and_returns_none(self, caplog):
+        import logging
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v2 = {
+                "schema_version": 2,
+                "weather": {"fetched_at": "NOT_A_TIMESTAMP", "data": {"x": "y"}},
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v2))
+            with caplog.at_level(logging.WARNING, logger="src.fetchers.cache"):
+                result = load_cached_source_with_metadata("weather", tmpdir)
+        assert result is None
+        assert "decode failed" in caplog.text
+
+    def test_v1_fallback_returns_events_with_empty_metadata(self):
+        """Legacy v1 cache files produce an empty metadata dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v1 = {
+                "fetched_at": "2024-03-15T08:00:00",
+                "events": [
+                    {
+                        "summary": "Old",
+                        "start": "2024-03-15T09:00:00",
+                        "end": "2024-03-15T10:00:00",
+                        "is_all_day": False,
+                        "location": None,
+                        "calendar_name": None,
+                    }
+                ],
+                "weather": None,
+                "birthdays": [],
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v1))
+            result = load_cached_source_with_metadata("events", tmpdir)
+        assert result is not None
+        events, _, metadata = result
+        assert len(events) == 1
+        assert metadata == {}
+
+    def test_v1_fallback_returns_none_for_unknown_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            v1 = {
+                "fetched_at": "2024-03-15T08:00:00",
+                "events": [],
+                "weather": None,
+                "birthdays": [],
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v1))
+            result = load_cached_source_with_metadata("air_quality", tmpdir)
+        assert result is None
+
+    def test_v1_fallback_parse_error_returns_none(self):
+        """If _deserialise_v1 raises, with-metadata loader returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # v1 with an unparseable timestamp — _deserialise_v1 will blow up.
+            v1 = {
+                "fetched_at": "totally-broken",
+                "events": "not-a-list",
+                "weather": None,
+                "birthdays": [],
+            }
+            (Path(tmpdir) / "dashboard_cache.json").write_text(json.dumps(v1))
+            result = load_cached_source_with_metadata("events", tmpdir)
+        assert result is None
+
+
 class TestAtomicWriteCleanup:
     def test_temp_file_cleaned_up_on_write_failure(self):
         """If json.dump fails, the temp file should be removed."""

--- a/tests/test_ical_edge_cases.py
+++ b/tests/test_ical_edge_cases.py
@@ -307,4 +307,144 @@ class TestUrlHostname:
 
     def test_invalid_url_returns_original(self):
         result = _url_hostname("not a url")
-        assert isinstance(result, str)
+        # urlparse of "not a url" gives hostname=None → falls back to input.
+        assert result == "not a url"
+
+    def test_url_hostname_swallows_exception(self):
+        """If urlparse raises, _url_hostname returns the original string."""
+        with patch(
+            "src.fetchers.calendar_ical.urlparse",
+            side_effect=ValueError("boom"),
+        ):
+            assert _url_hostname("https://example.com/cal.ics") == "https://example.com/cal.ics"
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: uncommon VEVENT / fetch branches
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalCoverage:
+    def test_event_with_unrecognised_dtstart_type_returns_none(self):
+        """A VEVENT whose DTSTART isn't a date or datetime is skipped."""
+        from icalendar import Calendar
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            "SUMMARY:Malformed\r\n"
+            "DTSTART:20260404T100000Z\r\n"
+            "UID:malformed-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        cal = Calendar.from_ical(ical_text)
+        for comp in cal.walk():
+            if comp.name == "VEVENT":
+                # Mutate the parsed component so .dt is a string — exercises the
+                # "unrecognised DTSTART type" branch.
+                dtstart = comp["DTSTART"]
+                dtstart.dt = "not a date"
+                assert _parse_ical_event(comp, "cal") is None
+
+    def test_timed_event_with_date_only_dtend(self):
+        """DTSTART is datetime but DTEND is a plain date — end is combined to midnight."""
+        from icalendar import Calendar
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            "SUMMARY:Oddly Typed\r\n"
+            "DTSTART:20260404T100000Z\r\n"
+            "DTEND;VALUE=DATE:20260405\r\n"
+            "UID:odd-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        cal = Calendar.from_ical(ical_text)
+        for comp in cal.walk():
+            if comp.name == "VEVENT":
+                event = _parse_ical_event(comp, "cal")
+                assert event is not None
+                assert event.is_all_day is False
+                # End snapped to midnight of DTEND date.
+                assert event.end.hour == 0
+                assert event.end.minute == 0
+
+    def test_allday_event_with_duration(self):
+        """All-day DTSTART with a DURATION property — DURATION extends the end date."""
+        from icalendar import Calendar
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            "SUMMARY:Multi-day Offsite\r\n"
+            "DTSTART;VALUE=DATE:20260404\r\n"
+            "DURATION:P3D\r\n"
+            "UID:allday-dur-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        cal = Calendar.from_ical(ical_text)
+        for comp in cal.walk():
+            if comp.name == "VEVENT":
+                event = _parse_ical_event(comp, "cal")
+                assert event is not None
+                assert event.is_all_day is True
+                assert (event.end - event.start).days == 3
+
+    def test_allday_event_with_datetime_dtend(self):
+        """All-day DTSTART but DTEND is a datetime — tzinfo is stripped."""
+        from icalendar import Calendar
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n"
+            "SUMMARY:All-day\r\n"
+            "DTSTART;VALUE=DATE:20260404\r\n"
+            "DTEND:20260405T000000Z\r\n"
+            "UID:allday-dtend-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        cal = Calendar.from_ical(ical_text)
+        for comp in cal.walk():
+            if comp.name == "VEVENT":
+                event = _parse_ical_event(comp, "cal")
+                assert event is not None
+                assert event.is_all_day is True
+                assert event.end.tzinfo is None
+
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_calendar_without_x_wr_calname_falls_back_to_hostname(self, mock_get):
+        """When X-WR-CALNAME is absent, events are labelled with the URL hostname."""
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        event_day = monday + timedelta(days=1)
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"  # no X-WR-CALNAME
+            "BEGIN:VEVENT\r\n"
+            f"DTSTART:{event_day.strftime('%Y%m%d')}T100000Z\r\n"
+            f"DTEND:{event_day.strftime('%Y%m%d')}T110000Z\r\n"
+            "SUMMARY:No Name Feed\r\nUID:nn-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        mock_get.return_value = _mock_response(ical_text)
+        events = fetch_from_ical(["https://calendar.example.org/feed.ics"])
+        assert events
+        assert all(e.calendar_name == "calendar.example.org" for e in events)
+
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_naive_datetime_events_are_kept_within_window(self, mock_get):
+        """VEVENTs without timezone info are filtered in naive local time."""
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        event_day = monday + timedelta(days=1)
+
+        ical_text = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "X-WR-CALNAME:Floating\r\n"
+            "BEGIN:VEVENT\r\n"
+            # Note: no Z suffix, no TZID → floating (naive) datetime
+            f"DTSTART:{event_day.strftime('%Y%m%d')}T120000\r\n"
+            f"DTEND:{event_day.strftime('%Y%m%d')}T130000\r\n"
+            "SUMMARY:Floating Event\r\nUID:f-1\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        mock_get.return_value = _mock_response(ical_text)
+        events = fetch_from_ical(["https://example.com/cal.ics"])  # no tz argument
+        assert len(events) == 1
+        assert events[0].summary == "Floating Event"

--- a/tests/test_photo_theme.py
+++ b/tests/test_photo_theme.py
@@ -162,6 +162,65 @@ class TestDrawPhotoBackground:
         white_canvas = bytes([255] * len(canvas.tobytes()))
         assert canvas.tobytes() != white_canvas
 
+    def test_rgb_canvas_falls_back_to_bayer_when_pil_quantize_scrambles_palette(
+        self, grey_png: Path, caplog
+    ):
+        """If PIL's FS quantize produces pixels outside the blended palette, the
+        photo theme should fall back to the Bayer path."""
+        from unittest.mock import patch
+
+        canvas = self._make_canvas(mode="RGB")
+        layout = self._make_layout()
+        style = self._make_style(path=str(grey_png))
+
+        # Produce an image that deliberately has a pixel outside the blended palette,
+        # so the "set(fs_result.getdata()) <= blended_set" check fails.
+        bad_fs = Image.new("RGB", (800, 480), (42, 42, 42))
+
+        # We patch quantize() on the opened image so the FS result goes through bad_fs.
+        real_image_class = Image.Image
+
+        class _WrappedImg:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+            def quantize(self, **kwargs):
+                return bad_fs.convert("P")
+
+        with patch.object(
+            real_image_class,
+            "quantize",
+            lambda self, **kw: bad_fs.convert("P"),
+        ):
+            with caplog.at_level(logging.DEBUG, logger="src.render.themes.photo"):
+                _draw_photo_background(canvas, layout, style)
+
+        # After the fallback, the canvas pixels must all be blended palette colours.
+        from src.render.quantize import blend_inky_palette
+
+        palette_set = set(blend_inky_palette(0.25))
+        assert set(canvas.getdata()) <= palette_set
+
+    def test_exception_during_load_is_logged_and_swallowed(self, caplog, grey_png: Path):
+        """An unexpected exception inside the dither path should log and not propagate."""
+        from unittest.mock import patch
+
+        canvas = self._make_canvas()
+        layout = self._make_layout()
+        style = self._make_style(path=str(grey_png))
+
+        with patch(
+            "src.render.primitives.load_and_dither_image",
+            side_effect=RuntimeError("dither broke"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="src.render.themes.photo"):
+                _draw_photo_background(canvas, layout, style)
+
+        assert any("failed to load image" in rec.message for rec in caplog.records)
+
     def test_rgb_canvas_pixels_are_palette_colors(self, grey_png: Path):
         """All pixels on the RGB canvas should be one of the 6 blended Inky palette colors.
 

--- a/tests/test_photo_theme.py
+++ b/tests/test_photo_theme.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from PIL import Image
@@ -26,6 +27,7 @@ from src.config import DisplayConfig
 from src.dummy_data import generate_dummy_data
 from src.render.canvas import render_dashboard
 from src.render.primitives import load_and_dither_image
+from src.render.quantize import blend_inky_palette
 from src.render.theme import AVAILABLE_THEMES, ThemeLayout, ThemeStyle, load_theme
 from src.render.themes.photo import _draw_photo_background, photo_theme
 
@@ -167,8 +169,6 @@ class TestDrawPhotoBackground:
     ):
         """If PIL's FS quantize produces pixels outside the blended palette, the
         photo theme should fall back to the Bayer path."""
-        from unittest.mock import patch
-
         canvas = self._make_canvas(mode="RGB")
         layout = self._make_layout()
         style = self._make_style(path=str(grey_png))
@@ -177,21 +177,8 @@ class TestDrawPhotoBackground:
         # so the "set(fs_result.getdata()) <= blended_set" check fails.
         bad_fs = Image.new("RGB", (800, 480), (42, 42, 42))
 
-        # We patch quantize() on the opened image so the FS result goes through bad_fs.
-        real_image_class = Image.Image
-
-        class _WrappedImg:
-            def __init__(self, inner):
-                self._inner = inner
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
-            def quantize(self, **kwargs):
-                return bad_fs.convert("P")
-
         with patch.object(
-            real_image_class,
+            Image.Image,
             "quantize",
             lambda self, **kw: bad_fs.convert("P"),
         ):
@@ -199,15 +186,11 @@ class TestDrawPhotoBackground:
                 _draw_photo_background(canvas, layout, style)
 
         # After the fallback, the canvas pixels must all be blended palette colours.
-        from src.render.quantize import blend_inky_palette
-
         palette_set = set(blend_inky_palette(0.25))
         assert set(canvas.getdata()) <= palette_set
 
     def test_exception_during_load_is_logged_and_swallowed(self, caplog, grey_png: Path):
         """An unexpected exception inside the dither path should log and not propagate."""
-        from unittest.mock import patch
-
         canvas = self._make_canvas()
         layout = self._make_layout()
         style = self._make_style(path=str(grey_png))

--- a/tests/test_purpleair_fetcher.py
+++ b/tests/test_purpleair_fetcher.py
@@ -258,3 +258,94 @@ class TestFetchAirQuality:
         assert call_kwargs[1]["headers"]["X-API-Key"] == "test-key"
         assert "pm2.5_60minute" in call_kwargs[1]["params"]["fields"]
         assert "pm1.0_atm" in call_kwargs[1]["params"]["fields"]
+
+
+# ---------------------------------------------------------------------------
+# Payload-shape robustness (covers _sensor_payload_to_dict edge branches)
+# ---------------------------------------------------------------------------
+
+
+def _make_payload_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+class TestSensorPayloadShape:
+    def test_malformed_fields_not_a_list_is_handled(self, cfg):
+        """When 'fields' is present but not a list, we fall through to 'no PM2.5' error."""
+        resp = _make_payload_response({"fields": "not-a-list", "data": [[1.0]]})
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            with pytest.raises(RuntimeError, match="PM2.5"):
+                fetch_air_quality(cfg)
+
+    def test_missing_data_list_is_handled(self, cfg):
+        """When 'data' is missing/empty, we fall through to 'no PM2.5' error."""
+        resp = _make_payload_response({"fields": ["pm2.5_60minute"], "data": []})
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            with pytest.raises(RuntimeError, match="PM2.5"):
+                fetch_air_quality(cfg)
+
+    def test_row_not_a_list_is_handled(self, cfg):
+        """When 'data' contains a non-list row, payload decode yields an empty dict."""
+        resp = _make_payload_response(
+            {"fields": ["pm2.5_60minute"], "data": [["valid"], "not-a-list-row"]}
+        )
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            # The first row is the list-of-row format — it IS a list, so it decodes.
+            # Just assert no crash; PM2.5 handling is exercised elsewhere.
+            with pytest.raises(RuntimeError):
+                fetch_air_quality(cfg)
+
+    def test_data_as_flat_row_list(self, cfg):
+        """data = [<scalar>, ...] (not list-of-rows) is also accepted."""
+        resp = _make_payload_response(
+            {"fields": ["pm2.5_60minute", "pm1.0_atm"], "data": [12.0, 4.0]}
+        )
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            result = fetch_air_quality(cfg)
+        assert result.pm25 == 12.0
+        assert result.pm1 == 4.0
+
+    def test_non_json_response_raises_runtime_error(self, cfg):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.side_effect = ValueError("expecting value")
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            with pytest.raises(RuntimeError, match="non-JSON"):
+                fetch_air_quality(cfg)
+
+    def test_sensor_field_with_unparseable_value_is_skipped(self, cfg):
+        """_first_float skips values that can't be converted to float."""
+        resp = _make_payload_response(
+            {
+                "sensor": {
+                    "pm2.5_60minute": "not-a-number",
+                    "pm2.5_60minute_a": 15.0,  # fallback succeeds
+                    "temperature": {"nested": "garbage"},  # bad type
+                }
+            }
+        )
+        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value.__enter__.return_value = mock_session
+            mock_session.get.return_value = resp
+            result = fetch_air_quality(cfg)
+        assert result.pm25 == 15.0
+        assert result.temperature is None

--- a/tests/test_purpleair_fetcher.py
+++ b/tests/test_purpleair_fetcher.py
@@ -293,20 +293,6 @@ class TestSensorPayloadShape:
             with pytest.raises(RuntimeError, match="PM2.5"):
                 fetch_air_quality(cfg)
 
-    def test_row_not_a_list_is_handled(self, cfg):
-        """When 'data' contains a non-list row, payload decode yields an empty dict."""
-        resp = _make_payload_response(
-            {"fields": ["pm2.5_60minute"], "data": [["valid"], "not-a-list-row"]}
-        )
-        with patch("src.fetchers.purpleair.requests.Session") as mock_session_cls:
-            mock_session = MagicMock()
-            mock_session_cls.return_value.__enter__.return_value = mock_session
-            mock_session.get.return_value = resp
-            # The first row is the list-of-row format — it IS a list, so it decodes.
-            # Just assert no crash; PM2.5 handling is exercised elsewhere.
-            with pytest.raises(RuntimeError):
-                fetch_air_quality(cfg)
-
     def test_data_as_flat_row_list(self, cfg):
         """data = [<scalar>, ...] (not list-of-rows) is also accepted."""
         resp = _make_payload_response(

--- a/tests/test_quantize.py
+++ b/tests/test_quantize.py
@@ -381,3 +381,88 @@ class TestQuantizeToPaletteFs:
             f"Sky-blue (70,130,200) mapped to {dominant} but expected blended blue {blended_blue}. "
             f"Full distribution: {pixel_counts}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python fallbacks (no numpy). Exercised by forcing ``import numpy`` to fail.
+# ---------------------------------------------------------------------------
+
+
+class TestPythonFallbacks:
+    """Drive the pure-Python branches by shadowing ``numpy`` with a failing import."""
+
+    @staticmethod
+    def _force_no_numpy(monkeypatch):
+        import builtins
+        import sys
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "numpy" or name.startswith("numpy."):
+                raise ImportError("numpy unavailable for this test")
+            return real_import(name, *args, **kwargs)
+
+        # Remove any cached numpy module so the import statement runs through the shim.
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        for mod in list(sys.modules):
+            if mod == "numpy" or mod.startswith("numpy."):
+                monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    def _solid_rgb(self, r, g, b, w=4, h=4):
+        return Image.new("RGB", (w, h), (r, g, b))
+
+    def test_ordered_palette_falls_back_to_python_without_numpy(self, monkeypatch):
+        self._force_no_numpy(monkeypatch)
+        palette = [(0, 0, 0), (255, 255, 255)]
+        img = self._solid_rgb(250, 250, 250, w=4, h=4)
+        result = quantize_to_palette_ordered(img, palette, bayer_strength=0)
+        assert result.mode == "RGB"
+        assert result.size == (4, 4)
+        # Every output pixel must be drawn from the palette.
+        palette_set = set(palette)
+        assert set(result.getdata()) <= palette_set
+
+    def test_fs_palette_falls_back_to_python_without_numpy(self, monkeypatch):
+        self._force_no_numpy(monkeypatch)
+        palette = [(0, 0, 0), (255, 0, 0), (0, 0, 255), (255, 255, 255)]
+        # Mixed-color image so the Floyd-Steinberg error diffusion actually propagates.
+        img = Image.new("RGB", (3, 3))
+        img.putdata(
+            [
+                (255, 0, 0),
+                (128, 128, 128),
+                (0, 0, 255),
+                (64, 64, 64),
+                (200, 200, 200),
+                (0, 0, 0),
+                (255, 255, 255),
+                (10, 10, 10),
+                (100, 0, 0),
+            ]
+        )
+        result = quantize_to_palette_fs(img, palette)
+        assert result.mode == "RGB"
+        assert result.size == (3, 3)
+        assert set(result.getdata()) <= set(palette)
+
+    def test_ordered_python_fallback_respects_bayer_threshold(self, monkeypatch):
+        """A mid-grey pixel with bayer_strength>0 should produce a mix of black and
+        white — never all one colour."""
+        self._force_no_numpy(monkeypatch)
+        palette = [(0, 0, 0), (255, 255, 255)]
+        img = self._solid_rgb(128, 128, 128, w=4, h=4)
+        result = quantize_to_palette_ordered(img, palette, bayer_strength=240)
+        data = set(result.getdata())
+        # With the 4×4 Bayer pattern spanning the full matrix, we should see both
+        # black and white pixels.
+        assert (0, 0, 0) in data
+        assert (255, 255, 255) in data
+
+    def test_fs_python_fallback_handles_1x1_image(self, monkeypatch):
+        """Edge case: width and height both 1 — no error diffusion neighbours exist."""
+        self._force_no_numpy(monkeypatch)
+        palette = [(0, 0, 0), (255, 255, 255)]
+        img = self._solid_rgb(10, 10, 10, w=1, h=1)
+        result = quantize_to_palette_fs(img, palette)
+        assert list(result.getdata()) == [(0, 0, 0)]

--- a/tests/test_weather_panel.py
+++ b/tests/test_weather_panel.py
@@ -4,8 +4,14 @@ from datetime import date, datetime, timedelta, timezone
 
 from PIL import Image, ImageDraw
 
-from src.data.models import DayForecast, WeatherAlert, WeatherData
-from src.render.components.weather_panel import _fmt_time, draw_weather
+from src.data.models import AirQualityData, DayForecast, WeatherAlert, WeatherData
+from src.render.components.weather_panel import (
+    _aqi_accent,
+    _draw_aqi_column,
+    _fmt_time,
+    draw_weather,
+)
+from src.render.theme import ThemeStyle
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -355,3 +361,106 @@ class TestFmtTime:
         dt = datetime(2024, 3, 15, 8, 0, tzinfo=timezone.utc)
         result = _fmt_time(dt)
         assert ":00" not in result
+
+
+def _make_aqi(aqi=42, category="Good", **kwargs):
+    return AirQualityData(aqi=aqi, category=category, pm25=kwargs.pop("pm25", 9.0), **kwargs)
+
+
+def _make_forecast(day_count=3):
+    base = date(2026, 4, 20)
+    return [
+        DayForecast(
+            date=base + timedelta(days=i + 1),
+            icon="01d",
+            description="clear",
+            high=60 + i,
+            low=50 + i,
+            precip_chance=0.15,
+        )
+        for i in range(day_count)
+    ]
+
+
+class TestAQIForecastColumn:
+    """Exercises the air-quality column that replaces a forecast slot when AQ data exists."""
+
+    def test_aqi_column_renders_when_air_quality_present(self):
+        weather = _make_weather(forecast=_make_forecast(3))
+        aqi = _make_aqi(aqi=42, category="Good")
+        img, draw = _make_draw()
+        draw_weather(draw, weather, today=date(2026, 4, 20), air_quality=aqi)
+        # Something was rendered — the image is no longer blank white.
+        assert img.getbbox() is not None
+
+    def test_aqi_column_truncates_long_category_label(self):
+        """Long category labels are truncated with an ellipsis so they fit the column."""
+        weather = _make_weather(forecast=_make_forecast(3))
+        aqi = _make_aqi(
+            aqi=175,
+            category="Unhealthy for Sensitive Groups with Extra Long Descriptor",
+        )
+        img, draw = _make_draw()
+        # Use a narrow region so truncation kicks in.
+        from src.render.theme import ComponentRegion
+
+        region = ComponentRegion(0, 0, 160, 200)
+        draw_weather(
+            draw,
+            weather,
+            today=date(2026, 4, 20),
+            air_quality=aqi,
+            region=region,
+        )
+        assert img.getbbox() is not None
+
+    def test_aqi_column_suppressed_when_alerts_present(self):
+        """When there is 1 alert, there are 2 forecast columns + alert column — no AQI column."""
+        weather = _make_weather(
+            forecast=_make_forecast(3),
+            alerts=[WeatherAlert(event="Heat Advisory")],
+        )
+        aqi = _make_aqi(aqi=42, category="Good")
+        img, draw = _make_draw()
+        draw_weather(draw, weather, today=date(2026, 4, 20), air_quality=aqi)
+        # No crash; rendering path ran without AQI-specific column.
+        assert img.getbbox() is not None
+
+    def test_draw_aqi_column_direct(self):
+        """Directly exercise _draw_aqi_column in isolation."""
+        img, draw = _make_draw(w=200, h=100)
+        style = ThemeStyle()
+        aqi = _make_aqi(aqi=87, category="Moderate")
+        _draw_aqi_column(draw, aqi, cx=0, top=0, col_w=80, col_h=80, style=style)
+        assert img.getbbox() is not None
+
+
+class TestAQIAccent:
+    def test_good_uses_accent_good(self):
+        style = ThemeStyle(accent_good=1, fg=0)
+        assert _aqi_accent(style, 20) == 1
+
+    def test_good_falls_back_to_fg_when_accent_unset(self):
+        style = ThemeStyle(fg=7)
+        assert _aqi_accent(style, 20) == 7
+
+    def test_moderate_uses_accent_warn(self):
+        style = ThemeStyle(accent_warn=2, fg=0)
+        # AQI 51–150 range
+        assert _aqi_accent(style, 100) == 2
+        assert _aqi_accent(style, 150) == 2  # upper boundary inclusive
+
+    def test_unhealthy_uses_accent_alert(self):
+        style = ThemeStyle(accent_alert=3, fg=0)
+        assert _aqi_accent(style, 200) == 3
+        assert _aqi_accent(style, 500) == 3
+
+    def test_boundary_51_is_warn_not_good(self):
+        style = ThemeStyle(accent_good=1, accent_warn=2, accent_alert=3, fg=0)
+        assert _aqi_accent(style, 50) == 1  # still good
+        assert _aqi_accent(style, 51) == 2  # transition
+
+    def test_boundary_151_is_alert(self):
+        style = ThemeStyle(accent_good=1, accent_warn=2, accent_alert=3, fg=0)
+        assert _aqi_accent(style, 150) == 2
+        assert _aqi_accent(style, 151) == 3

--- a/tests/test_web_actions.py
+++ b/tests/test_web_actions.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -248,3 +249,70 @@ def test_clear_cache_missing_source_returns_400(client):
         headers=_csrf_headers(client),
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Failure-path tests: each endpoint's ``except Exception`` branch returns 500.
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_refresh_returns_500_on_io_error(client):
+    headers = _csrf_headers(client)
+    with patch("src.web.routes.actions.Path.touch", side_effect=OSError("disk full")):
+        resp = client.post("/api/trigger-refresh", headers=headers)
+    assert resp.status_code == 500
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert "disk full" in body["error"]
+
+
+def test_reset_breaker_returns_500_on_write_failure(client):
+    headers = _csrf_headers(client)
+    with patch(
+        "src.web.routes.actions._atomic_write_json",
+        side_effect=OSError("no space left"),
+    ):
+        resp = client.post(
+            "/api/reset-breaker",
+            data=json.dumps({"source": "weather"}),
+            content_type="application/json",
+            headers=headers,
+        )
+    assert resp.status_code == 500
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert "no space" in body["error"]
+
+
+def test_clear_cache_returns_500_on_write_failure(client):
+    headers = _csrf_headers(client)
+    with patch(
+        "src.web.routes.actions._atomic_write_json",
+        side_effect=OSError("io broke"),
+    ):
+        resp = client.post(
+            "/api/clear-cache",
+            data=json.dumps({"source": "all"}),
+            content_type="application/json",
+            headers=headers,
+        )
+    assert resp.status_code == 500
+    body = json.loads(resp.data)
+    assert body["ok"] is False
+    assert "io broke" in body["error"]
+
+
+def test_atomic_write_json_cleans_up_tempfile_on_failure(tmp_path):
+    """If json.dump raises, the tempfile should be unlinked and the exception re-raised."""
+    from src.web.routes.actions import _atomic_write_json
+
+    target = tmp_path / "out.json"
+
+    # Something that json can't serialise should trigger cleanup.
+    unserialisable = {"bad": {object()}}
+    with pytest.raises(TypeError):
+        _atomic_write_json(target, unserialisable)
+
+    # No .tmp leftovers in the directory.
+    assert not any(p.suffix == ".tmp" for p in tmp_path.iterdir())
+    assert not target.exists()

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -132,9 +132,7 @@ def test_middleware_passes_with_correct_credentials():
 
 def test_cli_set_password_prints_hash(capsys):
     argv = ["src.web.auth", "--set-password"]
-    with patch.object(sys, "argv", argv), patch(
-        "getpass.getpass", side_effect=["hello", "hello"]
-    ):
+    with patch.object(sys, "argv", argv), patch("getpass.getpass", side_effect=["hello", "hello"]):
         runpy.run_module("src.web.auth", run_name="__main__")
     out = capsys.readouterr().out.strip().splitlines()[-1]
     assert out.startswith("scrypt:")
@@ -145,8 +143,9 @@ def test_cli_set_password_prints_hash(capsys):
 
 def test_cli_set_password_mismatch_exits_1(capsys):
     argv = ["src.web.auth", "--set-password"]
-    with patch.object(sys, "argv", argv), patch(
-        "getpass.getpass", side_effect=["hello", "goodbye"]
+    with (
+        patch.object(sys, "argv", argv),
+        patch("getpass.getpass", side_effect=["hello", "goodbye"]),
     ):
         with pytest.raises(SystemExit) as exc_info:
             runpy.run_module("src.web.auth", run_name="__main__")

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,162 @@
+"""Tests for src.web.auth — password hashing, check_password, Basic Auth middleware, CLI."""
+
+from __future__ import annotations
+
+import logging
+import runpy
+import sys
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from src.web.auth import check_password, hash_password, make_auth_middleware
+
+
+def test_hash_password_includes_scrypt_prefix():
+    h = hash_password("hunter2")
+    assert h.startswith("scrypt:")
+    # Format: scrypt:<base64 salt>:<base64 digest>
+    assert h.count(":") == 2
+
+
+def test_hash_password_roundtrip():
+    h = hash_password("hunter2")
+    assert check_password("hunter2", h) is True
+
+
+def test_hash_password_different_each_call():
+    """Salt should differ → two hashes of the same password are distinct."""
+    assert hash_password("same") != hash_password("same")
+
+
+def test_check_password_rejects_wrong_password():
+    h = hash_password("correct")
+    assert check_password("wrong", h) is False
+
+
+def test_check_password_rejects_non_scrypt_prefix():
+    assert check_password("x", "md5:garbage") is False
+    assert check_password("x", "") is False
+    assert check_password("x", "scrypthash-no-colon") is False
+
+
+def test_check_password_handles_malformed_scrypt_payload():
+    # Valid prefix but invalid base64 / wrong number of parts → exception swallowed.
+    assert check_password("x", "scrypt:not-base64!:also-not-base64!") is False
+    assert check_password("x", "scrypt:onlyonepart") is False
+
+
+def test_check_password_empty_password_against_valid_hash():
+    h = hash_password("real")
+    assert check_password("", h) is False
+
+
+# ---------------------------------------------------------------------------
+# make_auth_middleware
+# ---------------------------------------------------------------------------
+
+
+def test_make_auth_middleware_open_access_when_unconfigured(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.web.auth"):
+        mw = make_auth_middleware(None, None)
+    assert mw() is None
+    assert any("NOT configured" in rec.message for rec in caplog.records)
+
+
+def test_make_auth_middleware_open_access_when_username_missing(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.web.auth"):
+        mw = make_auth_middleware("", "scrypt:xxx:yyy")
+    assert mw() is None
+
+
+def test_make_auth_middleware_open_access_when_password_missing(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.web.auth"):
+        mw = make_auth_middleware("admin", "")
+    assert mw() is None
+
+
+def _app_with_auth(username, password_hash):
+    """Build a minimal Flask app that runs the auth middleware on each request."""
+    app = Flask(__name__)
+    app.before_request(make_auth_middleware(username, password_hash))
+
+    @app.route("/ping")
+    def ping():
+        return "pong"
+
+    return app
+
+
+def test_middleware_returns_401_without_credentials():
+    h = hash_password("secret")
+    app = _app_with_auth("admin", h)
+    client = app.test_client()
+    resp = client.get("/ping")
+    assert resp.status_code == 401
+    assert "WWW-Authenticate" in resp.headers
+    assert resp.headers["WWW-Authenticate"].startswith("Basic")
+
+
+def test_middleware_returns_401_with_bad_credentials():
+    h = hash_password("secret")
+    app = _app_with_auth("admin", h)
+    client = app.test_client()
+    resp = client.get("/ping", headers={"Authorization": "Basic YWRtaW46d3Jvbmc="})
+    assert resp.status_code == 401
+
+
+def test_middleware_returns_401_with_wrong_username():
+    h = hash_password("secret")
+    app = _app_with_auth("admin", h)
+    client = app.test_client()
+    # other:secret
+    resp = client.get("/ping", headers={"Authorization": "Basic b3RoZXI6c2VjcmV0"})
+    assert resp.status_code == 401
+
+
+def test_middleware_passes_with_correct_credentials():
+    h = hash_password("secret")
+    app = _app_with_auth("admin", h)
+    client = app.test_client()
+    # admin:secret
+    resp = client.get("/ping", headers={"Authorization": "Basic YWRtaW46c2VjcmV0"})
+    assert resp.status_code == 200
+    assert resp.data == b"pong"
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint: python -m src.web.auth --set-password
+# ---------------------------------------------------------------------------
+
+
+def test_cli_set_password_prints_hash(capsys):
+    argv = ["src.web.auth", "--set-password"]
+    with patch.object(sys, "argv", argv), patch(
+        "getpass.getpass", side_effect=["hello", "hello"]
+    ):
+        runpy.run_module("src.web.auth", run_name="__main__")
+    out = capsys.readouterr().out
+    assert out.startswith("scrypt:")
+
+
+def test_cli_set_password_mismatch_exits_1(capsys):
+    argv = ["src.web.auth", "--set-password"]
+    with patch.object(sys, "argv", argv), patch(
+        "getpass.getpass", side_effect=["hello", "goodbye"]
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_module("src.web.auth", run_name="__main__")
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "do not match" in err
+
+
+def test_cli_no_args_prints_usage_and_exits_1(capsys):
+    argv = ["src.web.auth"]
+    with patch.object(sys, "argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_module("src.web.auth", run_name="__main__")
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Usage:" in out

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -136,8 +136,11 @@ def test_cli_set_password_prints_hash(capsys):
         "getpass.getpass", side_effect=["hello", "hello"]
     ):
         runpy.run_module("src.web.auth", run_name="__main__")
-    out = capsys.readouterr().out
+    out = capsys.readouterr().out.strip().splitlines()[-1]
     assert out.startswith("scrypt:")
+    # The printed hash must validate against the original password.
+    assert check_password("hello", out) is True
+    assert check_password("wrong", out) is False
 
 
 def test_cli_set_password_mismatch_exits_1(capsys):

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -497,3 +497,161 @@ def test_post_config_requires_csrf(client):
         content_type="application/json",
     )
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode tests for internal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_load_raw_yaml_returns_empty_on_missing_file(tmp_path):
+    assert _load_raw_yaml(str(tmp_path / "does-not-exist.yaml")) == {}
+
+
+def test_load_raw_yaml_returns_empty_for_empty_file(tmp_path):
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    assert _load_raw_yaml(str(p)) == {}
+
+
+def test_load_raw_yaml_swallows_parse_error(tmp_path, caplog):
+    p = tmp_path / "broken.yaml"
+    p.write_text(":::not valid yaml:::\n- [unbalanced\n")
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="src.web.config_editor"):
+        result = _load_raw_yaml(str(p))
+    assert result == {}
+    assert any("Could not load" in rec.message for rec in caplog.records)
+
+
+def test_apply_to_raw_silently_drops_unknown_fields():
+    out = _apply_to_raw({}, {"nonexistent.field": 42, "title": "Kept"})
+    assert out == {"title": "Kept"}
+
+
+def test_apply_to_raw_theme_schedule_non_list_resets_to_empty():
+    out = _apply_to_raw({"theme_schedule": [1, 2, 3]}, {"theme_schedule": "not a list"})
+    assert out["theme_schedule"] == []
+
+
+def test_apply_to_raw_rebuilds_nested_dict_when_leaf_is_scalar():
+    """If an existing value at a non-leaf path is not a dict, it must be replaced."""
+    raw = {"display": "broken-scalar"}
+    out = _apply_to_raw(raw, {"display.show_weather": True})
+    assert out["display"] == {"show_weather": True}
+
+
+def test_apply_patch_rejects_invalid_theme_schedule_time(tmp_path):
+    """theme_schedule entries with a malformed time are a hard validation error."""
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: T\n")
+    saved, errors, _warnings = apply_patch(
+        str(cfg_path),
+        {"theme_schedule": [{"time": "not-a-time", "theme": "default"}]},
+    )
+    assert saved is False
+    assert errors
+    assert any("Invalid time" in e["message"] for e in errors)
+    # File must NOT have changed on validation failure.
+    assert yaml.safe_load(cfg_path.read_text()) == {"title": "T"}
+
+
+def test_apply_patch_warnings_do_not_block_save(tmp_path):
+    """Unknown theme names are warnings — save should proceed and persist."""
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: T\n")
+    saved, errors, warnings = apply_patch(str(cfg_path), {"theme": "not-a-real-theme"})
+    assert saved is True
+    assert errors == []
+    assert warnings  # warning emitted
+    assert yaml.safe_load(cfg_path.read_text())["theme"] == "not-a-real-theme"
+
+
+def test_write_raw_yaml_creates_backup_timestamp_on_repeat_save(tmp_path):
+    """A second save with an existing .bak should rotate it to a timestamped file."""
+    from src.web.config_editor import _write_raw_yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: Original\n")
+
+    # First save: creates .bak from the original.
+    _write_raw_yaml(str(cfg_path), {"title": "First"})
+    bak = cfg_path.with_suffix(".yaml.bak")
+    assert bak.exists()
+    assert yaml.safe_load(bak.read_text())["title"] == "Original"
+
+    # Second save: previous .bak must be rotated to a timestamped copy.
+    _write_raw_yaml(str(cfg_path), {"title": "Second"})
+    timestamped = list(tmp_path.glob("config.yaml.bak.*"))
+    assert len(timestamped) == 1
+    assert yaml.safe_load(timestamped[0].read_text())["title"] == "Original"
+    # Fresh .bak reflects the first-saved content.
+    assert yaml.safe_load(bak.read_text())["title"] == "First"
+
+
+def test_write_raw_yaml_cleans_up_tempfile_on_yaml_dump_failure(tmp_path):
+    """If yaml.dump raises during the atomic write, the .tmp file must be removed."""
+    from src.web.config_editor import _write_raw_yaml
+
+    cfg_path = tmp_path / "config.yaml"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("yaml exploded")
+
+    with patch("src.web.config_editor.yaml.dump", side_effect=_boom):
+        with pytest.raises(RuntimeError):
+            _write_raw_yaml(str(cfg_path), {"title": "X"})
+
+    # No stale .tmp files left behind, target file not created.
+    assert not any(p.suffix == ".tmp" for p in tmp_path.iterdir())
+    assert not cfg_path.exists()
+
+
+def test_write_raw_yaml_backup_io_error_is_non_fatal(tmp_path, caplog):
+    """A failing backup step should log a warning but allow the save to proceed."""
+    import logging as _logging
+
+    from src.web.config_editor import _write_raw_yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: Original\n")
+
+    # Force Path.read_bytes (the backup copy step) to raise — the save must still
+    # succeed after logging a warning.
+    with caplog.at_level(_logging.WARNING, logger="src.web.config_editor"):
+        with patch(
+            "src.web.config_editor.Path.read_bytes",
+            side_effect=OSError("cannot read source for backup"),
+        ):
+            _write_raw_yaml(str(cfg_path), {"title": "After"})
+
+    # The target file was still updated despite the backup failure.
+    assert yaml.safe_load(cfg_path.read_text())["title"] == "After"
+    assert any("Could not write config backup" in rec.message for rec in caplog.records)
+
+
+def test_restore_latest_backup_no_backup_returns_false(tmp_path):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: T\n")
+    ok, msg = restore_latest_backup(str(cfg_path))
+    assert ok is False
+    assert "No backup" in msg
+
+
+def test_restore_latest_backup_rejects_invalid_backup(tmp_path):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("title: Original\n")
+    bak = cfg_path.with_suffix(".yaml.bak")
+    # A bad quantization_mode is a hard validation error (not just a warning).
+    bak.write_text("display:\n  quantization_mode: bogus-mode\n")
+
+    ok, msg = restore_latest_backup(str(cfg_path))
+    assert ok is False
+    assert "failed validation" in msg
+    # Original config must remain untouched.
+    assert yaml.safe_load(cfg_path.read_text())["title"] == "Original"
+
+
+def test_list_config_backups_missing_parent_returns_empty(tmp_path):
+    assert list_config_backups(str(tmp_path / "nope" / "config.yaml")) == []

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -1,6 +1,7 @@
 """Tests for the P2 config editor — config_editor.py and /api/config routes."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,6 +14,7 @@ from src.web.config_editor import (
     EDITABLE_FIELD_PATHS,
     _apply_to_raw,
     _load_raw_yaml,
+    _write_raw_yaml,
     apply_patch,
     get_config_for_web,
     list_config_backups,
@@ -517,9 +519,8 @@ def test_load_raw_yaml_returns_empty_for_empty_file(tmp_path):
 def test_load_raw_yaml_swallows_parse_error(tmp_path, caplog):
     p = tmp_path / "broken.yaml"
     p.write_text(":::not valid yaml:::\n- [unbalanced\n")
-    import logging as _logging
 
-    with caplog.at_level(_logging.WARNING, logger="src.web.config_editor"):
+    with caplog.at_level(logging.WARNING, logger="src.web.config_editor"):
         result = _load_raw_yaml(str(p))
     assert result == {}
     assert any("Could not load" in rec.message for rec in caplog.records)
@@ -570,8 +571,6 @@ def test_apply_patch_warnings_do_not_block_save(tmp_path):
 
 def test_write_raw_yaml_creates_backup_timestamp_on_repeat_save(tmp_path):
     """A second save with an existing .bak should rotate it to a timestamped file."""
-    from src.web.config_editor import _write_raw_yaml
-
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text("title: Original\n")
 
@@ -592,8 +591,6 @@ def test_write_raw_yaml_creates_backup_timestamp_on_repeat_save(tmp_path):
 
 def test_write_raw_yaml_cleans_up_tempfile_on_yaml_dump_failure(tmp_path):
     """If yaml.dump raises during the atomic write, the .tmp file must be removed."""
-    from src.web.config_editor import _write_raw_yaml
-
     cfg_path = tmp_path / "config.yaml"
 
     def _boom(*args, **kwargs):
@@ -610,16 +607,12 @@ def test_write_raw_yaml_cleans_up_tempfile_on_yaml_dump_failure(tmp_path):
 
 def test_write_raw_yaml_backup_io_error_is_non_fatal(tmp_path, caplog):
     """A failing backup step should log a warning but allow the save to proceed."""
-    import logging as _logging
-
-    from src.web.config_editor import _write_raw_yaml
-
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text("title: Original\n")
 
     # Force Path.read_bytes (the backup copy step) to raise — the save must still
     # succeed after logging a warning.
-    with caplog.at_level(_logging.WARNING, logger="src.web.config_editor"):
+    with caplog.at_level(logging.WARNING, logger="src.web.config_editor"):
         with patch(
             "src.web.config_editor.Path.read_bytes",
             side_effect=OSError("cannot read source for backup"),

--- a/tests/test_web_status_logic.py
+++ b/tests/test_web_status_logic.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from src.config import ThemeScheduleConfig, ThemeScheduleEntry
 from src.web.routes.status import (
     _describe_theme_mode,
     _overall_health,
@@ -143,6 +144,7 @@ def test_overall_health_warn_source_does_not_replace_bad_status():
 
 
 def test_overall_health_caps_issues_at_four():
+    # Matches the issues[:4] slice in src/web/routes/status.py — update both together.
     sources = {
         f"src_{i}": _bad_source() for i in range(6)
     }
@@ -156,8 +158,8 @@ def test_overall_health_caps_issues_at_four():
 
 
 def _cfg(theme="default", entries=()):
-    schedule = SimpleNamespace(
-        entries=[SimpleNamespace(time=t, theme=th) for t, th in entries]
+    schedule = ThemeScheduleConfig(
+        entries=[ThemeScheduleEntry(time=t, theme=th) for t, th in entries]
     )
     return SimpleNamespace(theme=theme, theme_schedule=schedule)
 

--- a/tests/test_web_status_logic.py
+++ b/tests/test_web_status_logic.py
@@ -1,0 +1,201 @@
+"""Unit tests for the status-route decision table.
+
+Exercises the pure helpers in ``src.web.routes.status`` directly so we can cover
+every branch of the severity / title matrix without standing up a full app.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from src.web.routes.status import (
+    _describe_theme_mode,
+    _overall_health,
+    _source_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# _source_summary — each staleness / breaker combination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source_state, expected_severity, expected_status",
+    [
+        ({"breaker_state": "open", "staleness": "fresh"}, "bad", "needs_attention"),
+        ({"breaker_state": "closed", "staleness": "expired"}, "bad", "degraded"),
+        ({"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0}, "warn", "degraded"),
+        ({"breaker_state": "closed", "staleness": "stale"}, "warn", "degraded"),  # no age → fallback
+        ({"breaker_state": "closed", "staleness": "aging", "cache_age_minutes": 30.0}, "warn", "ok"),
+        ({"breaker_state": "closed", "staleness": "aging"}, "warn", "ok"),
+        ({"breaker_state": "closed", "staleness": "unknown"}, "warn", "unknown"),
+        ({"breaker_state": "closed", "staleness": "fresh", "cache_age_minutes": 5.0}, "ok", "ok"),
+        ({"breaker_state": "closed", "staleness": "fresh"}, "ok", "ok"),
+    ],
+)
+def test_source_summary_matrix(source_state, expected_severity, expected_status):
+    result = _source_summary("weather", source_state)
+    assert result["severity"] == expected_severity
+    assert result["status"] == expected_status
+
+
+def test_source_summary_stale_uses_age_in_detail():
+    s = _source_summary("events", {"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0})
+    assert "90" in s["detail"]
+
+
+def test_source_summary_stale_without_age_has_unavailable_detail():
+    s = _source_summary("events", {"breaker_state": "closed", "staleness": "stale"})
+    assert "unavailable" in s["detail"]
+
+
+# ---------------------------------------------------------------------------
+# _overall_health — each branch of the status transitions
+# ---------------------------------------------------------------------------
+
+
+def _healthy_source():
+    return {"breaker_state": "closed", "staleness": "fresh", "cache_age_minutes": 5}
+
+
+def _bad_source():
+    return {"breaker_state": "open", "staleness": "fresh"}
+
+
+def _warn_source():
+    return {"breaker_state": "closed", "staleness": "aging", "cache_age_minutes": 30}
+
+
+def test_overall_health_all_healthy():
+    sources = {"weather": _healthy_source(), "events": _healthy_source()}
+    result = _overall_health(30, False, sources)
+    assert result["status"] == "healthy"
+    assert result["severity"] == "ok"
+    assert result["issues"] == []
+
+
+def test_overall_health_quiet_hours_flags_paused():
+    sources = {"weather": _healthy_source()}
+    result = _overall_health(30, True, sources)
+    assert result["status"] == "paused"
+    assert result["severity"] == "warn"
+    assert "Quiet hours" in result["title"]
+
+
+def test_overall_health_no_last_run_seconds_is_degraded():
+    sources = {"weather": _healthy_source()}
+    result = _overall_health(None, False, sources)
+    assert result["status"] == "degraded"
+    assert any(iss["kind"] == "last_run" for iss in result["issues"])
+
+
+def test_overall_health_stale_last_run_not_during_quiet_hours():
+    sources = {"weather": _healthy_source()}
+    result = _overall_health(10_000, False, sources)
+    assert result["status"] == "degraded"
+    assert any("2 hours" in iss["message"] for iss in result["issues"])
+
+
+def test_overall_health_stale_last_run_suppressed_during_quiet_hours():
+    """When quiet hours are active, a stale last-run should NOT trigger a degraded
+    status (the paused status persists instead)."""
+    sources = {"weather": _healthy_source()}
+    result = _overall_health(10_000, True, sources)
+    assert result["status"] == "paused"
+    assert result["severity"] == "warn"
+
+
+def test_overall_health_bad_source_escalates_to_needs_attention():
+    sources = {"weather": _bad_source(), "events": _healthy_source()}
+    result = _overall_health(30, False, sources)
+    assert result["status"] == "needs_attention"
+    assert result["severity"] == "bad"
+    assert any(iss["kind"] == "weather" and iss["severity"] == "bad" for iss in result["issues"])
+
+
+def test_overall_health_bad_source_does_not_override_paused():
+    sources = {"weather": _bad_source()}
+    result = _overall_health(30, True, sources)
+    assert result["status"] == "paused"  # paused wins over needs_attention
+    # But the issue still gets appended.
+    assert any(iss["severity"] == "bad" for iss in result["issues"])
+
+
+def test_overall_health_warn_source_downgrades_healthy_to_degraded():
+    sources = {"weather": _warn_source()}
+    result = _overall_health(30, False, sources)
+    assert result["status"] == "degraded"
+    assert result["severity"] == "warn"
+
+
+def test_overall_health_warn_source_does_not_replace_bad_status():
+    sources = {"weather": _bad_source(), "events": _warn_source()}
+    result = _overall_health(30, False, sources)
+    assert result["status"] == "needs_attention"
+    # Both issues are surfaced.
+    kinds = {iss["kind"] for iss in result["issues"]}
+    assert "weather" in kinds
+    assert "events" in kinds
+
+
+def test_overall_health_caps_issues_at_four():
+    sources = {
+        f"src_{i}": _bad_source() for i in range(6)
+    }
+    result = _overall_health(30, False, sources)
+    assert len(result["issues"]) == 4
+
+
+# ---------------------------------------------------------------------------
+# _describe_theme_mode — next-entry wraparound and mode classification
+# ---------------------------------------------------------------------------
+
+
+def _cfg(theme="default", entries=()):
+    schedule = SimpleNamespace(
+        entries=[SimpleNamespace(time=t, theme=th) for t, th in entries]
+    )
+    return SimpleNamespace(theme=theme, theme_schedule=schedule)
+
+
+def test_describe_theme_mode_fixed():
+    cfg = _cfg(theme="terminal")
+    info = _describe_theme_mode(cfg, "terminal", datetime(2026, 4, 20, 12, 0))
+    assert info["mode"] == "fixed"
+    assert info["next_scheduled_change"] is None
+    assert info["schedule_count"] == 0
+
+
+@pytest.mark.parametrize("theme_name", ["random", "random_daily", "random_hourly"])
+def test_describe_theme_mode_randomized(theme_name):
+    cfg = _cfg(theme=theme_name)
+    info = _describe_theme_mode(cfg, "terminal", datetime(2026, 4, 20, 12, 0))
+    assert info["mode"] == "randomized"
+
+
+def test_describe_theme_mode_scheduled_picks_next_entry_later_today():
+    cfg = _cfg(theme="default", entries=[("08:00", "terminal"), ("18:00", "fantasy")])
+    info = _describe_theme_mode(cfg, "terminal", datetime(2026, 4, 20, 12, 0))
+    assert info["mode"] == "scheduled"
+    assert info["next_scheduled_change"] == {"time": "18:00", "theme": "fantasy"}
+
+
+def test_describe_theme_mode_scheduled_wraps_to_first_entry():
+    """After the last scheduled entry for the day, next should wrap to the earliest."""
+    cfg = _cfg(theme="default", entries=[("08:00", "terminal"), ("18:00", "fantasy")])
+    info = _describe_theme_mode(cfg, "fantasy", datetime(2026, 4, 20, 23, 30))
+    assert info["mode"] == "scheduled"
+    assert info["next_scheduled_change"] == {"time": "08:00", "theme": "terminal"}
+
+
+def test_describe_theme_mode_scheduled_before_first_entry_uses_first_entry():
+    """If all entries are in the future, next should be the earliest."""
+    cfg = _cfg(theme="default", entries=[("08:00", "terminal"), ("18:00", "fantasy")])
+    info = _describe_theme_mode(cfg, "default", datetime(2026, 4, 20, 3, 0))
+    assert info["mode"] == "scheduled"
+    assert info["next_scheduled_change"] == {"time": "08:00", "theme": "terminal"}
+    assert info["schedule_count"] == 2

--- a/tests/test_web_status_logic.py
+++ b/tests/test_web_status_logic.py
@@ -18,7 +18,6 @@ from src.web.routes.status import (
     _source_summary,
 )
 
-
 # ---------------------------------------------------------------------------
 # _source_summary — each staleness / breaker combination
 # ---------------------------------------------------------------------------
@@ -29,9 +28,21 @@ from src.web.routes.status import (
     [
         ({"breaker_state": "open", "staleness": "fresh"}, "bad", "needs_attention"),
         ({"breaker_state": "closed", "staleness": "expired"}, "bad", "degraded"),
-        ({"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0}, "warn", "degraded"),
-        ({"breaker_state": "closed", "staleness": "stale"}, "warn", "degraded"),  # no age → fallback
-        ({"breaker_state": "closed", "staleness": "aging", "cache_age_minutes": 30.0}, "warn", "ok"),
+        (
+            {"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0},
+            "warn",
+            "degraded",
+        ),
+        (
+            {"breaker_state": "closed", "staleness": "stale"},
+            "warn",
+            "degraded",
+        ),  # no age → fallback
+        (
+            {"breaker_state": "closed", "staleness": "aging", "cache_age_minutes": 30.0},
+            "warn",
+            "ok",
+        ),
         ({"breaker_state": "closed", "staleness": "aging"}, "warn", "ok"),
         ({"breaker_state": "closed", "staleness": "unknown"}, "warn", "unknown"),
         ({"breaker_state": "closed", "staleness": "fresh", "cache_age_minutes": 5.0}, "ok", "ok"),
@@ -45,7 +56,9 @@ def test_source_summary_matrix(source_state, expected_severity, expected_status)
 
 
 def test_source_summary_stale_uses_age_in_detail():
-    s = _source_summary("events", {"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0})
+    s = _source_summary(
+        "events", {"breaker_state": "closed", "staleness": "stale", "cache_age_minutes": 90.0}
+    )
     assert "90" in s["detail"]
 
 
@@ -145,9 +158,7 @@ def test_overall_health_warn_source_does_not_replace_bad_status():
 
 def test_overall_health_caps_issues_at_four():
     # Matches the issues[:4] slice in src/web/routes/status.py — update both together.
-    sources = {
-        f"src_{i}": _bad_source() for i in range(6)
-    }
+    sources = {f"src_{i}": _bad_source() for i in range(6)}
     result = _overall_health(30, False, sources)
     assert len(result["issues"]) == 4
 


### PR DESCRIPTION
Adds targeted tests for the lowest-coverage modules:
- web/auth.py: new test_web_auth.py covering scrypt hashing, middleware
  branches, and the --set-password CLI (17 tests)
- web/routes/actions.py: 500-error paths for trigger/reset/clear endpoints
- web/routes/status.py: new test_web_status_logic.py unit tests for
  _source_summary, _overall_health, _describe_theme_mode (28 tests)
- web/config_editor.py: malformed YAML, tempfile cleanup, backup rotation,
  invalid patch rejection, warnings-do-not-block-save
- render/quantize.py: pure-Python fallback paths (numpy-absent)
- render/components/weather_panel.py: AQI column and accent thresholds
- render/themes/photo.py: Bayer fallback and load-failure branch
- fetchers/purpleair.py: sensor payload edge shapes
- fetchers/calendar_ical.py: DURATION, datetime DTEND, floating-time,
  X-WR-CALNAME fallback, unrecognised DTSTART type
- fetchers/cache.py: load_cached_source_with_metadata branch coverage

Overall coverage improves from 98% to 99%.

https://claude.ai/code/session_01JPP72gCk5kKQmdHd9kQn8h