### PR TITLE
Point README at the plumpbug.dev project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ sudo reboot
 - [Architecture](docs/architecture.md) for internals and design decisions
 - [Contributing](CONTRIBUTING.md) for contribution-specific guidance
 
+### Elsewhere
+
+There's also a project landing page at
+[plumpbug.dev/homedashboard](https://plumpbug.dev/homedashboard/home.html), maintained in
+the separate [`gkoch02/plumpbug-site`](https://github.com/gkoch02/plumpbug-site) repo
+alongside the other Plumpbug-family projects. This repo stays the source of truth for the
+theme preview PNGs that page embeds (`assets/previews/theme_<name>.png`); re-copy them
+there if the themes are re-rendered.
+
 ## Quick Checks
 
 After setup, these are the main operator commands:


### PR DESCRIPTION
## What and why

Adds a pointer in README.md to the Home Dashboard landing page at plumpbug.dev, maintained in the separate `gkoch02/plumpbug-site` repo. This repo had no reference to it at all, while the sibling `BetweenUs` and `Nightdraft` repos already cross-reference that site. Part of a pass across the Plumpbug-family repos (`plumpbug-site`, `BetweenUs`, `HomeDashboard`, `Idle-Hours`, `Nightdraft`) checking that READMEs and CLAUDE.mds are correct and reference each other where appropriate.

## Notes for the reviewer

Docs-only change (one new "Elsewhere" section in README.md, no code touched). Verified against `plumpbug-site`'s actual `docs/homedashboard/` contents and its `CLAUDE.md`, which already documents this repo as the source of truth for the `assets/previews/theme_<name>.png` files that page embeds.

## Checklist

Not applicable — README-only change, no code/tests/config/themes touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZpqMonSmmNoTm2MqMv6oc)_