### PR TITLE
Sync required status checks with the jobs that actually exist

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -34,9 +34,12 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "lint" },
-          { "context": "test (3.9)" },
+          { "context": "test (3.10)" },
           { "context": "test (3.11)" },
           { "context": "test (3.12)" },
+          { "context": "test (3.13)" },
+          { "context": "test-core-install" },
+          { "context": "snapshot-tests" },
           { "context": "typecheck" },
           { "context": "smoke" }
         ]


### PR DESCRIPTION
## What and why

`.github/rulesets/main.json` required `test (3.9)` — a job retired in `8a52ea0` when the Python floor moved to 3.10. A required check that never reports blocks a PR indefinitely, so that entry is either inert or a merge trap depending on whether the file is applied.

It also left four real jobs unrequired. One of those matters considerably more than the stale entry:

**`snapshot-tests` is the only job that asserts theme pixel hashes.** The assertion in `test_theme_pixel_snapshots.py` is gated on runtime Pillow exactly matching `reference_env.pillow_version` — the baseline pins `12.2.0`, and CI's unpinned `pip install` resolves `12.3.0`, so all four `test (3.x)` jobs render every theme (a crash check) and then `pytest.skip` the comparison. Only `snapshot-tests` pins Pillow and actually compares hashes. Leaving it unrequired meant **a theme pixel regression could merge with every required check green**.

The other three:

- `test-core-install` — the only guard against core code importing an optional-extra package (`flask`, `waitress`). Live concern: `skyart.py` added a `numpy` import last week, safe only because numpy is a core dep.
- `test (3.10)` — the floor declared in `requires-python = ">=3.10"`, previously ungated.
- `test (3.13)` — the newest supported version.

The required list is now exactly the set of CI job names, verified programmatically against the workflow matrix in both directions:

```
required but missing from CI: none
in CI but not required      : none
→ exact match
```

## Notes for the reviewer

**I could not read the repo's live ruleset configuration.** The `/rulesets` and branch-protection APIs aren't available to this session, so this syncs the checked-in file only. Evidence suggests the file is *not* currently applied — #191 and #192 both reported `mergeable_state: clean` and merged without hanging on the non-existent `test (3.9)` — but that's inference from merge behaviour, not a read of live config.

So: **if the live ruleset was configured by hand rather than imported from this JSON, merging this changes nothing** and the same edit needs applying in repo settings. Worth a look before assuming the hole is closed.

This came out of a wider audit of whether every documented check maps to a CI step and every required check maps to a job that exists. The remaining findings were minor and are not in this PR: `ruff format --check` and `test-core-install` have no local `make` equivalent, which is why a contributor can be locally green and remotely red.

No `CHANGELOG.md` entry — this is repo governance config, not a change to the software or to any workflow a contributor runs. Happy to add one if you read it differently.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate (2949 tests, 95.85%)
- [x] `venv/bin/python -m mypy src/` is clean
- [x] Tests added or updated for behaviour changes — n/a; no source change, and the required-check list is verified against the workflow matrix rather than by a test

Not applicable: no rendering changes (theme pixel snapshots untouched), no docs or user-facing behaviour change, no new config options.

---
_Generated by [Claude Code](https://claude.ai/code/session_014cmXSfoMt4qGsPFMEUmQZN)_