### PR TITLE
Enforce docs-check in CI, and fix the theme lists that drifted without it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
+      # Validates markdown links and the canonical theme inventories in
+      # docs/themes.md and docs/previews.md. CONTRIBUTING asks contributors to
+      # run this, but nothing enforced it — which is how themes drifted out of
+      # the preview batch loop unnoticed.
+      - run: python scripts/check_docs.py
 
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- `make docs-check` now runs in the `lint` CI job. It previously existed but
+  nothing enforced it, so the "all concrete themes" preview batch loop in
+  `docs/previews.md` silently drifted — `day_arc` and `moonphase_photo` were
+  both missing from it. `scripts/check_docs.py` now validates that list
+  against the theme registry as well, and both themes were added.
 - `CONTRIBUTING.md` coverage figures corrected — the gate has been 94% (with
   actual ≈96%) since it was ratcheted; the doc still claimed ≥90% and ~99%.
 - `to_local_naive` no longer consults the host machine's timezone when no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ make dry            # Preview with dummy data → output/latest.png
 make previews       # Generate all theme preview PNGs → assets/previews/theme_*.png
 make previews-split # Combine Waveshare + Inky previews into assets/previews/theme_<name>_split.png
 make check          # Validate config/config.yaml
-make docs-check     # Run scripts/check_docs.py (markdown link / heading sanity)
+make docs-check     # Run scripts/check_docs.py (markdown links + the canonical theme
+                    #   inventories in docs/themes.md and docs/previews.md). Enforced by
+                    #   the `lint` CI job, so drift here blocks a merge.
 make version        # Print current version (e.g. main.py 5.1.0)
 make deploy         # Rsync to Pi (configurable: PI_USER, PI_HOST, PI_DIR)
 make install        # Install systemd timer on remote Pi (via ssh/scp)

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -87,9 +87,10 @@ cp output/latest.png assets/previews/theme_fuzzyclock_inky.png
 Example full batch for all concrete themes:
 
 ```bash
-for theme in agenda air_quality almanac astronomy constellation_map countdown default diags fantasy fuzzyclock fuzzyclock_invert \
-             halftone light_cycle message minimalist monthly moonphase moonphase_invert naturalist old_fashioned photo postcard qotd \
-             qotd_invert scorecard sunrise terminal tides timeline today trends weather weatherglass year_pulse; do
+for theme in agenda air_quality almanac astronomy constellation_map countdown day_arc default diags fantasy fuzzyclock \
+             fuzzyclock_invert halftone light_cycle message minimalist monthly moonphase moonphase_invert moonphase_photo \
+             naturalist old_fashioned photo postcard qotd qotd_invert scorecard sunrise terminal tides timeline today trends \
+             weather weatherglass year_pulse; do
   if [ "$theme" = "message" ]; then
     python3 -m src.main --config /path/to/inky-config.yaml --dry-run --dummy \
       --theme "$theme" --message "Preview Message"

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -11,6 +11,8 @@ ROOT = Path(__file__).resolve().parents[1]
 DOC_FILES = [ROOT / "README.md", ROOT / "CONTRIBUTING.md"] + sorted((ROOT / "docs").glob("*.md"))
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 THEME_DETAIL_RE = re.compile(r"^####\s+(.+)$", re.MULTILINE)
+# The "full batch for all concrete themes" shell loop in docs/previews.md.
+PREVIEW_BATCH_RE = re.compile(r"for theme in ([^;]+); do", re.DOTALL)
 
 
 def normalize_heading(heading: str) -> str:
@@ -69,6 +71,29 @@ def check_theme_inventory(theme_names: set[str]) -> list[str]:
     for name in extra_in_themes:
         errors.append(f"docs/themes.md: unexpected theme heading '{name}'")
 
+    errors.extend(check_preview_batch(theme_names))
+    return errors
+
+
+def check_preview_batch(theme_names: set[str]) -> list[str]:
+    """Keep the Inky preview batch loop in sync with the theme registry.
+
+    The loop is documented as covering "all concrete themes", so a theme that
+    never gets added to it silently never gets an Inky preview regenerated.
+    Both ``day_arc`` and ``moonphase_photo`` drifted out of it that way before
+    this check existed.
+    """
+    errors: list[str] = []
+    previews_doc = (ROOT / "docs" / "previews.md").read_text()
+    match = PREVIEW_BATCH_RE.search(previews_doc)
+    if match is None:
+        return ["docs/previews.md: could not find the 'for theme in ...' batch loop"]
+
+    listed = set(match.group(1).replace("\\", " ").split())
+    for name in sorted(theme_names - listed):
+        errors.append(f"docs/previews.md: theme '{name}' missing from the preview batch loop")
+    for name in sorted(listed - theme_names):
+        errors.append(f"docs/previews.md: unknown theme '{name}' in the preview batch loop")
     return errors
 
 


### PR DESCRIPTION
## What and why

`docs/previews.md` documents a shell loop covering *"all concrete themes"*, used to regenerate the Inky preview set. Two themes were missing from it: `day_arc` (mine, from #191) and `moonphase_photo` (drifted out when it was added). Anyone following those instructions would silently skip regenerating those previews.

The list drifted because nothing checked it — and nothing checked it because **CI never ran `make docs-check` at all**. `CONTRIBUTING.md` asks contributors to run it before opening a PR, and `Makefile`, `CLAUDE.md` and `docs/development.md` all document it, but no workflow invoked it. So `scripts/check_docs.py` could validate the theme inventory perfectly and still let an incomplete list through.

Three changes:

- `check_preview_batch()` in `scripts/check_docs.py` diffs the loop's theme list against the registry in both directions, mirroring the existing `docs/themes.md` heading check.
- `day_arc` and `moonphase_photo` added to the loop.
- `python scripts/check_docs.py` added to the `lint` CI job.

## Notes for the reviewer

**This makes documentation drift merge-blocking.** `lint` is a required status check, so a missing theme heading or an out-of-date preview list will now fail a PR. That's the intent — the alternative is a check that exists but never fires, which is exactly how we got here — but it is a policy change, so it's worth an explicit yes/no. If you'd rather it not gate merges, moving the step into its own non-required job is a one-line change.

The new check was confirmed non-vacuous before the list was fixed: it reported both missing themes and exited 1.

```
docs/previews.md: theme 'day_arc' missing from the preview batch loop
docs/previews.md: theme 'moonphase_photo' missing from the preview batch loop
```

Worth noting this is the second enforcement gap found in two days — the first being that `mypy` is a required CI job but appeared in no contributor checklist until the PR template added it. Both are the same shape: a check that exists, is documented, and isn't wired to anything that fails.

This branch was restarted from `main` after #191 merged rather than stacked on merged history.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate (2949 tests, 95.85% vs the 94% gate)
- [x] `venv/bin/python -m mypy src/` is clean — CI runs it over every module
- [x] Tests added or updated for behaviour changes — n/a; the change *is* a check, and it was verified to fail before the fix and pass after

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs updated per the [Docs Update Policy](../CONTRIBUTING.md#docs-update-policy) — `docs/previews.md` list corrected; `CLAUDE.md`'s command description widened, since "markdown link / heading sanity" undersells it now and gave no hint it is merge-blocking
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

If the change affects **architecture or contributor workflow**:

- [x] `CLAUDE.md` updated

Not applicable: no rendering changes (theme pixel snapshots untouched), no new config options.

---
_Generated by [Claude Code](https://claude.ai/code/session_014cmXSfoMt4qGsPFMEUmQZN)_