### PR TITLE
Freeze clock in quiet-hours integration test

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -608,6 +608,13 @@ class TestRunIntegration:
             patch("src.app.DataPipeline") as mock_pipeline_cls,
             patch("src.app.render_dashboard") as mock_render,
             patch.object(app.output, "publish") as mock_publish,
+            # Freeze "now" at 10:00 so we fall squarely inside the [00:00, 23:00)
+            # quiet window regardless of wall-clock time on the CI host.
+            patch(
+                "src.app.datetime",
+                wraps=datetime,
+                **{"now.return_value": datetime(2026, 4, 22, 10, 0, tzinfo=app.tz)},
+            ),
         ):
             app.run()
 


### PR DESCRIPTION
The test configured quiet_hours_start=0, quiet_hours_end=23, producing
a [00:00, 23:00) quiet window. Between 23:00 and 23:59 local time, the
real datetime.now() would fall outside the window and DashboardApp.run()
would proceed — triggering DataPipeline and violating the assert_not_called
expectations.

Patch src.app.datetime.now to return a fixed 10:00 timestamp (same pattern
already used by test_theme_schedule_overrides_configured_theme) so the
test is deterministic regardless of wall-clock time on the CI host.

https://claude.ai/code/session_0119aVYW5rumQuQPhHYKBxJd