### PR TITLE
tests: improve coverage from 97.3% to 99.0%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ ruff format src/ tests/                        # Format
 - **PyYAML** — config parsing
 - **numpy** — Inky palette quantization (`src/render/quantize.py` fast path) and Inky `show()`/`clear()` buffer assembly (`src/display/driver.py`); declared in core `dependencies`
 - **Flask 3 + Waitress** — optional web UI (`requirements-web.txt`; `pip install -e ".[web]"`)
-- **pytest** — testing (with unittest.mock); coverage via **pytest-cov** (target: ≥90%, currently ~97%); theme pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`
+- **pytest** — testing (with unittest.mock); coverage via **pytest-cov** (target: ≥90%, currently ~99%); theme pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`
 - **ruff** — linting and formatting (max line length: 100)
 - **AST-based custom guard** in `tools/check_naive_datetime.py` enforces aware-datetime discipline; CI runs it via `tests/test_naive_datetime_guard.py`
 

--- a/tests/test__time.py
+++ b/tests/test__time.py
@@ -1,0 +1,83 @@
+"""Unit tests for src._time — sanctioned aware-datetime helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, tzinfo
+import zoneinfo
+
+import pytest
+
+from src._time import assert_aware, now_local, now_utc, to_aware
+
+
+class TestNowUtc:
+    def test_returns_aware_datetime(self):
+        dt = now_utc()
+        assert dt.tzinfo is not None
+
+    def test_timezone_is_utc(self):
+        dt = now_utc()
+        assert dt.utcoffset().total_seconds() == 0
+
+
+class TestNowLocal:
+    def test_returns_aware_datetime_with_no_tz_arg(self):
+        dt = now_local()
+        assert dt.tzinfo is not None
+
+    def test_falls_back_to_utc_when_tz_is_none(self):
+        dt = now_local(None)
+        assert dt.utcoffset().total_seconds() == 0
+
+    def test_honours_explicit_timezone(self):
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        dt = now_local(ny)
+        assert dt.tzinfo is not None
+        assert dt.tzinfo is ny or str(dt.tzinfo) == "America/New_York"
+
+
+class TestToAware:
+    def test_naive_datetime_gets_utc_when_no_tz(self):
+        naive = datetime(2026, 5, 5, 12, 0)
+        result = to_aware(naive)
+        assert result.tzinfo is not None
+        assert result.utcoffset().total_seconds() == 0
+        assert result.replace(tzinfo=None) == naive
+
+    def test_naive_datetime_gets_supplied_tz(self):
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        naive = datetime(2026, 5, 5, 12, 0)
+        result = to_aware(naive, tz=ny)
+        assert result.tzinfo is not None
+        assert result.replace(tzinfo=None) == naive
+
+    def test_aware_datetime_passes_through_unchanged(self):
+        """Already-aware value must be returned as-is — no tz conversion."""
+        aware = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+        result = to_aware(aware)
+        assert result is aware
+
+    def test_aware_datetime_with_explicit_tz_still_passes_through(self):
+        """Even when tz is given, an already-aware value is never re-wrapped."""
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        aware = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+        result = to_aware(aware, tz=ny)
+        assert result is aware
+        assert result.tzinfo is timezone.utc
+
+
+class TestAssertAware:
+    def test_aware_datetime_returned_unchanged(self):
+        aware = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+        result = assert_aware(aware)
+        assert result is aware
+
+    def test_naive_datetime_raises_value_error(self):
+        naive = datetime(2026, 5, 5, 12, 0)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            assert_aware(naive)
+
+    def test_error_message_includes_custom_name(self):
+        naive = datetime(2026, 5, 5, 12, 0)
+        with pytest.raises(ValueError, match="fetched_at"):
+            assert_aware(naive, name="fetched_at")

--- a/tests/test__time.py
+++ b/tests/test__time.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone, tzinfo
 import zoneinfo
+from datetime import datetime, timezone
 
 import pytest
 

--- a/tests/test_calendar_caldav.py
+++ b/tests/test_calendar_caldav.py
@@ -513,7 +513,6 @@ class TestWalkVevents:
 class TestParseCalDAVEventExtended:
     def _vevent_with_duration(self, summary, start, duration_td):
         """Build a VEVENT mock using DURATION instead of DTEND."""
-        from datetime import timedelta
 
         class Prop:
             def __init__(self, dt):

--- a/tests/test_calendar_caldav.py
+++ b/tests/test_calendar_caldav.py
@@ -335,3 +335,350 @@ class TestDispatcherUsesCalDAV:
         mock_ical.assert_not_called()
         mock_google.assert_not_called()
         assert result == ["caldav-event"]
+
+
+# ---------------------------------------------------------------------------
+# _read_password — OSError branch
+# ---------------------------------------------------------------------------
+
+
+class TestReadPasswordOSError:
+    def test_oserror_on_read_raises_runtime_error(self, tmp_path):
+        """When the password file exists but cannot be read, raise RuntimeError."""
+        f = tmp_path / "pw.txt"
+        f.write_text("secret\n")
+        with patch("pathlib.Path.read_text", side_effect=OSError("permission denied")):
+            with pytest.raises(RuntimeError, match="Could not read"):
+                _read_password(str(f))
+
+
+# ---------------------------------------------------------------------------
+# fetch_from_caldav — calendar lookup failure & tz-aware today branch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFromCalDAVAdditional:
+    def test_calendar_lookup_failure_returns_empty(self, tmp_path, caplog):
+        """When principal.calendars() raises, return [] and log a warning."""
+        pw = tmp_path / "pw.txt"
+        pw.write_text("secret\n")
+
+        fake_client_cls = MagicMock()
+        fake_client = MagicMock()
+        fake_principal = MagicMock()
+        fake_principal.calendars.side_effect = RuntimeError("lookup failed")
+        fake_client.principal.return_value = fake_principal
+        fake_client_cls.return_value = fake_client
+        fake_module = MagicMock(DAVClient=fake_client_cls)
+
+        with patch.dict("sys.modules", {"caldav": fake_module}):
+            events = fetch_from_caldav(
+                url="https://example.com/dav/",
+                username="alice",
+                password_file=str(pw),
+            )
+
+        assert events == []
+        assert "calendar lookup failed" in caplog.text
+
+    def test_tz_arg_used_for_today_date(self, tmp_path):
+        """When tz is supplied, 'today' is computed in that timezone."""
+        import zoneinfo
+
+        pw = tmp_path / "pw.txt"
+        pw.write_text("secret\n")
+        cal = _make_calendar("Work", [])
+
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        with _patch_caldav([cal]):
+            fetch_from_caldav(
+                url="https://example.com/dav/",
+                username="alice",
+                password_file=str(pw),
+                tz=ny,
+            )
+
+        # If tz branch didn't run, the call would still succeed; we verify
+        # it ran without error and search was invoked.
+        cal.search.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _calendar_name — attribute-exception fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarName:
+    def test_returns_name_attribute(self):
+        from src.fetchers.calendar_caldav import _calendar_name
+
+        cal = MagicMock()
+        cal.name = "Work"
+        assert _calendar_name(cal) == "Work"
+
+    def test_callable_name_method_is_called(self):
+        """When cal.name is a callable (a method), it is invoked and its return used."""
+        from src.fetchers.calendar_caldav import _calendar_name
+
+        class CalWithMethod:
+            def name(self):
+                return "Work"
+
+        assert _calendar_name(CalWithMethod()) == "Work"
+
+    def test_callable_name_raises_falls_through_to_displayname(self):
+        """When cal.name() raises, the except continues to 'displayname'."""
+        from src.fetchers.calendar_caldav import _calendar_name
+
+        class CalWithRaisingName:
+            def name(self):
+                raise RuntimeError("unavailable")
+
+            displayname = "Fallback"
+
+        assert _calendar_name(CalWithRaisingName()) == "Fallback"
+
+    def test_returns_caldav_when_all_attributes_fail(self):
+        from src.fetchers.calendar_caldav import _calendar_name
+
+        class CalAllFail:
+            def name(self):
+                raise RuntimeError("boom")
+
+            def displayname(self):
+                raise RuntimeError("boom too")
+
+        assert _calendar_name(CalAllFail()) == "CalDAV"
+
+
+# ---------------------------------------------------------------------------
+# _walk_vevents — exception branches
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarNameNoneValue:
+    def test_none_name_falls_through_to_displayname(self):
+        """When getattr returns None for 'name', the loop continues to 'displayname'."""
+        from src.fetchers.calendar_caldav import _calendar_name
+
+        class CalNoneName:
+            name = None
+            displayname = "My Calendar"
+
+        assert _calendar_name(CalNoneName()) == "My Calendar"
+
+
+class TestWalkVevents:
+    def test_icalendar_instance_exception_yields_nothing(self):
+        from src.fetchers.calendar_caldav import _walk_vevents
+
+        entry = MagicMock()
+        type(entry).icalendar_instance = property(
+            lambda self: (_ for _ in ()).throw(Exception("parse error"))
+        )
+        assert list(_walk_vevents(entry)) == []
+
+    def test_component_walk_exception_yields_nothing(self):
+        from src.fetchers.calendar_caldav import _walk_vevents
+
+        ical = MagicMock()
+        ical.walk.side_effect = Exception("walk exploded")
+        entry = MagicMock()
+        entry.icalendar_instance = ical
+        assert list(_walk_vevents(entry)) == []
+
+    def test_non_vevent_components_are_skipped(self):
+        """Components that are not VEVENT (e.g. VCALENDAR) must be filtered out."""
+        from src.fetchers.calendar_caldav import _walk_vevents
+
+        vcal = MagicMock()
+        vcal.name = "VCALENDAR"
+        vevent = MagicMock()
+        vevent.name = "VEVENT"
+
+        ical = MagicMock()
+        ical.walk.return_value = [vcal, vevent]
+        entry = MagicMock()
+        entry.icalendar_instance = ical
+
+        results = list(_walk_vevents(entry))
+        assert results == [vevent]
+
+
+# ---------------------------------------------------------------------------
+# _parse_caldav_event — duration-based end times & all-day edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestParseCalDAVEventExtended:
+    def _vevent_with_duration(self, summary, start, duration_td):
+        """Build a VEVENT mock using DURATION instead of DTEND."""
+        from datetime import timedelta
+
+        class Prop:
+            def __init__(self, dt):
+                self.dt = dt
+
+        component = MagicMock()
+        component.name = "VEVENT"
+
+        def _get(key, default=None):
+            mapping = {
+                "SUMMARY": summary,
+                "DTSTART": Prop(start),
+                "DURATION": Prop(duration_td),
+                "UID": "dur-uid",
+            }
+            return mapping.get(key, default)
+
+        component.get.side_effect = _get
+        return component
+
+    def test_timed_event_duration_used_when_no_dtend(self):
+        """When DTEND is absent but DURATION is set, end = start + duration."""
+        from datetime import timedelta
+
+        v = self._vevent_with_duration(
+            "Long meeting", datetime(2026, 5, 5, 9, 0), timedelta(hours=2)
+        )
+        e = _parse_caldav_event(v, "Cal", tz=None)
+        assert e is not None
+        assert e.end == datetime(2026, 5, 5, 11, 0)
+
+    def test_all_day_event_dtend_is_datetime(self):
+        """All-day DTSTART (date) with a datetime DTEND should parse correctly."""
+
+        class Prop:
+            def __init__(self, dt):
+                self.dt = dt
+
+        component = MagicMock()
+        component.name = "VEVENT"
+
+        def _get(key, default=None):
+            return {
+                "SUMMARY": "Holiday",
+                "DTSTART": Prop(date(2026, 5, 5)),
+                # DTEND is a datetime rather than a date (non-standard but seen)
+                "DTEND": Prop(datetime(2026, 5, 6, 0, 0, tzinfo=timezone.utc)),
+                "UID": "allday-dt",
+            }.get(key, default)
+
+        component.get.side_effect = _get
+        e = _parse_caldav_event(component, "Cal", tz=None)
+        assert e is not None
+        assert e.is_all_day is True
+
+    def test_all_day_event_duration_used_when_no_dtend(self):
+        """All-day event without DTEND falls back to start + DURATION."""
+        from datetime import timedelta
+
+        v = self._vevent_with_duration("Multi-day", date(2026, 5, 5), timedelta(days=3))
+        e = _parse_caldav_event(v, "Cal", tz=None)
+        assert e is not None
+        assert e.is_all_day is True
+        assert e.end.date() == date(2026, 5, 8)
+
+    def test_general_exception_returns_none(self):
+        """A component that blows up during parsing returns None gracefully."""
+        component = MagicMock()
+        component.get.side_effect = Exception("unexpected crash")
+        assert _parse_caldav_event(component, "Cal", tz=None) is None
+
+    def test_timed_event_no_dtend_no_duration_defaults_to_one_hour(self):
+        """When neither DTEND nor DURATION is present, end defaults to start + 1 hour."""
+
+        class Prop:
+            def __init__(self, dt):
+                self.dt = dt
+
+        component = MagicMock()
+        component.name = "VEVENT"
+
+        def _get(key, default=None):
+            return {
+                "SUMMARY": "Quick call",
+                "DTSTART": Prop(datetime(2026, 5, 5, 10, 0)),
+                "UID": "no-end",
+            }.get(key, default)
+
+        component.get.side_effect = _get
+        e = _parse_caldav_event(component, "Cal", tz=None)
+        assert e is not None
+        assert e.end == datetime(2026, 5, 5, 11, 0)
+
+    def test_all_day_event_no_dtend_no_duration_defaults_to_one_day(self):
+        """All-day event with neither DTEND nor DURATION defaults to start + 1 day."""
+
+        class Prop:
+            def __init__(self, dt):
+                self.dt = dt
+
+        component = MagicMock()
+        component.name = "VEVENT"
+
+        def _get(key, default=None):
+            return {
+                "SUMMARY": "Holiday",
+                "DTSTART": Prop(date(2026, 5, 5)),
+                "UID": "all-day-noend",
+            }.get(key, default)
+
+        component.get.side_effect = _get
+        e = _parse_caldav_event(component, "Cal", tz=None)
+        assert e is not None
+        assert e.is_all_day is True
+        assert e.end.date() == date(2026, 5, 6)
+
+
+class TestFetchSkipsUnparsableVEvents:
+    def test_none_parse_result_is_skipped(self, tmp_path):
+        """When _parse_caldav_event returns None the entry is silently skipped."""
+        pw = tmp_path / "pw.txt"
+        pw.write_text("secret\n")
+
+        # Build an entry whose VEVENT has no DTSTART (returns None from parser)
+        class Prop:
+            def __init__(self, dt):
+                self.dt = dt
+
+        bad_vevent = MagicMock()
+        bad_vevent.name = "VEVENT"
+        bad_vevent.get.return_value = None  # every .get() returns None → no DTSTART
+
+        ical = MagicMock()
+        ical.walk.return_value = [bad_vevent]
+        bad_entry = MagicMock()
+        bad_entry.icalendar_instance = ical
+
+        good_vevent = MagicMock()
+        good_vevent.name = "VEVENT"
+
+        def _get_good(key, default=None):
+            return {
+                "SUMMARY": "Good event",
+                "DTSTART": Prop(datetime(2026, 5, 5, 9, 0)),
+                "DTEND": Prop(datetime(2026, 5, 5, 10, 0)),
+                "UID": "good-uid",
+            }.get(key, default)
+
+        good_vevent.get.side_effect = _get_good
+        good_ical = MagicMock()
+        good_ical.walk.return_value = [good_vevent]
+        good_entry = MagicMock()
+        good_entry.icalendar_instance = good_ical
+
+        cal = _make_calendar("Work", [bad_entry, good_entry])
+
+        with _patch_caldav([cal]):
+            events = fetch_from_caldav(
+                url="https://example.com/dav/",
+                username="alice",
+                password_file=str(pw),
+                days=7,
+                start_date=date(2026, 5, 4),
+            )
+
+        # The bad entry is skipped; the good one surfaces.
+        assert len(events) == 1
+        assert events[0].summary == "Good event"

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -108,3 +108,33 @@ class TestBackup:
     def test_write_pre_migration_backup_missing_source(self, tmp_path):
         cfg = tmp_path / "missing.yaml"
         assert write_pre_migration_backup(str(cfg), 4) is None
+
+    def test_write_pre_migration_backup_oserror_returns_none(self, tmp_path):
+        """When shutil.copy2 raises OSError, return None and log a warning."""
+        import shutil
+        from unittest.mock import patch
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("title: test\n")
+        with patch("shutil.copy2", side_effect=OSError("disk full")):
+            result = write_pre_migration_backup(str(cfg), 4)
+        assert result is None
+
+
+class TestMigrateInMemoryNoStep:
+    def test_no_registered_step_stamps_current_and_continues(self):
+        """When a config is at an unknown old version with no migration step
+        registered, migrate_in_memory must NOT loop — it stamps current and
+        returns safely."""
+        from src import config_migrations as cm
+
+        original = cm._MIGRATIONS
+        cm._MIGRATIONS = []  # empty — no step covers any version
+        try:
+            # Feed a dict at version 3 (no step covers 3 → 5)
+            out = cm.migrate_in_memory({"schema_version": 3, "title": "X"})
+        finally:
+            cm._MIGRATIONS = original
+
+        assert out["schema_version"] == cm.CURRENT_SCHEMA_VERSION
+        assert out["title"] == "X"

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -111,7 +111,6 @@ class TestBackup:
 
     def test_write_pre_migration_backup_oserror_returns_none(self, tmp_path):
         """When shutil.copy2 raises OSError, return None and log a warning."""
-        import shutil
         from unittest.mock import patch
 
         cfg = tmp_path / "config.yaml"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -478,9 +478,7 @@ class TestCountdownValidation:
         from src.config import CountdownConfig, CountdownEvent
 
         cfg = Config()
-        cfg.countdown = CountdownConfig(
-            events=[CountdownEvent(name=n, date=d) for n, d in events]
-        )
+        cfg.countdown = CountdownConfig(events=[CountdownEvent(name=n, date=d) for n, d in events])
         return cfg
 
     def test_valid_countdown_event_no_issues(self):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -316,3 +316,196 @@ class TestLoadConfigWarnsOnMissingFile:
         with caplog.at_level(logging.WARNING, logger="src.config"):
             load_config(str(tmp_path / "nonexistent.yaml"))
         assert "not found" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# CalDAV validation
+# ---------------------------------------------------------------------------
+
+
+class TestCalDAVValidation:
+    def test_caldav_bad_scheme_is_error(self):
+        cfg = Config(
+            google=GoogleConfig(
+                caldav_url="caldavs://example.com/dav/",
+                caldav_username="alice",
+                caldav_password_file="/some/file",
+            )
+        )
+        errors, _ = validate_config(cfg)
+        assert any(e.field == "google.caldav_url" for e in errors)
+
+    def test_caldav_missing_username_is_error(self):
+        cfg = Config(
+            google=GoogleConfig(
+                caldav_url="https://example.com/dav/",
+                caldav_username="",
+                caldav_password_file="/some/file",
+            )
+        )
+        errors, _ = validate_config(cfg)
+        assert any(e.field == "google.caldav_username" for e in errors)
+
+    def test_caldav_missing_password_file_is_error(self):
+        cfg = Config(
+            google=GoogleConfig(
+                caldav_url="https://example.com/dav/",
+                caldav_username="alice",
+                caldav_password_file="",
+            )
+        )
+        errors, _ = validate_config(cfg)
+        assert any(e.field == "google.caldav_password_file" for e in errors)
+
+    def test_caldav_password_file_not_on_disk_warns(self, tmp_path):
+        cfg = Config(
+            google=GoogleConfig(
+                caldav_url="https://example.com/dav/",
+                caldav_username="alice",
+                caldav_password_file=str(tmp_path / "missing_pw.txt"),
+            )
+        )
+        _, warnings = validate_config(cfg)
+        assert any(w.field == "google.caldav_password_file" for w in warnings)
+
+    def test_caldav_and_ical_both_set_warns(self, tmp_path):
+        pw = tmp_path / "pw.txt"
+        pw.write_text("secret\n")
+        cfg = Config(
+            google=GoogleConfig(
+                caldav_url="https://example.com/dav/",
+                caldav_username="alice",
+                caldav_password_file=str(pw),
+                ical_url="https://example.com/calendar.ics",
+            )
+        )
+        _, warnings = validate_config(cfg)
+        assert any(w.field == "google.caldav_url" for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# theme_rules validation
+# ---------------------------------------------------------------------------
+
+
+class TestThemeRulesValidation:
+    def _cfg_with_rule(self, theme, **when_kwargs):
+        from src.config import ThemeRule, ThemeRuleCondition, ThemeRulesConfig
+
+        cfg = Config()
+        cfg.theme_rules = ThemeRulesConfig(
+            rules=[ThemeRule(when=ThemeRuleCondition(**when_kwargs), theme=theme)]
+        )
+        return cfg
+
+    def test_unknown_theme_in_rule_warns(self):
+        cfg = self._cfg_with_rule("nonexistent_theme_xyz")
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[0].theme" in w.field for w in warnings)
+
+    def test_valid_theme_in_rule_no_warning(self):
+        cfg = self._cfg_with_rule("agenda")
+        _, warnings = validate_config(cfg)
+        assert not any("theme_rules" in w.field for w in warnings)
+
+    def test_invalid_daypart_warns(self):
+        cfg = self._cfg_with_rule("agenda", daypart="noon")
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[0].when.daypart" in w.field for w in warnings)
+
+    def test_valid_daypart_no_warning(self):
+        cfg = self._cfg_with_rule("agenda", daypart="morning")
+        _, warnings = validate_config(cfg)
+        assert not any("daypart" in w.field for w in warnings)
+
+    def test_daypart_list_with_one_bad_value_warns(self):
+        cfg = self._cfg_with_rule("agenda", daypart=["morning", "noon"])
+        _, warnings = validate_config(cfg)
+        assert any("daypart" in w.field for w in warnings)
+
+    def test_invalid_season_warns(self):
+        cfg = self._cfg_with_rule("agenda", season="monsoon")
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[0].when.season" in w.field for w in warnings)
+
+    def test_valid_season_no_warning(self):
+        cfg = self._cfg_with_rule("agenda", season="winter")
+        _, warnings = validate_config(cfg)
+        assert not any("season" in w.field for w in warnings)
+
+    def test_invalid_weekday_warns(self):
+        cfg = self._cfg_with_rule("agenda", weekday="funday")
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[0].when.weekday" in w.field for w in warnings)
+
+    def test_valid_weekday_no_warning(self):
+        cfg = self._cfg_with_rule("agenda", weekday="weekend")
+        _, warnings = validate_config(cfg)
+        assert not any("weekday" in w.field for w in warnings)
+
+    def test_invalid_calendar_state_warns(self):
+        cfg = self._cfg_with_rule("agenda", calendar="partying")
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[0].when.calendar" in w.field for w in warnings)
+
+    def test_valid_calendar_state_no_warning(self):
+        cfg = self._cfg_with_rule("agenda", calendar="active")
+        _, warnings = validate_config(cfg)
+        assert not any("when.calendar" in w.field for w in warnings)
+
+    def test_multiple_rules_indexed_correctly(self):
+        from src.config import ThemeRule, ThemeRuleCondition, ThemeRulesConfig
+
+        cfg = Config()
+        cfg.theme_rules = ThemeRulesConfig(
+            rules=[
+                ThemeRule(when=ThemeRuleCondition(daypart="morning"), theme="agenda"),
+                ThemeRule(when=ThemeRuleCondition(season="monsoon"), theme="agenda"),
+            ]
+        )
+        _, warnings = validate_config(cfg)
+        assert any("theme_rules[1].when.season" in w.field for w in warnings)
+        assert not any("theme_rules[0]" in w.field for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# countdown.events validation
+# ---------------------------------------------------------------------------
+
+
+class TestCountdownValidation:
+    def _cfg_with_countdown(self, *events):
+        from src.config import CountdownConfig, CountdownEvent
+
+        cfg = Config()
+        cfg.countdown = CountdownConfig(
+            events=[CountdownEvent(name=n, date=d) for n, d in events]
+        )
+        return cfg
+
+    def test_valid_countdown_event_no_issues(self):
+        cfg = self._cfg_with_countdown(("Trip", "2027-01-01"))
+        errors, warnings = validate_config(cfg)
+        assert not any("countdown" in e.field for e in errors)
+        assert not any("countdown" in w.field for w in warnings)
+
+    def test_missing_event_name_warns(self):
+        cfg = self._cfg_with_countdown(("", "2027-01-01"))
+        _, warnings = validate_config(cfg)
+        assert any("countdown.events[0].name" in w.field for w in warnings)
+
+    def test_malformed_date_is_error(self):
+        cfg = self._cfg_with_countdown(("Trip", "01-01-2027"))
+        errors, _ = validate_config(cfg)
+        assert any("countdown.events[0].date" in e.field for e in errors)
+
+    def test_completely_invalid_date_string_is_error(self):
+        cfg = self._cfg_with_countdown(("Trip", "not-a-date"))
+        errors, _ = validate_config(cfg)
+        assert any("countdown.events[0].date" in e.field for e in errors)
+
+    def test_multiple_events_indexed_correctly(self):
+        cfg = self._cfg_with_countdown(("Trip", "2027-01-01"), ("Party", "not-valid"))
+        errors, _ = validate_config(cfg)
+        assert any("countdown.events[1].date" in e.field for e in errors)
+        assert not any("countdown.events[0].date" in e.field for e in errors)

--- a/tests/test_services_output.py
+++ b/tests/test_services_output.py
@@ -549,3 +549,61 @@ class TestLegacyInkyMigration:
             json.dumps({"last_refresh_at": "totally-not-a-date"})
         )
         assert _load_last_refresh(str(tmp_path)) is None
+
+    def test_legacy_rename_oserror_still_returns_timestamp(self, tmp_path):
+        """When the atomic rename of the legacy file fails with OSError, the
+        parsed timestamp is still returned — the migration is best-effort."""
+        legacy = tmp_path / "inky_refresh_state.json"
+        legacy.write_text('{"last_refresh_at": "2026-04-08T11:30:00"}')
+
+        with patch("pathlib.Path.replace", side_effect=OSError("read-only fs")):
+            ts = _load_last_refresh(str(tmp_path))
+
+        # Timestamp was still parsed and returned even though rename failed.
+        assert ts == datetime(2026, 4, 8, 11, 30)
+
+
+class TestThrottleNoStateFile:
+    def test_no_state_file_does_not_throttle(self, tmp_path):
+        """When min_interval > 0 but no prior refresh state exists, don't throttle."""
+        from datetime import timezone
+
+        result = should_throttle_display_refresh(
+            provider="inky",
+            now=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+            state_dir=str(tmp_path),
+            force_full=False,
+            min_interval_seconds=3600,
+        )
+        assert result is False
+
+
+class TestWriteErrorMarker:
+    def test_creates_error_marker_file(self, tmp_path):
+        from src.config import Config
+
+        cfg = Config()
+        cfg.output_dir = str(tmp_path)
+        svc = OutputService(cfg, tz=None)
+        exc = RuntimeError("something broke")
+        svc.write_error_marker(exc)
+
+        marker = tmp_path / "last_error.txt"
+        assert marker.exists()
+        payload = json.loads(marker.read_text())
+        assert payload["exception_type"] == "RuntimeError"
+        assert payload["message"] == "something broke"
+        assert "timestamp" in payload
+
+    def test_write_failure_logs_warning_and_does_not_raise(self, tmp_path, caplog):
+        from src.config import Config
+
+        cfg = Config()
+        cfg.output_dir = str(tmp_path)
+        svc = OutputService(cfg, tz=None)
+
+        with caplog.at_level(logging.WARNING, logger="src.services.output"):
+            with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+                svc.write_error_marker(RuntimeError("oops"))
+
+        assert "last_error.txt" in caplog.text


### PR DESCRIPTION
Five targeted additions addressing the highest-impact gaps identified
in the coverage analysis:

- tests/test__time.py (new): full unit coverage for all four helpers in
  src/_time.py (now_utc, now_local, to_aware, assert_aware), including
  the aware-passthrough and ValueError branches that were previously at 44%.

- tests/test_calendar_caldav.py: 77% → 100% — adds coverage for
  _read_password OSError, calendar lookup failure, tz-aware today-date
  branch, _calendar_name callable/None/exception paths, _walk_vevents
  non-VEVENT filtering and exception paths, duration-based event ends
  for both timed and all-day events, the no-DTEND/no-DURATION fallbacks,
  and the None-parse skip inside the main fetch loop.

- tests/test_config_validation.py: extends with CalDAV validation
  (bad scheme, missing username, missing password file, file-not-found
  warning, simultaneous caldav+ical warning), theme_rules validation
  (invalid daypart/season/weekday/calendar values), and countdown event
  validation (missing name, malformed date).

- tests/test_config_migrations.py: adds the "no step registered for
  version N" defensive branch and the write_pre_migration_backup OSError
  path.

- tests/test_services_output.py: adds legacy migration OSError (rename
  fails but timestamp still returned), no-state-file throttle check,
  write_error_marker success path, and write_error_marker write failure.

https://claude.ai/code/session_01XbsGqxETTHJZZExT2a2dCg