### PR TITLE
fix: harden timeouts, atomic state writes, edge cases, and web security

### DIFF
--- a/src/astronomy.py
+++ b/src/astronomy.py
@@ -130,9 +130,12 @@ def _hour_angle(latitude: float, declination: float, altitude: float) -> float |
     lat_rad = math.radians(latitude)
     dec_rad = math.radians(declination)
     alt_rad = math.radians(altitude)
-    cos_h = (math.sin(alt_rad) - math.sin(lat_rad) * math.sin(dec_rad)) / (
-        math.cos(lat_rad) * math.cos(dec_rad)
-    )
+    denom = math.cos(lat_rad) * math.cos(dec_rad)
+    # At the geographic poles (cos(lat) == 0) the denominator vanishes before the
+    # out-of-range guard below can fire — treat it as polar day/night (no event).
+    if abs(denom) < 1e-12:
+        return None
+    cos_h = (math.sin(alt_rad) - math.sin(lat_rad) * math.sin(dec_rad)) / denom
     if cos_h > 1 or cos_h < -1:
         return None
     return math.degrees(math.acos(cos_h))

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -363,12 +363,22 @@ class DataPipeline:
             return futures
 
         max_workers = max(1, len(runnable))
-        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        # NOTE: deliberately *not* using ``with ThreadPoolExecutor(...) as pool``.
+        # The context-manager exit calls ``shutdown(wait=True)`` with no timeout,
+        # which would block until every fetch finishes before this method even
+        # returns — defeating the per-source ``future.result(timeout=120)`` bound
+        # applied in ``_resolve_source``. By shutting down with ``wait=False`` we
+        # let the caller resolve each future under its own 120s ceiling, so a
+        # single hung source can't stall the whole run indefinitely.
+        pool = ThreadPoolExecutor(max_workers=max_workers)
+        try:
             for f in runnable:
                 label = f.name.replace("_", " ").title().replace(" ", "")
                 futures[f.name] = pool.submit(
                     retry_fetch, label, lambda fetcher=f: fetcher.fetch(ctx)
                 )
+        finally:
+            pool.shutdown(wait=False)
         return futures
 
     def _resolve_source(self, source: str, future: Future | None, current, success_log_fn=None):

--- a/src/fetchers/calendar.py
+++ b/src/fetchers/calendar.py
@@ -73,8 +73,12 @@ def _build_people_service(cfg: GoogleConfig):
     Workspace Admin, and ``cfg.contacts_email`` must be set to the email of
     the user whose contacts should be read.
     """
+    import httplib2
     from google.oauth2 import service_account
+    from google_auth_httplib2 import AuthorizedHttp
     from googleapiclient.discovery import build
+
+    from src.fetchers.calendar_google import _HTTP_TIMEOUT_SECONDS
 
     key = f"{cfg.service_account_path}:{cfg.contacts_email}"
     if key not in _people_service_cache:
@@ -89,7 +93,10 @@ def _build_people_service(cfg: GoogleConfig):
             ) from exc
         if cfg.contacts_email:
             creds = creds.with_subject(cfg.contacts_email)
-        _people_service_cache[key] = build("people", "v1", credentials=creds, cache_discovery=False)
+        # Use an explicit per-request HTTP timeout (matching the Calendar path) so a
+        # stalled contacts request can't waste the full 120s DataPipeline slot.
+        http = AuthorizedHttp(creds, http=httplib2.Http(timeout=_HTTP_TIMEOUT_SECONDS))
+        _people_service_cache[key] = build("people", "v1", http=http, cache_discovery=False)
     return _people_service_cache[key]
 
 

--- a/src/fetchers/host.py
+++ b/src/fetchers/host.py
@@ -87,6 +87,10 @@ def fetch_host_data() -> Optional[HostData]:
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
+            # UDP connect normally returns instantly, but a host with no default
+            # route can block; this fetch runs synchronously outside the pipeline's
+            # 120s executor ceiling, so cap it defensively.
+            s.settimeout(0.5)
             s.connect(("8.8.8.8", 80))
             host.ip_address = s.getsockname()[0]
             any_success = True

--- a/src/render/components/info_panel.py
+++ b/src/render/components/info_panel.py
@@ -71,6 +71,11 @@ def _cached_select_quote(key: str) -> dict:
     else:
         quotes = DEFAULT_QUOTES
 
+    # A valid-but-empty quotes file (``[]``) decodes fine but would make the
+    # modulo below divide by zero — fall back to the bundled defaults.
+    if not quotes:
+        quotes = DEFAULT_QUOTES
+
     day_hash = int(hashlib.md5(key.encode()).hexdigest(), 16)
     return quotes[day_hash % len(quotes)]
 

--- a/src/render/components/moonphase_panel.py
+++ b/src/render/components/moonphase_panel.py
@@ -104,6 +104,11 @@ def _quote_for_panel(today: date, refresh: str = "daily", now: datetime | None =
     else:
         quotes = _DEFAULT_QUOTES
 
+    # A valid-but-empty quotes file (``[]``) decodes fine but would make the
+    # modulo below divide by zero — fall back to the bundled defaults.
+    if not quotes:
+        quotes = _DEFAULT_QUOTES
+
     day_hash = int(hashlib.md5(key.encode()).hexdigest(), 16)
     return quotes[day_hash % len(quotes)]
 

--- a/src/render/components/scorecard_panel.py
+++ b/src/render/components/scorecard_panel.py
@@ -65,6 +65,10 @@ def _quote_for_panel(today: date, refresh: str = "daily", now: datetime | None =
             quotes = _DEFAULT_QUOTES
     else:
         quotes = _DEFAULT_QUOTES
+    # A valid-but-empty quotes file (``[]``) decodes fine but would make the
+    # modulo below divide by zero — fall back to the bundled defaults.
+    if not quotes:
+        quotes = _DEFAULT_QUOTES
     day_hash = int(hashlib.md5(key.encode()).hexdigest(), 16)
     return quotes[day_hash % len(quotes)]
 

--- a/src/render/components/tides_panel.py
+++ b/src/render/components/tides_panel.py
@@ -60,6 +60,10 @@ def _quote_for_panel(today: date, refresh: str = "daily", now: datetime | None =
             quotes = _DEFAULT_QUOTES
     else:
         quotes = _DEFAULT_QUOTES
+    # A valid-but-empty quotes file (``[]``) decodes fine but would make the
+    # modulo below divide by zero — fall back to the bundled defaults.
+    if not quotes:
+        quotes = _DEFAULT_QUOTES
     day_hash = int(hashlib.md5(key.encode()).hexdigest(), 16)
     return quotes[day_hash % len(quotes)]
 

--- a/src/services/output.py
+++ b/src/services/output.py
@@ -95,7 +95,7 @@ def _save_last_refresh(state_dir: str, when: datetime) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write so a kill mid-write can't truncate the state file (matches
         # the invariant used by every other JSON state file — see src/_io.py).
-        atomic_write_json(str(path), {"last_refresh_at": when.isoformat()})
+        atomic_write_json(path, {"last_refresh_at": when.isoformat()})
     except OSError as exc:
         logger.warning("Could not write refresh throttle state: %s", exc)
 

--- a/src/services/output.py
+++ b/src/services/output.py
@@ -17,6 +17,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
+from src._io import atomic_write_json
 from src._time import now_local
 from src.display.driver import DryRunDisplay, build_display_driver, image_changed
 
@@ -92,7 +93,9 @@ def _save_last_refresh(state_dir: str, when: datetime) -> None:
     path = _refresh_state_path(state_dir)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"last_refresh_at": when.isoformat()}) + "\n")
+        # Atomic write so a kill mid-write can't truncate the state file (matches
+        # the invariant used by every other JSON state file — see src/_io.py).
+        atomic_write_json(str(path), {"last_refresh_at": when.isoformat()})
     except OSError as exc:
         logger.warning("Could not write refresh throttle state: %s", exc)
 

--- a/src/services/run_policy.py
+++ b/src/services/run_policy.py
@@ -62,7 +62,7 @@ def record_morning_refresh(now: datetime, state_dir: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic write so a kill mid-write can't truncate the marker (matches the
         # invariant used by every other JSON state file — see src/_io.py).
-        atomic_write_json(str(path), {"last_refresh_date": now.date().isoformat()})
+        atomic_write_json(path, {"last_refresh_date": now.date().isoformat()})
     except OSError as exc:
         logger.warning("Failed to write morning refresh state to %s: %s", path, exc)
 

--- a/src/services/run_policy.py
+++ b/src/services/run_policy.py
@@ -6,6 +6,8 @@ from datetime import date as _date
 from datetime import datetime
 from pathlib import Path
 
+from src._io import atomic_write_json
+
 logger = logging.getLogger(__name__)
 
 _MORNING_REFRESH_STATE_FILENAME = "morning_refresh_state.json"
@@ -58,7 +60,9 @@ def record_morning_refresh(now: datetime, state_dir: str) -> None:
     path = _morning_state_path(state_dir)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"last_refresh_date": now.date().isoformat()}))
+        # Atomic write so a kill mid-write can't truncate the marker (matches the
+        # invariant used by every other JSON state file — see src/_io.py).
+        atomic_write_json(str(path), {"last_refresh_date": now.date().isoformat()})
     except OSError as exc:
         logger.warning("Failed to write morning refresh state to %s: %s", path, exc)
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -58,7 +58,23 @@ def create_app(
 
     # --- Load configs ---
     web_cfg = _load_web_config(web_config_path)
-    app.secret_key = web_cfg.get("secret_key") or "dashboard-web-dev-secret"
+    secret_key = web_cfg.get("secret_key")
+    if not secret_key:
+        # No configured key: generate a random per-process key instead of falling
+        # back to a shared, publicly-known constant (which would let anyone forge a
+        # signed session cookie and defeat CSRF protection on mutating endpoints).
+        # Sessions won't survive a restart, which is fine for this admin UI.
+        import secrets
+
+        secret_key = secrets.token_hex(32)
+        logger.warning(
+            "No 'secret_key' set in web config; generated a random ephemeral key. "
+            "Set 'secret_key' in web.yaml to keep sessions stable across restarts."
+        )
+    app.secret_key = secret_key
+    # Harden session cookies: never send over plain navigation cross-site, and keep
+    # them out of JavaScript.
+    app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SAMESITE="Strict")
     dash_cfg = None
     if app_config_path and Path(app_config_path).exists():
         try:
@@ -88,6 +104,17 @@ def create_app(
         "air_quality": dash_cfg.cache.air_quality_ttl_minutes,
     }
 
+    # --- Auth ---
+    # Register auth FIRST so unauthenticated mutating requests are rejected with 401
+    # before any CSRF/session logic runs (before_request callbacks fire in
+    # registration order).
+    auth_section = web_cfg.get("auth", {})
+    auth_fn = make_auth_middleware(
+        username=auth_section.get("username"),
+        password_hash=auth_section.get("password_hash"),
+    )
+    app.before_request(auth_fn)
+
     # --- CSRF + template globals ---
     from src.web.csrf import csrf_protect, get_csrf_token
 
@@ -99,14 +126,6 @@ def create_app(
             csrf_protect()
 
     app.jinja_env.globals["csrf_token"] = get_csrf_token
-
-    # --- Auth ---
-    auth_section = web_cfg.get("auth", {})
-    auth_fn = make_auth_middleware(
-        username=auth_section.get("username"),
-        password_hash=auth_section.get("password_hash"),
-    )
-    app.before_request(auth_fn)
 
     # --- Register P1 blueprints ---
     from src.web.routes.image import image_bp

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -338,7 +338,7 @@ class TestRecordMorningRefresh:
         import logging
         from unittest.mock import patch
 
-        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+        with patch("src.services.run_policy.atomic_write_json", side_effect=OSError("disk full")):
             with caplog.at_level(logging.WARNING, logger="src.services.run_policy"):
                 record_morning_refresh(self._dt(6, 5), str(tmp_path))
         assert "Failed to write morning refresh state" in caplog.text

--- a/tests/test_services_output.py
+++ b/tests/test_services_output.py
@@ -520,7 +520,7 @@ class TestLoadLastRefreshDefensive:
 class TestSaveLastRefreshDefensive:
     def test_save_failure_logs_warning_and_does_not_raise(self, tmp_path, caplog):
         with caplog.at_level(logging.WARNING, logger="src.services.output"):
-            with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            with patch("src.services.output.atomic_write_json", side_effect=OSError("disk full")):
                 _save_last_refresh(str(tmp_path), datetime(2026, 4, 8, 12, 0))
 
         assert "refresh throttle" in caplog.text

--- a/tests/test_web_app_factory.py
+++ b/tests/test_web_app_factory.py
@@ -111,13 +111,22 @@ def test_create_app_uses_secret_key_from_web_config(tmp_path):
     assert app.secret_key == "super-secret-string"
 
 
-def test_create_app_falls_back_to_dev_secret_when_unset(tmp_path):
+def test_create_app_generates_random_secret_when_unset(tmp_path):
+    """With no configured secret_key, the app must NOT fall back to a shared,
+    publicly-known constant (which would let anyone forge a signed session
+    cookie). It should generate a random per-process key instead."""
     web_yaml = tmp_path / "web.yaml"
     web_yaml.write_text("")
     cfg_yaml = tmp_path / "config.yaml"
     cfg_yaml.write_text("")
-    app = create_app(web_config_path=str(web_yaml), app_config_path=str(cfg_yaml))
-    assert app.secret_key == "dashboard-web-dev-secret"
+    app1 = create_app(web_config_path=str(web_yaml), app_config_path=str(cfg_yaml))
+    app2 = create_app(web_config_path=str(web_yaml), app_config_path=str(cfg_yaml))
+    # A real, non-trivial key that differs between instances (i.e. random).
+    assert app1.secret_key and app1.secret_key != "dashboard-web-dev-secret"
+    assert app1.secret_key != app2.secret_key
+    # Cookies hardened against cross-site leakage.
+    assert app1.config["SESSION_COOKIE_SAMESITE"] == "Strict"
+    assert app1.config["SESSION_COOKIE_HTTPONLY"] is True
 
 
 def test_create_app_derives_source_ttl_map(tmp_path):


### PR DESCRIPTION
Codebase review pass addressing several latent bugs and robustness gaps:

- data_pipeline: don't join the fetch ThreadPoolExecutor before resolving
  futures. The `with` block's shutdown(wait=True) blocked indefinitely on a
  hung source, defeating the documented per-source future.result(timeout=120)
  bound. Shut down with wait=False so each source is actually capped at 120s.
- calendar (People API): build the contacts service with an explicit 30s HTTP
  timeout, matching the Calendar path, so a stalled contacts request can't
  consume the full pipeline slot.
- host: add a 0.5s socket timeout on the outbound-IP probe; it runs
  synchronously outside the pipeline's executor ceiling.
- output / run_policy: persist refresh-throttle and morning-refresh state via
  atomic_write_json so a kill mid-write can't truncate the file (matches the
  invariant every other JSON state file already follows).
- astronomy: guard _hour_angle against division by zero at the geographic
  poles (cos(lat) == 0) — return None (polar day/night) instead of crashing.
- quote panels (info, tides, scorecard, moonphase): fall back to bundled
  defaults when quotes.json decodes to an empty list, avoiding a
  ZeroDivisionError in the selection modulo.
- web app: stop falling back to a shared, publicly-known Flask secret_key;
  generate a random per-process key and warn when unset. Register auth before
  the CSRF hook and harden session cookies (SameSite=Strict, HttpOnly).

Tests updated to match the new behavior; full suite green.