### PR TITLE
Enable Dependabot monitoring for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds a pip ecosystem entry alongside the existing github-actions one.
Monthly cadence with minor/patch updates grouped into a single PR to
keep noise low for a personal project; major bumps still open
individual PRs so breaking changes get reviewed on their own.

https://claude.ai/code/session_016G7UjNyPHH8b49rSk8zCJL