### PR TITLE
Add main branch ruleset for import via GitHub UI

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,47 @@
+{
+  "name": "main branch protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "test (3.9)" },
+          { "context": "test (3.11)" },
+          { "context": "test (3.12)" },
+          { "context": "typecheck" },
+          { "context": "smoke" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Defines deletion + force-push protection, PR requirement, and
required CI status checks (lint, test 3.9/3.11/3.12, typecheck,
smoke). Import via Settings -> Rules -> Rulesets -> Import.