### PR TITLE
Preserve cached birthdays when fetcher fails (#146)

### DIFF
--- a/src/fetchers/calendar.py
+++ b/src/fetchers/calendar.py
@@ -213,6 +213,9 @@ def _birthdays_from_calendar(
     time_min = datetime.combine(today, datetime.min.time()).astimezone(timezone.utc)
     time_max = time_min + timedelta(days=birthday_cfg.lookahead_days)
 
+    # API errors (DNS/auth/network/HTTP) propagate so the data pipeline can fall
+    # back to the previously-cached birthday list rather than overwriting it with
+    # an empty list that blanks the birthday panel (issue #146).
     try:
         result = (
             service.events()
@@ -229,7 +232,7 @@ def _birthdays_from_calendar(
         )
     except Exception as exc:
         logger.warning("Failed to fetch birthday events: %s", exc)
-        return []
+        raise
 
     birthdays: list[Birthday] = []
     for item in result.get("items", []):
@@ -270,11 +273,16 @@ def _birthdays_from_contacts(
         if page_token:
             kwargs["pageToken"] = page_token
 
+        # Propagate on failure instead of ``break``-ing: breaking would silently
+        # commit a partial (or empty, on the first page) list to the cache via
+        # _resolve_source. Raising lets the pipeline fall back to the previously
+        # cached birthday list so the panel keeps rendering last-known-good data
+        # (issue #146).
         try:
             result = service.people().connections().list(**kwargs).execute()
         except Exception as exc:
             logger.warning("Failed to fetch Google Contacts: %s", exc)
-            break
+            raise
 
         for person in result.get("connections", []):
             bday = _parse_contact_birthday(person, today, lookahead)

--- a/tests/test_calendar_fetcher.py
+++ b/tests/test_calendar_fetcher.py
@@ -346,16 +346,43 @@ class TestFetchBirthdaysFromContacts:
         assert results[0].name == "Alice"
 
     @patch("src.fetchers.calendar._build_people_service")
-    def test_api_failure_returns_empty(self, mock_build):
+    def test_api_failure_propagates(self, mock_build):
+        """Regression for issue #146: an API failure must propagate so the
+        pipeline falls back to cached birthdays instead of overwriting the
+        cache with an empty (or, mid-pagination, partial) list."""
         mock_service = MagicMock()
         mock_build.return_value = mock_service
         mock_service.people().connections().list().execute.side_effect = Exception("API error")
 
         cfg_google = GoogleConfig(contacts_email="user@example.com")
         cfg_bday = BirthdayConfig(source="contacts", lookahead_days=30)
-        results = fetch_birthdays(cfg_google, cfg_bday)
+        with pytest.raises(Exception, match="API error"):
+            fetch_birthdays(cfg_google, cfg_bday)
 
-        assert results == []
+    @patch("src.fetchers.calendar._build_people_service")
+    def test_partial_pagination_failure_propagates(self, mock_build):
+        """Regression for issue #146: when a later pagination page fails, the
+        earlier pages' contacts must NOT be silently committed to cache via
+        ``break`` — propagate instead so the pipeline preserves the previous
+        complete list."""
+        today = date.today()
+        upcoming = today + timedelta(days=5)
+
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+        page1 = {
+            "connections": [self._person("Alice", upcoming.month, upcoming.day)],
+            "nextPageToken": "token123",
+        }
+        mock_service.people().connections().list().execute.side_effect = [
+            page1,
+            Exception("network timeout on page 2"),
+        ]
+
+        cfg_google = GoogleConfig(contacts_email="user@example.com")
+        cfg_bday = BirthdayConfig(source="contacts", lookahead_days=30)
+        with pytest.raises(Exception, match="network timeout on page 2"):
+            fetch_birthdays(cfg_google, cfg_bday)
 
     @patch("src.fetchers.calendar._build_people_service")
     def test_pagination(self, mock_build):
@@ -786,15 +813,18 @@ class TestBirthdaysFromCalendar:
         assert results[0].name == "Alice"
 
     @patch("src.fetchers.calendar._build_service")
-    def test_api_failure_returns_empty(self, mock_build):
+    def test_api_failure_propagates(self, mock_build):
+        """Regression for issue #146: an API failure must propagate so the
+        pipeline falls back to cached birthdays instead of overwriting the
+        cache with an empty list that blanks the birthday panel."""
         mock_service = MagicMock()
         mock_build.return_value = mock_service
         mock_service.events().list().execute.side_effect = Exception("API down")
 
         cfg_google = GoogleConfig()
         cfg_bday = BirthdayConfig(source="calendar", lookahead_days=30)
-        results = fetch_birthdays(cfg_google, cfg_bday)
-        assert results == []
+        with pytest.raises(Exception, match="API down"):
+            fetch_birthdays(cfg_google, cfg_bday)
 
     @patch("src.fetchers.calendar._build_service")
     def test_skips_non_matching_events(self, mock_build):

--- a/tests/test_data_pipeline_e2e.py
+++ b/tests/test_data_pipeline_e2e.py
@@ -155,6 +155,45 @@ class TestDataPipelineE2E:
         assert "events" in data.stale_sources
         assert data.source_staleness.get("events") != StalenessLevel.EXPIRED
 
+    def test_birthday_network_failure_preserves_cache(self, tmp_path):
+        """Regression for issue #146: when the birthday fetch raises
+        (e.g. DNS/auth/network failure in the calendar or contacts path),
+        previously-cached birthdays must be returned — NOT overwritten with
+        an empty list that blanks the birthday panel on the dashboard."""
+        events = _make_events()
+        weather = _make_weather()
+        birthdays = _make_birthdays()
+
+        # First run populates the cache with a known birthday list.
+        pipeline1 = _make_pipeline(tmp_path, force_refresh=True)
+        with (
+            patch("src.data_pipeline.fetch_events", return_value=events),
+            patch("src.data_pipeline.fetch_weather", return_value=weather),
+            patch("src.data_pipeline.fetch_birthdays", return_value=birthdays),
+            patch("src.data_pipeline.fetch_host_data", return_value=None),
+        ):
+            pipeline1.fetch()
+
+        # Second run: birthday fetch raises a DNS-style error.
+        pipeline2 = _make_pipeline(tmp_path, force_refresh=True)
+        with (
+            patch("src.data_pipeline.fetch_events", return_value=events),
+            patch("src.data_pipeline.fetch_weather", return_value=weather),
+            patch(
+                "src.data_pipeline.fetch_birthdays",
+                side_effect=OSError("Unable to find the server at oauth2.googleapis.com"),
+            ),
+            patch("src.data_pipeline.fetch_host_data", return_value=None),
+        ):
+            data = pipeline2.fetch()
+
+        # Cached birthdays preserved, not clobbered with [].
+        assert len(data.birthdays) == 1
+        assert data.birthdays[0].name == "Alice"
+        assert data.is_stale
+        assert "birthdays" in data.stale_sources
+        assert data.source_staleness.get("birthdays") != StalenessLevel.EXPIRED
+
     def test_all_sources_fail_no_cache(self, tmp_path):
         """When all fetchers fail and no cache exists, returns empty data."""
         pipeline = _make_pipeline(tmp_path, force_refresh=True)


### PR DESCRIPTION
Follow-up to #145. The calendar-events fix in _fetch_full landed, but the
same swallow-and-return-empty pattern was still in both birthday fetch
paths:

  * _birthdays_from_calendar caught all exceptions and returned [].
  * _birthdays_from_contacts caught all exceptions inside the pagination
    loop and ``break``-ed, silently committing a partial (or first-page-
    empty) list.

Either way, DataPipeline._resolve_source treated the result as a
successful fetch, overwrote the on-disk birthdays cache with the empty
or partial list, and the next render blanked the birthday panel.

Both paths now propagate the exception so _resolve_source falls back to
the previously cached birthdays and marks the source stale, mirroring
the calendar-events contract from #145.

Tests:
  * Updated the two existing "API failure returns empty" unit tests to
    assert the exception now propagates.
  * Added a partial-pagination regression test covering the contacts
    path (first page succeeds, second page raises).
  * Added an e2e regression test in test_data_pipeline_e2e.py mirroring
    test_calendar_network_failure_preserves_cache — a DNS-style failure
    on the second run leaves the previously-cached birthday visible and
    flags "birthdays" in stale_sources.