### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Home Dashboard
 
+[![CI](https://github.com/gkoch02/HomeDashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoch02/HomeDashboard/actions/workflows/ci.yml)
+
 Home Dashboard is a low-maintenance eInk wall display for family logistics on a Raspberry Pi. It shows calendar events, weather, birthdays, quotes, and optional diagnostics on supported Waveshare and Inky displays, with graceful fallback behavior for unattended use.
 
 ![Default theme preview](output/theme_default.png)


### PR DESCRIPTION
Adds a GitHub Actions CI badge that links to the workflow status, displaying at the top of the README.

https://claude.ai/code/session_01W88AyLL8bJwvL3XqotQNKz