### PR TITLE
Rank config backups by recency, not filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   stamp.
 - The captions were also wrong: `updated 12:45 pm` over weather fetched at
   12:20 reported when the pixels were painted, not when the data arrived.
+- **"Restore latest backup" no longer rolls the config back two or more
+  edits.** The web UI's backup list sorted filenames in reverse lexicographic
+  order, and `config.yaml.bak.<timestamp>` sorts after the shorter
+  `config.yaml.bak` — so a rotated archive outranked the plain backup that is
+  actually the snapshot from the immediately preceding save. After saves
+  A → B → C, restoring "the latest" gave you A. The plain `.bak` now always
+  ranks first and rotated archives follow by modification time, so the list
+  shown on the config page is genuinely newest-first too.
+- Pre-migration backups (`config.yaml.bak-v4`) match the same glob and were
+  offered as restorable config backups, which would have rolled the file back
+  to an older schema. They are no longer listed.
+- Backup rotation carried only second precision, so two saves inside the same
+  second rotated onto the same filename and the second one silently discarded
+  an archive. Rotated names now carry microseconds.
 
 ### Added
 

--- a/src/web/config_editor.py
+++ b/src/web/config_editor.py
@@ -66,29 +66,50 @@ EDITABLE_FIELD_PATHS: dict[str, tuple] = _editable_field_paths()
 
 
 def list_config_backups(config_path: str, limit: int = 5) -> list[dict]:
-    """Return available backup files for *config_path*, newest first."""
+    """Return available backup files for *config_path*, newest first.
+
+    Ordering is *not* lexicographic on the filename: ``config.yaml.bak.<ts>``
+    sorts after the shorter ``config.yaml.bak``, so a reverse name sort puts a
+    rotated archive ahead of the plain backup that is actually the newest one.
+    Instead the plain ``.bak`` — which ``_write_raw_yaml`` guarantees is the
+    snapshot taken by the immediately preceding save — always ranks first, and
+    the rotated archives follow by modification time (newest first). The
+    embedded name timestamp only breaks mtime ties, since a rotation renames
+    the file and carries the original mtime with it.
+
+    Versioned pre-migration backups (``config.yaml.bak-v4``, written by
+    ``src.config_migrations``) are a different kind of artifact — restoring one
+    would roll the file back to an older schema — so they are not listed here.
+    """
     path = Path(config_path)
     if not path.parent.exists():
         return []
 
-    backups: list[dict] = []
-    for candidate in sorted(path.parent.glob(f"{path.stem}.yaml.bak*"), reverse=True):
+    plain_name = f"{path.stem}.yaml.bak"
+    rotated_prefix = f"{plain_name}."
+
+    plain: list[dict] = []
+    rotated: list[tuple[int, str, dict]] = []
+    for candidate in path.parent.glob(f"{plain_name}*"):
+        is_plain = candidate.name == plain_name
+        if not is_plain and not candidate.name.startswith(rotated_prefix):
+            continue  # e.g. a .bak-v4 pre-migration backup
         try:
             stat = candidate.stat()
-            backups.append(
-                {
-                    "name": candidate.name,
-                    "size": stat.st_size,
-                    "modified_at": datetime.fromtimestamp(stat.st_mtime).isoformat(
-                        timespec="seconds"
-                    ),
-                }
-            )
         except OSError:
             continue
-        if len(backups) >= limit:
-            break
-    return backups
+        entry = {
+            "name": candidate.name,
+            "size": stat.st_size,
+            "modified_at": datetime.fromtimestamp(stat.st_mtime).isoformat(timespec="seconds"),
+        }
+        if is_plain:
+            plain.append(entry)
+        else:
+            rotated.append((stat.st_mtime_ns, candidate.name, entry))
+
+    rotated.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return (plain + [entry for _mtime, _name, entry in rotated])[:limit]
 
 
 def restore_latest_backup(config_path: str) -> tuple[bool, str]:
@@ -319,6 +340,24 @@ def _load_raw_yaml(config_path: str) -> dict:
         return {}
 
 
+def _rotated_backup_path(path: Path) -> Path:
+    """Return an unused ``<config>.yaml.bak.<timestamp>`` path for a rotation.
+
+    The timestamp carries microseconds because two saves landing in the same
+    second would otherwise rotate onto the same filename, and the second
+    ``replace()`` would silently discard the first archive. The suffix loop is
+    belt-and-braces for a clock that repeats a microsecond.
+    """
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")  # allow-naive-datetime — file naming
+    base = f"{path.stem}.yaml.bak.{stamp}"
+    candidate = path.with_name(base)
+    counter = 1
+    while candidate.exists():
+        candidate = path.with_name(f"{base}-{counter}")
+        counter += 1
+    return candidate
+
+
 def _write_raw_yaml(config_path: str, raw: dict, *, rotate_backup: bool = True) -> None:
     """Write *raw* to *config_path* atomically using a temp-file rename.
 
@@ -336,10 +375,7 @@ def _write_raw_yaml(config_path: str, raw: dict, *, rotate_backup: bool = True) 
             with os.fdopen(fd_b, "wb") as fb:
                 fb.write(path.read_bytes())
             if bak.exists():
-                timestamp = datetime.now().strftime(
-                    "%Y%m%d-%H%M%S"
-                )  # allow-naive-datetime — backup file naming
-                bak.replace(path.with_name(f"{path.stem}.yaml.bak.{timestamp}"))
+                bak.replace(_rotated_backup_path(path))
             os.replace(tmp_b, bak)
         except OSError as exc:
             logger.warning("Could not write config backup to %s: %s", bak, exc)

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -409,6 +409,112 @@ def test_restore_latest_backup(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Backup ordering — the plain .bak is the newest snapshot, not a rotated one
+# ---------------------------------------------------------------------------
+
+
+def test_list_config_backups_ranks_plain_bak_ahead_of_timestamped(tmp_path):
+    """A reverse name sort puts config.yaml.bak.<ts> first; the plain .bak is newer."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: C\n")
+    (tmp_path / "config.yaml.bak.20260816-113201").write_text("title: A\n")
+    (tmp_path / "config.yaml.bak").write_text("title: B\n")
+
+    names = [item["name"] for item in list_config_backups(str(cfg), limit=5)]
+
+    assert names[0] == "config.yaml.bak"
+    assert names == ["config.yaml.bak", "config.yaml.bak.20260816-113201"]
+
+
+def test_list_config_backups_orders_rotated_archives_newest_first(tmp_path):
+    """Rotated archives rank by mtime, so the ordering survives a name-format change."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: live\n")
+    older = tmp_path / "config.yaml.bak.20260101-000000"
+    newer = tmp_path / "config.yaml.bak.20260816-113201-000123"
+    older.write_text("title: older\n")
+    newer.write_text("title: newer\n")
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+
+    names = [item["name"] for item in list_config_backups(str(cfg), limit=5)]
+
+    assert names == [newer.name, older.name]
+
+
+def test_list_config_backups_limit_applies_after_ordering(tmp_path):
+    """The limit must truncate the ranked list, not the raw directory-scan order."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: live\n")
+    (tmp_path / "config.yaml.bak.20260101-000000").write_text("title: old\n")
+    (tmp_path / "config.yaml.bak.20260816-113201").write_text("title: mid\n")
+    (tmp_path / "config.yaml.bak").write_text("title: newest\n")
+
+    backups = list_config_backups(str(cfg), limit=1)
+
+    assert [item["name"] for item in backups] == ["config.yaml.bak"]
+
+
+def test_list_config_backups_excludes_pre_migration_backups(tmp_path):
+    """config.yaml.bak-v4 matches the glob but is a schema snapshot, not an edit backup."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: live\n")
+    (tmp_path / "config.yaml.bak").write_text("title: previous\n")
+    (tmp_path / "config.yaml.bak-v4").write_text("title: pre-migration\n")
+
+    names = [item["name"] for item in list_config_backups(str(cfg), limit=5)]
+
+    assert names == ["config.yaml.bak"]
+
+
+def test_restore_latest_backup_returns_immediately_previous_save(tmp_path):
+    """A -> B -> C then Restore Latest must land on B, not the rotated A."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: A\n")
+    with patch(_VALIDATE_PATCH, _no_errors):
+        apply_patch(str(cfg), {"title": "B"})
+        apply_patch(str(cfg), {"title": "C"})
+        assert yaml.safe_load(cfg.read_text())["title"] == "C"
+
+        restored, message = restore_latest_backup(str(cfg))
+
+    assert restored is True
+    assert "config.yaml.bak" in message
+    assert yaml.safe_load(cfg.read_text())["title"] == "B"
+
+
+def test_write_raw_yaml_rotations_within_one_second_keep_both_archives(tmp_path):
+    """Second-precision names collided, so a fast second save discarded an archive."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: A\n")
+    _write_raw_yaml(str(cfg), {"title": "B"})  # .bak = A
+    _write_raw_yaml(str(cfg), {"title": "C"})  # A rotates out, .bak = B
+    _write_raw_yaml(str(cfg), {"title": "D"})  # B rotates out, .bak = C
+
+    rotated = sorted(tmp_path.glob("config.yaml.bak.*"))
+    assert len(rotated) == 2
+    assert {yaml.safe_load(p.read_text())["title"] for p in rotated} == {"A", "B"}
+    assert yaml.safe_load((tmp_path / "config.yaml.bak").read_text())["title"] == "C"
+
+
+def test_rotated_backup_path_avoids_an_existing_name(tmp_path):
+    """Defensive suffix loop for a clock that repeats a microsecond."""
+    from src.web.config_editor import _rotated_backup_path
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("title: live\n")
+
+    first = _rotated_backup_path(cfg)
+    first.write_text("title: taken\n")
+    with patch("src.web.config_editor.datetime") as fake_dt:
+        fake_dt.now.return_value.strftime.return_value = first.name.split(".bak.")[1]
+        second = _rotated_backup_path(cfg)
+
+    assert second != first
+    assert second.name == f"{first.name}-1"
+
+
+# ---------------------------------------------------------------------------
 # /api/config HTTP routes — also mock validate_config
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What and why

Fixes #199. "Restore latest backup" could roll the config back two or more edits.

`list_config_backups()` sorted filenames in reverse lexicographic order, and `config.yaml.bak.<timestamp>` sorts *after* the shorter `config.yaml.bak` — same prefix, longer string. So the rotated archive outranked the plain backup that `_write_raw_yaml()` guarantees is the snapshot from the immediately preceding save. After saves A → B → C, "Restore Latest" restored A. The backup list on the config page was mis-ordered for the same reason, despite `docs/web-ui.md` describing it as newest-first.

## Notes for the reviewer

**Why the plain `.bak` ranks first unconditionally, rather than sorting everything by mtime.** The issue offered either as an acceptance criterion. Sorting purely by mtime is correct in practice — rotation is a `replace()`, i.e. a rename, so the archive carries its original mtime along — but it inherits the filesystem's timestamp resolution, and the three files in a fresh test run can land in the same tick. The rotation invariant is a hard guarantee from the writer, so the plain `.bak` leads and mtime only orders the archives behind it, with the embedded name timestamp breaking ties. That makes the A → B → C case deterministic rather than resolution-dependent.

The `limit` was applied *during* the directory scan, so it truncated the raw scan order rather than the ranked list; it now applies after ranking.

**One thing the issue didn't mention.** `config.yaml.bak-v4` pre-migration backups (written by `src/config_migrations.py`) match the same `config.yaml.bak*` glob. They were listed as ordinary edit backups and were restorable — which would roll the config back to an older *schema*, not just an older edit. They're now excluded. Flagging it because it widens the diff slightly beyond the reported bug, and it's a judgement call worth a second opinion.

The rotation-collision half of the issue is fixed as suggested: microsecond precision, with a suffix loop behind it for a clock that repeats.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate — 3072 passed, 37 skipped, 96.01% (gate 94%)
- [x] `venv/bin/python -m mypy src/` is clean — `Success: no issues found in 139 source files`
- [x] Tests added or updated for behaviour changes — 7 new, including the issue's exact A → B → C reproduction, a mixed plain/timestamped listing, limit-after-ordering, and the same-second rotation case

If the change touches **themes, components, or anything that renders**:

- [x] N/A — no rendering code touched; theme pixel hashes unchanged

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs: no change needed — `docs/web-ui.md` already documents "newest first" and "Restore the most recent backup". The docs described the intent; the code was what disagreed
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

If the change adds a **config option**: N/A

If the change affects **architecture or contributor workflow**: N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_016nRGdMbiNS6a5NSTt2WgAU)_