### PR TITLE
Cover low-hanging defensive paths in tests

### DIFF
--- a/tests/test_astronomy_module.py
+++ b/tests/test_astronomy_module.py
@@ -133,21 +133,37 @@ class TestMeteorShowers:
         assert shower.name == "Quadrantids"
         assert days > 0
 
-    def test_next_shower_skips_invalid_peak_dates(self, monkeypatch):
+    def test_next_shower_skips_always_invalid_peak_dates(self, monkeypatch):
         """A shower with an impossible (month, day) — e.g. Feb 30 — is skipped.
 
-        Exercises both ValueError arms in ``next_meteor_shower``: the initial
-        ``date(year, ...)`` build and the year-rollover ``date(year + 1, ...)``
-        build.  Querying late in the year forces the rollover branch on the
-        invalid entry.
+        Exercises the first-arm ValueError path: ``date(year, peak_month, peak_day)``
+        raises immediately and the loop ``continue``s without reaching the rollover.
         """
         from src import astronomy
 
         bogus = astronomy.MeteorShower("Imaginarids", 2, 30, 999)
         monkeypatch.setattr(astronomy, "METEOR_SHOWERS", [bogus, *METEOR_SHOWERS])
 
-        # Late-year query: bogus shower's Feb-30 fails on the year-N attempt,
-        # then fails again on the year-(N+1) rollover — exercising both arms.
-        shower, days = astronomy.next_meteor_shower(date(2026, 12, 30))
-        assert shower.name == "Quadrantids"
-        assert days > 0
+        shower, days = astronomy.next_meteor_shower(date(2026, 4, 23))
+        # Bogus entry was skipped silently; real lookup still works.
+        assert shower.name == "Eta Aquariids"
+        assert days >= 0
+
+    def test_next_shower_handles_leap_day_rollover(self, monkeypatch):
+        """A Feb-29 shower in a leap year correctly skips the non-leap rollover.
+
+        Exercises the rollover-arm ValueError path: ``date(year, 2, 29)`` succeeds
+        in the current (leap) year, but its peak is in the past so the loop tries
+        ``date(year + 1, 2, 29)`` — which fails because year+1 is not a leap year.
+        """
+        from src import astronomy
+
+        leap_only = astronomy.MeteorShower("Leapids", 2, 29, 999)
+        monkeypatch.setattr(astronomy, "METEOR_SHOWERS", [leap_only, *METEOR_SHOWERS])
+
+        # 2024 is leap, 2025 is not. Today is past Feb 29 2024 so the year-N
+        # peak is in the past → triggers the year-(N+1) rollover, which fails.
+        shower, days = astronomy.next_meteor_shower(date(2024, 3, 15))
+        # Leapids was skipped on rollover; nearest real shower is Lyrids (Apr 22).
+        assert shower.name == "Lyrids"
+        assert days >= 0

--- a/tests/test_astronomy_module.py
+++ b/tests/test_astronomy_module.py
@@ -132,3 +132,22 @@ class TestMeteorShowers:
         shower, days = next_meteor_shower(date(2026, 12, 23))
         assert shower.name == "Quadrantids"
         assert days > 0
+
+    def test_next_shower_skips_invalid_peak_dates(self, monkeypatch):
+        """A shower with an impossible (month, day) — e.g. Feb 30 — is skipped.
+
+        Exercises both ValueError arms in ``next_meteor_shower``: the initial
+        ``date(year, ...)`` build and the year-rollover ``date(year + 1, ...)``
+        build.  Querying late in the year forces the rollover branch on the
+        invalid entry.
+        """
+        from src import astronomy
+
+        bogus = astronomy.MeteorShower("Imaginarids", 2, 30, 999)
+        monkeypatch.setattr(astronomy, "METEOR_SHOWERS", [bogus, *METEOR_SHOWERS])
+
+        # Late-year query: bogus shower's Feb-30 fails on the year-N attempt,
+        # then fails again on the year-(N+1) rollover — exercising both arms.
+        shower, days = astronomy.next_meteor_shower(date(2026, 12, 30))
+        assert shower.name == "Quadrantids"
+        assert days > 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -687,6 +687,30 @@ class TestAtomicWriteCleanup:
                     atomic_write_json(path, {"key": "value"})
             assert list(Path(tmpdir).glob("*.tmp")) == []
 
+    def test_unlink_oserror_during_cleanup_is_swallowed(self):
+        """If unlinking the temp file also fails, the original error still propagates.
+
+        Exercises the OSError-on-cleanup arm in atomic_write_json: the primary write
+        fails, then the cleanup unlink raises OSError too — the helper swallows the
+        cleanup failure and re-raises the original exception.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.json"
+
+            def patched_fdopen(fd, *args, **kwargs):
+                raise OSError("write failed")
+
+            def patched_unlink(*args, **kwargs):
+                raise OSError("unlink failed too")
+
+            with patch("os.fdopen", side_effect=patched_fdopen):
+                with patch("os.unlink", side_effect=patched_unlink):
+                    from src._io import atomic_write_json
+
+                    # Original write error propagates; the unlink OSError is swallowed.
+                    with pytest.raises(OSError, match="write failed"):
+                        atomic_write_json(path, {"key": "value"})
+
 
 class TestLoadCachedSourceAirQuality:
     """Cover the air_quality branch in load_cached_source (non-metadata variant)."""

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -4,7 +4,10 @@ from PIL import ImageFont
 
 from src.render.fonts import (
     bold,
+    cinzel_regular,
+    cinzel_semibold,
     medium,
+    nucore,
     regular,
     semibold,
     weather_icon,
@@ -28,6 +31,15 @@ class TestFontAccessors:
 
     def test_weather_icon(self):
         assert isinstance(weather_icon(20), ImageFont.FreeTypeFont)
+
+    def test_cinzel_regular(self):
+        assert isinstance(cinzel_regular(12), ImageFont.FreeTypeFont)
+
+    def test_cinzel_semibold(self):
+        assert isinstance(cinzel_semibold(12), ImageFont.FreeTypeFont)
+
+    def test_nucore(self):
+        assert isinstance(nucore(12), ImageFont.FreeTypeFont)
 
     def test_caching_returns_same_object(self):
         """@lru_cache should return the same object on repeated calls."""

--- a/tests/test_ical_edge_cases.py
+++ b/tests/test_ical_edge_cases.py
@@ -1,8 +1,11 @@
 """Edge-case tests for ICS feed fetching (src/fetchers/calendar_ical.py)."""
 
+import sys
 import zoneinfo
 from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.fetchers.calendar_ical import _parse_ical_event, _url_hostname, fetch_from_ical
 
@@ -448,3 +451,13 @@ class TestAdditionalCoverage:
         events = fetch_from_ical(["https://example.com/cal.ics"])  # no tz argument
         assert len(events) == 1
         assert events[0].summary == "Floating Event"
+
+
+class TestIcalendarMissing:
+    def test_fetch_from_ical_raises_when_icalendar_unavailable(self, monkeypatch):
+        """If the icalendar package can't be imported, raise a helpful RuntimeError."""
+        # Force the local `from icalendar import ...` to raise ImportError without
+        # affecting other tests that import the module at file scope.
+        monkeypatch.setitem(sys.modules, "icalendar", None)
+        with pytest.raises(RuntimeError, match="icalendar"):
+            fetch_from_ical(["https://example.com/cal.ics"])

--- a/tests/test_new_themes.py
+++ b/tests/test_new_themes.py
@@ -403,6 +403,29 @@ class TestYearPulsePanel:
         # Should not raise
         _build_countdowns(data, today)
 
+    def test_birthday_already_past_this_year_rolls_to_next(self):
+        """Birthday earlier in the year already passed → next_occ rolls to next year."""
+        from src.render.components.year_pulse_panel import _build_countdowns
+
+        today = date(2026, 4, 5)
+        # Birthday in January — already passed this year
+        bdays = [Birthday(name="Early", date=date(1990, 1, 15), age=35)]
+        data = DashboardData(events=[], birthdays=bdays)
+        # 120-day horizon doesn't reach next January, so the result is empty,
+        # but the year-rollover line still executes inside _build_countdowns.
+        result = _build_countdowns(data, today)
+        assert result == []
+
+    def test_renders_with_default_region(self):
+        """Calling draw_year_pulse with region=None falls back to a default region."""
+        from src.render.components.year_pulse_panel import draw_year_pulse
+
+        draw, img = self._make_draw()
+        # No region= kwarg → exercises the `if region is None` default path.
+        draw_year_pulse(draw, self._make_data(), date(2026, 4, 5))
+        pixels = list(img.tobytes())
+        assert not all(p == 255 for p in pixels), "Panel is blank"
+
 
 class TestMonthlyPanel:
     def test_month_grid_is_six_weeks(self):

--- a/tests/test_weather_fetcher.py
+++ b/tests/test_weather_fetcher.py
@@ -447,9 +447,7 @@ class TestSunriseSunset:
         assert len(result.forecast) == 1
 
     @patch("src.fetchers.weather.requests.Session")
-    def test_forecast_skips_day_when_midday_slot_has_empty_weather(
-        self, mock_session_cls, cfg
-    ):
+    def test_forecast_skips_day_when_midday_slot_has_empty_weather(self, mock_session_cls, cfg):
         """A day whose midday slot has an empty 'weather' list is dropped silently."""
         # Build slots for one future day where every slot has empty weather.
         from datetime import timedelta

--- a/tests/test_weather_fetcher.py
+++ b/tests/test_weather_fetcher.py
@@ -413,3 +413,73 @@ class TestSunriseSunset:
         result = fetch_weather(cfg)
         assert result.sunrise is None
         assert result.sunset is None
+
+    @patch("src.fetchers.weather.requests.Session")
+    def test_forecast_skips_day_when_all_slots_lack_main_key(self, mock_session_cls, cfg):
+        """Forecast days where every slot lacks the 'main' key are dropped silently."""
+        # Day +1 has only malformed slots (no "main" key); day +2 is healthy.
+        bad_slots = []
+        for hour in [6, 12, 18]:
+            base = datetime(2024, 3, 15, hour, 0, tzinfo=timezone.utc)
+            from datetime import timedelta
+
+            dt = base + timedelta(days=1)
+            bad_slots.append({"dt": int(dt.timestamp())})  # no "main", no "weather"
+        good_slots = [_make_slot(h, day_offset=2) for h in (6, 12, 18)]
+
+        current_resp = MagicMock()
+        current_resp.json.return_value = _mock_current_response()
+        current_resp.raise_for_status = MagicMock()
+        forecast_resp = MagicMock()
+        forecast_resp.json.return_value = {"list": bad_slots + good_slots}
+        forecast_resp.raise_for_status = MagicMock()
+        alerts_resp = MagicMock()
+        alerts_resp.json.return_value = {}
+        alerts_resp.raise_for_status = MagicMock()
+
+        session = MagicMock()
+        session.get.side_effect = [current_resp, forecast_resp, alerts_resp]
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = fetch_weather(cfg)
+        # The malformed day was skipped; only the healthy day made it through.
+        assert len(result.forecast) == 1
+
+    @patch("src.fetchers.weather.requests.Session")
+    def test_forecast_skips_day_when_midday_slot_has_empty_weather(
+        self, mock_session_cls, cfg
+    ):
+        """A day whose midday slot has an empty 'weather' list is dropped silently."""
+        # Build slots for one future day where every slot has empty weather.
+        from datetime import timedelta
+
+        slots = []
+        for hour in [6, 12, 18]:
+            base = datetime(2024, 3, 15, hour, 0, tzinfo=timezone.utc)
+            dt = base + timedelta(days=1)
+            slots.append(
+                {
+                    "dt": int(dt.timestamp()),
+                    "main": {"temp": 50.0, "temp_max": 55.0, "temp_min": 45.0},
+                    "weather": [],  # empty → forecast row is skipped
+                }
+            )
+
+        current_resp = MagicMock()
+        current_resp.json.return_value = _mock_current_response()
+        current_resp.raise_for_status = MagicMock()
+        forecast_resp = MagicMock()
+        forecast_resp.json.return_value = {"list": slots}
+        forecast_resp.raise_for_status = MagicMock()
+        alerts_resp = MagicMock()
+        alerts_resp.json.return_value = {}
+        alerts_resp.raise_for_status = MagicMock()
+
+        session = MagicMock()
+        session.get.side_effect = [current_resp, forecast_resp, alerts_resp]
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = fetch_weather(cfg)
+        assert result.forecast == []


### PR DESCRIPTION
Adds targeted tests for previously-uncovered defensive arms — font
wrappers (cinzel_regular/semibold, nucore), the meteor-shower year
rollover ValueError fallback, the ICS feed ImportError path when the
icalendar package is missing, OWM forecast slots without "main" or with
empty "weather" arrays, the year_pulse_panel default-region path and
year-rollover birthday case, and the atomic_write_json cleanup path
when both the write and the temp-file unlink fail.

Total coverage 98.00% → 98.17% (13 additional lines).