### PR TITLE
docs: refresh CLAUDE.md with banner script + lint/fmt make targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Bundled OFL fonts** — Astloch (Regular + Bold), Audiowide
   (Regular), Righteous (Regular).  Each ships alongside its upstream
   `OFL.txt` license file under `fonts/`.
+- **eInk-faithful README logo banner** — `scripts/build_banner.py`
+  (`make banner`) renders a 1600×400 hero image at `assets/banner.png`
+  combining a Maratype wordmark, a DM Sans tagline, and a compressed
+  motif strip; output is quantized to 1-bit with Floyd-Steinberg dither
+  (mirroring `render/quantize.py::quantize_for_display()`) so the
+  banner reads as authentic eInk on screen.  Standalone PIL script — no
+  imports from the rest of the project — and deterministic (no
+  `datetime.now()`), so re-running produces byte-identical output.
 
 ### Changed
 
@@ -76,6 +84,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   non-leap years (the `except ValueError: continue` branch) or crash
   on the year-+1 rollover.  Both branches now follow the convention
   `birthday_bar.py` already uses (Feb 29 → Feb 28 in non-leap years).
+- **README banner — sun glyph / weather label overlap** in
+  `scripts/build_banner.py`.  The weather-icons font for the sunny
+  glyph carries a 15 px top margin and rays extending to `y0 + 108`,
+  but the "CLEAR" label was placed at `y0 + 96` so the text sat in
+  the same vertical band as the sun's lower-left rays.  Dropped the
+  label to `y0 + 116` so it clears the glyph.
 
 ## [5.0.0] — Pluggable & Polished
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,11 @@ make configure      # Run deploy/configure.sh interactive setup
 make web-enable     # Install and start web UI systemd service (run ON Pi)
 make web-status     # Web service status + recent log tail (run ON Pi)
 make web-logs       # Tail output/dashboard-web.log (run ON Pi)
-ruff check src/ tests/                         # Lint
-ruff format src/ tests/                        # Format
+make banner         # Regenerate the eInk-faithful README logo → assets/banner.png
+make lint           # ruff check src/ tests/
+make fmt            # ruff format src/ tests/
+ruff check src/ tests/                         # Lint (direct invocation)
+ruff format src/ tests/                        # Format (direct invocation)
 ```
 
 ## Tech Stack
@@ -178,7 +181,8 @@ docs/
 tests/                         # test files, extensive mocking
 fonts/                         # Bundled TTF fonts
 deploy/                        # Systemd service + timer + configure.sh + logrotate
-scripts/                       # Build/dev helpers: build_split_previews.py, check_docs.py
+scripts/                       # Build/dev helpers: build_split_previews.py, check_docs.py, build_banner.py
+assets/                        # Tracked image assets: banner.png (README hero) + previews/ (theme PNGs)
 state/                         # Runtime state: cache, breaker, quota, sync tokens (git-ignored)
 output/                        # Generated PNGs + logs + health marker (git-ignored except latest.png)
 credentials/                   # Google service account JSON (git-ignored)
@@ -434,3 +438,4 @@ default to `None` and fall back gracefully so adding a new field never breaks ex
 - The web `event_store` (`state/web_events.jsonl`) is append-only JSONL and `append_event()` serialises concurrent writes through a module-level `threading.Lock()` so two simultaneous web requests can't interleave half-lines into the file.
 - `scripts/build_split_previews.py` (`make previews-split`) combines `assets/previews/theme_<name>.png` and `assets/previews/theme_<name>_inky.png` into `assets/previews/theme_<name>_split.png` for the docs. Each theme picks an orientation from `_THEME_SPLIT_MODES` (anti-diagonal default, plus `main_diagonal`, `vertical`, `horizontal`); the orientation is chosen to keep each theme's Inky color story visible — vertical for centered hero content, horizontal for banded layouts (weather strip, scorecard). Cross-reference `_INKY_THEME_KEY_COLORS` in `canvas.py` when adding entries.
 - `make previews` regenerates Waveshare previews for the curated theme list embedded in the Makefile rule (not every concrete theme); the Inky `_inky` previews and the moon-phase preview date pinning live in their own scripts/CI steps. Don't expect `make previews` alone to refresh every PNG referenced by `docs/themes.md`.
+- `scripts/build_banner.py` (`make banner`) renders the README hero logo at `assets/banner.png`. It is a standalone PIL script that does **not** import the rest of the project — it draws a 1600×400 wordmark + tagline + motif strip at 8-bit greyscale and then quantizes to 1-bit via Floyd-Steinberg, mirroring `render/quantize.py::quantize_for_display()` so the on-screen result looks like authentic eInk output. The render is deterministic (no `datetime.now()`); re-running produces byte-identical output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ make docs-check   # validate markdown links and theme inventories
 
 ## Adding a Theme
 
+v5 themes self-register via a `register_theme(...)` call at the bottom of their own
+module — there is no central registry dict to edit.
+
 1. Create `src/render/themes/my_theme.py`.
 2. Return a `Theme` built from the current theme API:
 
@@ -60,13 +63,36 @@ def my_theme() -> Theme:
     return Theme(name="my_theme", style=style, layout=layout)
 ```
 
-3. Register the theme in `src/render/theme.py` by adding it to `_THEME_REGISTRY`.
-4. If it should never appear in rotation, add it to `_EXCLUDED_FROM_POOL` in `src/render/random_theme.py`.
-5. If the theme is user-facing, update:
+3. At the bottom of the same module, register the theme and its Inky palette pair:
+
+```python
+def _register() -> None:
+    from src.render.theme import INKY_BLUE, INKY_RED
+    from src.render.themes.registry import register_theme
+
+    register_theme("my_theme", my_theme, inky_palette=(INKY_BLUE, INKY_RED))
+
+_register()
+```
+
+4. Add the module to `src/render/themes/__init__.py` so the side-effect import fires
+   on package load.
+5. If it should never appear in random rotation (utility / diagnostic views), add the
+   name to `_EXCLUDED_FROM_POOL` in `src/render/random_theme.py`.
+6. Regenerate the pixel-hash baseline — the snapshot guard fails on any unregistered
+   theme:
+
+```bash
+UPDATE_SNAPSHOTS=1 pytest tests/test_theme_pixel_snapshots.py
+```
+
+   Commit the updated `tests/snapshots/theme_pixel_hashes.json` alongside the source.
+
+7. If the theme is user-facing, update:
    - `docs/themes.md` (add a `#### <name>` section with a short description and both
      the Waveshare and Inky preview images — see existing entries for the pattern)
    - any theme lists in config or setup docs that are intended to be exhaustive
-6. Regenerate the preview PNGs that `docs/themes.md` embeds — see
+8. Regenerate the preview PNGs that `docs/themes.md` embeds — see
    [docs/previews.md](docs/previews.md) for the Waveshare and Inky commands.
    For a quick sanity check before committing previews:
 
@@ -74,17 +100,45 @@ def my_theme() -> Theme:
 venv/bin/python -m src.main --dry-run --dummy --theme my_theme
 ```
 
-For greyscale custom themes, set `ThemeLayout.canvas_mode = "L"` and use `fg=0, bg=255` in `ThemeStyle`.
+For greyscale custom themes, set `ThemeLayout.canvas_mode = "L"` and use `fg=0, bg=255` in `ThemeStyle` (or `fg=255, bg=0` for a dark canvas — `bg=1` is near-black in L mode).
 
 ## Adding a Fetcher or Data Source
 
-1. Create the fetcher module in `src/fetchers/`.
-2. Return typed data models from `src/data/models.py`.
-3. Add cache serialization support in `src/fetchers/cache.py`.
-4. Integrate the source into `src/data_pipeline.py`.
-5. Extend `DashboardData` if the source becomes part of the render pipeline.
-6. Add tests that mock all external I/O.
-7. Update operator docs if the source introduces new config or new UI behavior.
+v5 fetchers self-register via a `register_fetcher(...)` call. The `DataPipeline`,
+cache layer, circuit breaker, and quota tracker all iterate the registry — no edits
+to `data_pipeline.py` or `cache.py` are required.
+
+1. Create the fetcher module in `src/fetchers/` with a function that takes the
+   relevant config (or the full `Config`) and returns a serialisable value.
+2. Return typed data models from `src/data/models.py`; extend `DashboardData` if a
+   new top-level field is needed.
+3. At the bottom of the module, register the adapter:
+
+```python
+from src.fetchers.registry import Fetcher, register_fetcher
+
+def _ser(value): ...   # value → JSON-able primitives
+def _deser(blob): ...  # JSON-able → value
+
+register_fetcher(Fetcher(
+    name="my_source",
+    fetch=lambda ctx: my_source_fetch(ctx.cfg.my_source, tz=ctx.tz),
+    serialize=_ser,
+    deserialize=_deser,
+    ttl_minutes=lambda cfg: cfg.cache.my_source_ttl_minutes,
+    interval_minutes=lambda cfg: cfg.cache.my_source_fetch_interval,
+    enabled=lambda cfg: bool(cfg.my_source.api_key),
+    log_success=lambda v: f"Fetched my_source: {v}",
+))
+```
+
+4. Add `from src.fetchers import my_source as _my_source  # noqa: F401` to
+   `src/fetchers/__init__.py` so the side-effect import fires.
+5. Add tests that mock all external I/O.
+6. Update operator docs if the source introduces new config or new UI behavior.
+
+See `src/fetchers/calendar_caldav.py` plus the `_register()` block at the bottom of
+`src/fetchers/calendar.py` as the v5 reference.
 
 ## Adding a Config Option
 


### PR DESCRIPTION
The Quick Commands section was missing `make banner`, `make lint`, and
`make fmt`; the repository tree listing was missing `scripts/build_banner.py`
and the top-level `assets/` directory. Add a Gotchas entry describing the
banner script's standalone (no project imports) and deterministic nature
so future agents know not to wire it into the render pipeline.

https://claude.ai/code/session_012sXDjDbCAJ2ZPADt3VMDRo