### PR TITLE
fix(halftone): centre big temp horizontally within left column

### DIFF
--- a/src/render/components/halftone_panel.py
+++ b/src/render/components/halftone_panel.py
@@ -757,13 +757,15 @@ def _draw_margin_band(
 
     # The temp numeral lives inside a fixed-width left column so the
     # right-side text column width is stable across 1-, 2-, and 3-digit
-    # temperatures. Within that column the temp is left-aligned to the
-    # outer margin.
+    # temperatures. Within that column the temp is horizontally centred
+    # so 1- and 2-digit values don't look left-biased against the wide
+    # blank reservation that 3-digit values would fill.
     temp_font = style.font_title(TEMP_NUMERAL_SIZE)
     temp_text = _fmt_temp(weather.current_temp) if weather else "—"
     temp_bbox = draw.textbbox((0, 0), temp_text, font=temp_font)
     temp_visible_h = temp_bbox[3] - temp_bbox[1]
-    temp_x = x0 + MARGIN_PAD_X - temp_bbox[0]
+    temp_w = temp_bbox[2] - temp_bbox[0]
+    temp_x = x0 + (TEMP_COL_W - temp_w) // 2 - temp_bbox[0]
     # Vertically centre the temp + caption stack in the FULL band height —
     # the footer caption is right-aligned so it never collides with this
     # left-column stack, and centring against `inner_h` would otherwise
@@ -771,7 +773,6 @@ def _draw_margin_band(
     stack_h = temp_visible_h + feels_h
     temp_y = y0 + (h - stack_h) // 2 - temp_bbox[1]
     draw.text((temp_x, temp_y), temp_text, font=temp_font, fill=ink)
-    temp_w = temp_bbox[2] - temp_bbox[0]
     text_col_x = x0 + TEMP_COL_W
     text_col_right = x0 + w - MARGIN_PAD_X
 
@@ -780,7 +781,6 @@ def _draw_margin_band(
     if feels_caption and feels_font is not None:
         fb = draw.textbbox((0, 0), feels_caption, font=feels_font)
         cap_w = fb[2] - fb[0]
-        temp_w = temp_bbox[2] - temp_bbox[0]
         cap_x = temp_x + (temp_w - cap_w) // 2 - fb[0]
         cap_y = temp_y + temp_bbox[1] + temp_visible_h + 8 - fb[1]
         draw.text((cap_x, cap_y), feels_caption, font=feels_font, fill=ink)

--- a/tests/snapshots/theme_pixel_hashes.json
+++ b/tests/snapshots/theme_pixel_hashes.json
@@ -14,7 +14,7 @@
     "fantasy": "2a9cb03c7f6f5e1ac0b3d99832f0cc0fdd028a4f29779395803d380b5b8a0c2b",
     "fuzzyclock": "bdc4a975f2c99205fc021ded0b8b2897ff25ca387f6cf1a3cd815c7c72cd4fae",
     "fuzzyclock_invert": "018aef88a888f8c8a38e07942c5985676a1c07450a6ad7a062ce05dd9cfd87f0",
-    "halftone": "74de23a624b72d68b747e0a91acae05cb7dac68e3955907463a79dfa19655f36",
+    "halftone": "f48d5043b4ad788d2cbeed33a3efbb0faf5eb55cb7df4987b38f6e4985b4239a",
     "light_cycle": "3de8ef01668ffb6fd9ff3843b7e6dce6b9b238eb8ae304e08665b99f2bd9379b",
     "message": "171355f3550d9d8cb7b9c038db55d92f5495a599569dd461807c267052ab57d5",
     "minimalist": "f51d57b21eb97073344b97a19c838e417e1ab66e126374c9ac375087eaab1b77",


### PR DESCRIPTION
The 280px temp column was previously left-anchored at MARGIN_PAD_X,
so 1-/2-digit temperatures (e.g. "61°") sat against the outer margin
with a large blank gap on the right inside the column reservation
sized for 3-digit values. Centre the numeral within TEMP_COL_W so
the headline reads as visually balanced regardless of digit count;
the feels-like caption already centres relative to the numeral.

https://claude.ai/code/session_01Ax2Djy2nXckjjw53f5Ljuq