### PR TITLE
test: close the four largest coverage gaps; route weatherglass state through _io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **The weatherglass pressure history goes through `atomic_write_json`.**
+  `_save_pressure_sample` hand-rolled its own `mkstemp` + `os.replace` instead
+  of the shared helper in `src/_io.py`, which is documented as the only
+  sanctioned way to persist JSON state from the renderer. The helper re-raises
+  where this call site must swallow, so the `try`/`except` stays local and the
+  contract is unchanged: history bookkeeping never breaks a render. The
+  rendered plate is byte-identical, so no snapshot baselines moved.
+- **The four largest test-coverage gaps are closed.** Overall coverage was
+  96%, but the misses were concentrated rather than diffuse:
+  `weatherglass_panel` sat at 70% with 60% of every missed statement in the
+  repo and was the only substantive module never referenced by name from a
+  test — its rolling pressure history and every metric/standard unit branch
+  had no protection at all. Also covered now: the deepest tier of the ICS
+  recurrence-expansion fallback, and the event stream's cross-process `fcntl`
+  lock, which had only ever been tested through the fallback taken when
+  `fcntl` is absent. Three `week_view` tests that named a visual behaviour and
+  then asserted only that the plate was non-blank now measure the thing they
+  describe. Coverage is ~98%.
+
 - **A lapsed One Call subscription is now visible.** A 401/403 from an
   unsubscribed One Call version was handled identically to a read timeout:
   one `DEBUG` line and no other trace. The degradation contract is unchanged —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ ruff format src/ tests/                        # Format (direct invocation)
 - **PyYAML** — config parsing
 - **numpy** — Inky palette quantization (`src/render/quantize.py` fast path) and Inky `show()`/`clear()` buffer assembly (`src/display/driver.py`); declared in core `dependencies`
 - **Flask 3 + Waitress** — optional web UI (`requirements-web.txt`; `pip install -e ".[web]"`)
-- **pytest** — testing (with unittest.mock); coverage via **pytest-cov** (gate: ≥94%, currently ~96%); theme pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`
+- **pytest** — testing (with unittest.mock); coverage via **pytest-cov** (gate: ≥94%, currently ~98%); theme pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`
 - **ruff** — linting and formatting (max line length: 100)
 - **AST-based custom guard** in `tools/check_naive_datetime.py` enforces aware-datetime discipline; CI runs it via `tests/test_naive_datetime_guard.py`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ When changing any of these areas, update the canonical docs in the same PR:
 - Use `tmp_path` for temporary files.
 - Do not make real network calls in tests.
 - Add or update documentation checks when you introduce a new exhaustive list.
-- Coverage is enforced at ≥94% via `pytest-cov` (`fail_under` in `pyproject.toml`); current coverage is ~96%. Run `make coverage` to see missing lines and an HTML report at `htmlcov/index.html`. New defensive branches should ship with tests.
+- Coverage is enforced at ≥94% via `pytest-cov` (`fail_under` in `pyproject.toml`); current coverage is ~98%. Run `make coverage` to see missing lines and an HTML report at `htmlcov/index.html`. New defensive branches should ship with tests.
 - Theme changes shift the pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`. If the diff is intentional, regenerate with `UPDATE_SNAPSHOTS=1 pytest tests/test_theme_pixel_snapshots.py` and commit the updated JSON alongside the source change. Adding a new theme also requires a fresh baseline — the coverage guard test fails without one.
 
 ## PR Checklist

--- a/src/render/components/weatherglass_panel.py
+++ b/src/render/components/weatherglass_panel.py
@@ -30,13 +30,12 @@ from __future__ import annotations
 
 import json
 import math
-import os
-import tempfile
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from PIL import Image, ImageDraw
 
+from src._io import atomic_write_json
 from src.astronomy import sun_times
 from src.data.models import AirQualityData, DashboardData, WeatherAlert, WeatherData
 from src.render.artkit import grey as _grey
@@ -203,20 +202,11 @@ def _save_pressure_sample(state_dir: str | None, current_hpa: float | None, now:
                 pass
     samples.append({"ts": now_utc.isoformat(), "hPa": float(current_hpa)})
     samples = samples[-_MAX_SAMPLES:]
-    payload = json.dumps({"samples": samples})
     try:
-        fd, tmp_name = tempfile.mkstemp(
-            prefix=".weatherglass_pressure_", suffix=".tmp", dir=str(path.parent)
-        )
-        try:
-            with os.fdopen(fd, "w") as fh:
-                fh.write(payload)
-            os.replace(tmp_name, path)
-        except OSError:
-            try:
-                os.unlink(tmp_name)
-            except OSError:
-                pass
+        # The shared helper is the only sanctioned way to persist JSON state
+        # here; it cleans up its own tempfile and re-raises, so the swallow
+        # stays local — history bookkeeping must never break a render.
+        atomic_write_json(path, {"samples": samples})
     except OSError:
         return
 

--- a/tests/test_ical_edge_cases.py
+++ b/tests/test_ical_edge_cases.py
@@ -773,3 +773,135 @@ class TestRunawaySeriesCap:
             "RRULE:FREQ=HOURLY\r\nEND:VEVENT\r\n"
         )
         assert len(self._fetch(mock_get, hourly)) == 168
+
+
+class TestExpansionFallbackTiers:
+    """The expansion has three tiers; the deepest one had no test.
+
+    1. ``recurring_ical_events.of(cal).between(...)`` for the whole feed.
+    2. On failure, ``_expand_one_by_one`` retries each component alone so one
+       poisoned series costs only itself.
+    3. If that *also* raises, the raw walk returns the unexpanded VEVENTs.
+
+    Tier 3 is the one with the worst blast radius — every recurring series in
+    the feed silently reverts to first-week-only — so it is worth pinning that
+    it recovers the events rather than raising or returning nothing.
+
+    Note tier 2 swallows per-component failures internally and appends the
+    offending VEVENT unexpanded, so a broken *series* never reaches tier 3.
+    Only a failure in tier 2's own scaffolding does.
+    """
+
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_feed_wide_failure_falls_through_to_per_event(self, mock_get):
+        """Tier 1 → tier 2: the series still expands."""
+        mock_get.return_value = _mock_response(_make_ical_response(_WEEKLY_SERIES))
+
+        real_module = sys.modules.get("recurring_ical_events")
+        assert real_module is not None, "recurring-ical-events must be installed"
+
+        class FeedWideBoom:
+            """Fails the whole-feed call, delegates per-component calls."""
+
+            calls = 0
+
+            @staticmethod
+            def of(cal, *args, **kwargs):
+                FeedWideBoom.calls += 1
+                if FeedWideBoom.calls == 1:
+                    raise RuntimeError("feed-wide expansion exploded")
+                return real_module.of(cal, *args, **kwargs)
+
+        with patch.dict(sys.modules, {"recurring_ical_events": FeedWideBoom}):
+            events = fetch_from_ical(
+                ["https://example.com/cal.ics"], days=7, start_date=date(2026, 4, 6)
+            )
+
+        assert [e.summary for e in events] == ["Weekly Standup"]
+        assert events[0].start.date() == date(2026, 4, 6)
+        assert FeedWideBoom.calls > 1, "tier 2 must have been attempted"
+
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_per_event_tier_keeps_a_broken_series_unexpanded(self, mock_get):
+        """Tier 2 absorbs a component that cannot expand at all.
+
+        It appends the raw VEVENT instead of propagating, which is why a
+        malformed series alone never reaches tier 3.
+        """
+        mock_get.return_value = _mock_response(_make_ical_response(_WEEKLY_SERIES))
+
+        class AlwaysBoom:
+            @staticmethod
+            def of(cal, *args, **kwargs):
+                raise RuntimeError("expansion exploded")
+
+        with patch.dict(sys.modules, {"recurring_ical_events": AlwaysBoom}):
+            events = fetch_from_ical(
+                ["https://example.com/cal.ics"], days=7, start_date=date(2025, 1, 6)
+            )
+
+        # Unexpanded, so only the series' own DTSTART week survives filtering.
+        assert [e.summary for e in events] == ["Weekly Standup"]
+        assert events[0].start.date() == date(2025, 1, 6)
+
+    @patch("src.fetchers.calendar_ical._expand_one_by_one")
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_tier_three_raw_walk_recovers_the_events(self, mock_get, mock_one_by_one):
+        """Tier 3: tier 2's scaffolding itself fails, so fall back to the raw walk."""
+        mock_get.return_value = _mock_response(_make_ical_response(_WEEKLY_SERIES))
+        mock_one_by_one.side_effect = RuntimeError("per-event scaffolding exploded")
+
+        class AlwaysBoom:
+            @staticmethod
+            def of(cal, *args, **kwargs):
+                raise RuntimeError("feed-wide expansion exploded")
+
+        with patch.dict(sys.modules, {"recurring_ical_events": AlwaysBoom}):
+            events = fetch_from_ical(
+                ["https://example.com/cal.ics"], days=7, start_date=date(2025, 1, 6)
+            )
+
+        assert mock_one_by_one.called
+        assert [e.summary for e in events] == ["Weekly Standup"]
+        assert events[0].start.date() == date(2025, 1, 6)
+
+    @patch("src.fetchers.calendar_ical._expand_one_by_one")
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_tier_three_logs_the_reason(self, mock_get, mock_one_by_one, caplog):
+        """A silent revert to first-week-only is the failure mode #212 fixed;
+        the log line is how an operator notices it happened."""
+        mock_get.return_value = _mock_response(_make_ical_response(_WEEKLY_SERIES))
+        mock_one_by_one.side_effect = RuntimeError("per-event scaffolding exploded")
+
+        class AlwaysBoom:
+            @staticmethod
+            def of(cal, *args, **kwargs):
+                raise RuntimeError("feed-wide expansion exploded")
+
+        with patch.dict(sys.modules, {"recurring_ical_events": AlwaysBoom}):
+            with caplog.at_level("WARNING"):
+                fetch_from_ical(
+                    ["https://example.com/cal.ics"], days=7, start_date=date(2025, 1, 6)
+                )
+
+        assert any("using raw events" in r.getMessage() for r in caplog.records)
+
+    @patch("src.fetchers.calendar_ical._expand_one_by_one")
+    @patch("src.fetchers.calendar_ical.requests.get")
+    def test_tier_three_never_raises_out_of_the_fetch(self, mock_get, mock_one_by_one):
+        """Whatever happens in expansion, a fetch degrades — it never crashes
+        the render."""
+        mock_get.return_value = _mock_response(_make_ical_response(_WEEKLY_SERIES))
+        mock_one_by_one.side_effect = RuntimeError("per-event scaffolding exploded")
+
+        class AlwaysBoom:
+            @staticmethod
+            def of(cal, *args, **kwargs):
+                raise RuntimeError("feed-wide expansion exploded")
+
+        with patch.dict(sys.modules, {"recurring_ical_events": AlwaysBoom}):
+            events = fetch_from_ical(
+                ["https://example.com/cal.ics"], days=7, start_date=date(2026, 4, 6)
+            )
+        # Out-of-window raw events are filtered out, leaving an empty list.
+        assert events == []

--- a/tests/test_weatherglass_panel.py
+++ b/tests/test_weatherglass_panel.py
@@ -685,16 +685,42 @@ class TestPanelPressureIntegration:
 
     def test_rising_and_falling_trends_differ(self, tmp_path):
         """Rising is drawn green / falling blue on Inky — they must not
-        collapse to the same plate."""
+        collapse to the same plate.
+
+        Both plates render at the *same* current pressure, so the primary
+        needle is identical and only the trend needle can account for the
+        difference. Seeding different current pressures would let this pass
+        on the primary needle alone, even with the trend needle removed.
+        """
+        current = 1013.0
         rising_dir = tmp_path / "rising"
         falling_dir = tmp_path / "falling"
         for d in (rising_dir, falling_dir):
             d.mkdir()
-        self._draw_at(rising_dir, 1000.0, NOW_UTC - timedelta(hours=6))
-        self._draw_at(falling_dir, 1030.0, NOW_UTC - timedelta(hours=6))
-        rising = self._draw_at(rising_dir, 1020.0, NOW_UTC)
-        falling = self._draw_at(falling_dir, 1000.0, NOW_UTC)
+
+        # Histories on opposite sides of the same current reading.
+        self._draw_at(rising_dir, current - 20.0, NOW_UTC - timedelta(hours=6))
+        self._draw_at(falling_dir, current + 20.0, NOW_UTC - timedelta(hours=6))
+
+        rising = self._draw_at(rising_dir, current, NOW_UTC)
+        falling = self._draw_at(falling_dir, current, NOW_UTC)
         assert rising.tobytes() != falling.tobytes()
+
+    def test_steady_trend_differs_from_a_moving_one(self, tmp_path):
+        """A delta inside ±1.0 hPa reads as steady and takes the ink colour
+        rather than the rising/falling accent."""
+        current = 1013.0
+        steady_dir = tmp_path / "steady"
+        moving_dir = tmp_path / "moving"
+        for d in (steady_dir, moving_dir):
+            d.mkdir()
+
+        self._draw_at(steady_dir, current - 0.5, NOW_UTC - timedelta(hours=6))
+        self._draw_at(moving_dir, current - 20.0, NOW_UTC - timedelta(hours=6))
+
+        steady = self._draw_at(steady_dir, current, NOW_UTC)
+        moving = self._draw_at(moving_dir, current, NOW_UTC)
+        assert steady.tobytes() != moving.tobytes()
 
     def test_repeated_ticks_do_not_grow_the_history(self, tmp_path):
         """The default timer fires every 5 minutes."""

--- a/tests/test_weatherglass_panel.py
+++ b/tests/test_weatherglass_panel.py
@@ -1,0 +1,723 @@
+"""Tests for the weatherglass theme and weatherglass_panel component.
+
+The panel is the largest component in the tree and carries two clusters of
+logic that nothing else in the render layer has:
+
+* a rolling pressure history persisted to ``state/`` — the only on-disk state
+  written by a component — with malformed-file recovery, an append gap, a
+  sample cap, and an atomic write;
+* five unit-aware scale functions that decide the thermometer range, the
+  comfort band, the freeze/hot thresholds, and the wind label.
+
+Both were previously exercised only incidentally through the pixel-snapshot
+suite, which renders every theme at a single pinned moment under imperial
+units — so the metric and standard branches and every pressure-history path
+had no regression protection.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from PIL import Image, ImageDraw
+
+from src.config import DisplayConfig
+from src.data.models import (
+    AirQualityData,
+    DashboardData,
+    WeatherAlert,
+    WeatherData,
+)
+from src.dummy_data import generate_dummy_data
+from src.render.canvas import render_dashboard
+from src.render.components.weatherglass_panel import (
+    _MAX_SAMPLES,
+    _MIN_APPEND_GAP,
+    _PRESSURE_FILE,
+    _TREND_MAX_AGE,
+    _TREND_MIN_AGE,
+    _fmt_clock,
+    _load_prev_pressure,
+    _pressure_to_angle,
+    _save_pressure_sample,
+    _temp_cold_threshold,
+    _temp_comfort_band,
+    _temp_hot_threshold,
+    _temp_scale,
+    _wind_unit_label,
+    draw_weatherglass,
+)
+from src.render.theme import AVAILABLE_THEMES, ComponentRegion, ThemeStyle, load_theme
+
+FIXED_NOW = datetime(2026, 4, 6, 10, 30)
+TODAY = FIXED_NOW.date()
+NOW_UTC = datetime(2026, 4, 6, 10, 30, tzinfo=timezone.utc)
+
+
+def _render(**kwargs):
+    data = generate_dummy_data(now=FIXED_NOW)
+    theme = load_theme("weatherglass")
+    return render_dashboard(data, DisplayConfig(), theme=theme, **kwargs)
+
+
+def _weather(**overrides) -> WeatherData:
+    base = dict(
+        current_temp=64.0,
+        current_icon="01d",
+        current_description="clear sky",
+        high=72.0,
+        low=51.0,
+        humidity=55,
+        wind_speed=8.0,
+        wind_deg=270.0,
+        pressure=1013.0,
+        uv_index=4.0,
+        location_name="New York",
+        units="imperial",
+    )
+    base.update(overrides)
+    return WeatherData(**base)
+
+
+def _canvas(mode: str = "L", size: tuple[int, int] = (1600, 960)):
+    bg = 255 if mode != "RGB" else (255, 255, 255)
+    img = Image.new(mode, size, bg)
+    return img, ImageDraw.Draw(img)
+
+
+def _style(mode: str = "L") -> ThemeStyle:
+    if mode == "RGB":
+        return ThemeStyle(fg=(0, 0, 0), bg=(255, 255, 255))
+    return ThemeStyle(fg=0, bg=255)
+
+
+def _history(path) -> list[dict]:
+    return json.loads(path.read_text())["samples"]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherglassRegistration:
+    def test_in_available_themes(self):
+        assert "weatherglass" in AVAILABLE_THEMES
+
+    def test_load_theme(self):
+        assert load_theme("weatherglass").name == "weatherglass"
+
+    def test_region_is_supersampled_canvas(self):
+        layout = load_theme("weatherglass").layout
+        assert layout.weatherglass.visible is True
+        # 2× supersample; the backend resizes to display resolution via LANCZOS.
+        assert (layout.weatherglass.w, layout.weatherglass.h) == (1600, 960)
+
+    def test_threshold_quantization_not_dithering(self):
+        """Every shaded zone is hand-stippled, so the plate must not dither.
+
+        Floyd-Steinberg would turn the antialiased instrument rims into
+        speckle instead of snapping them to solid black.
+        """
+        assert load_theme("weatherglass").layout.preferred_quantization_mode == "threshold"
+
+
+# ---------------------------------------------------------------------------
+# Unit-aware scales
+# ---------------------------------------------------------------------------
+
+
+class TestUnitAwareScales:
+    @pytest.mark.parametrize(
+        "units,lo,hi,symbol",
+        [
+            ("imperial", 0.0, 110.0, "°F"),
+            ("metric", -20.0, 45.0, "°C"),
+            ("standard", 253.0, 318.0, "K"),
+            (None, 0.0, 110.0, "°F"),
+            ("nonsense", 0.0, 110.0, "°F"),
+        ],
+    )
+    def test_temp_scale(self, units, lo, hi, symbol):
+        got_lo, got_hi, got_symbol, ticks = _temp_scale(units)
+        assert (got_lo, got_hi, got_symbol) == (lo, hi, symbol)
+        assert ticks == sorted(ticks), "major ticks must ascend"
+        assert lo <= ticks[0] and ticks[-1] <= hi, "ticks must sit inside the scale"
+
+    @pytest.mark.parametrize(
+        "units,expected",
+        [
+            ("imperial", (60.0, 75.0)),
+            ("metric", (16.0, 24.0)),
+            ("standard", (289.15, 297.15)),
+            (None, (60.0, 75.0)),
+        ],
+    )
+    def test_comfort_band(self, units, expected):
+        assert _temp_comfort_band(units) == expected
+
+    @pytest.mark.parametrize(
+        "units,cold,hot",
+        [
+            ("imperial", 32.0, 85.0),
+            ("metric", 0.0, 30.0),
+            ("standard", 273.15, 303.15),
+            (None, 32.0, 85.0),
+        ],
+    )
+    def test_freeze_and_hot_thresholds(self, units, cold, hot):
+        assert _temp_cold_threshold(units) == cold
+        assert _temp_hot_threshold(units) == hot
+
+    @pytest.mark.parametrize("units", ["imperial", "metric", "standard", None])
+    def test_thresholds_are_ordered_within_scale(self, units):
+        """cold < comfort band < hot, and all of it inside the drawn scale.
+
+        A threshold outside the scale range would silently clamp to the end of
+        the thermometer and read as a permanently freezing (or boiling) day.
+        """
+        lo, hi, _, _ = _temp_scale(units)
+        cold = _temp_cold_threshold(units)
+        hot = _temp_hot_threshold(units)
+        comf_lo, comf_hi = _temp_comfort_band(units)
+        assert lo < cold < comf_lo < comf_hi < hot < hi
+
+    @pytest.mark.parametrize(
+        "units,label",
+        [
+            ("imperial", "mph"),
+            ("metric", "m/s"),
+            ("standard", "m/s"),
+            (None, "mph"),
+        ],
+    )
+    def test_wind_unit_label(self, units, label):
+        assert _wind_unit_label(units) == label
+
+    def test_scales_are_equivalent_across_unit_systems(self):
+        """The three scales must describe the same physical temperatures.
+
+        Otherwise a metric user's comfort band sits at a different real
+        temperature than an imperial user's, and the instrument lies.
+        """
+
+        def f_to_c(f):
+            return (f - 32) * 5 / 9
+
+        imp_cold = _temp_cold_threshold("imperial")
+        assert f_to_c(imp_cold) == pytest.approx(_temp_cold_threshold("metric"), abs=0.1)
+        assert f_to_c(imp_cold) + 273.15 == pytest.approx(_temp_cold_threshold("standard"), abs=0.1)
+
+        imp_lo, imp_hi = _temp_comfort_band("imperial")
+        met_lo, met_hi = _temp_comfort_band("metric")
+        assert f_to_c(imp_lo) == pytest.approx(met_lo, abs=1.0)
+        assert f_to_c(imp_hi) == pytest.approx(met_hi, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Pressure history — load
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPrevPressure:
+    def test_no_state_dir_returns_empty(self):
+        assert _load_prev_pressure(None, NOW_UTC) == (None, None)
+        assert _load_prev_pressure("", NOW_UTC) == (None, None)
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _load_prev_pressure(str(tmp_path), NOW_UTC) == (None, None)
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        (tmp_path / _PRESSURE_FILE).write_text("{not json")
+        assert _load_prev_pressure(str(tmp_path), NOW_UTC) == (None, None)
+
+    @pytest.mark.parametrize("blob", ["[]", '"a string"', "42", '{"samples": {}}', "{}"])
+    def test_non_dict_and_non_list_shapes_return_empty(self, tmp_path, blob):
+        (tmp_path / _PRESSURE_FILE).write_text(blob)
+        assert _load_prev_pressure(str(tmp_path), NOW_UTC) == (None, None)
+
+    def test_reads_sample_inside_the_trend_window(self, tmp_path):
+        ts = NOW_UTC - timedelta(hours=6)
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1008.0}]})
+        )
+        prev, got_ts = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1008.0
+        assert got_ts == ts
+
+    @pytest.mark.parametrize(
+        "age,expected",
+        [
+            (timedelta(minutes=30), None),  # younger than _TREND_MIN_AGE
+            (_TREND_MIN_AGE, 1008.0),  # inclusive lower bound
+            (timedelta(hours=12), 1008.0),
+            (_TREND_MAX_AGE, 1008.0),  # inclusive upper bound
+            (timedelta(hours=48), None),  # older than _TREND_MAX_AGE
+        ],
+    )
+    def test_trend_window_bounds(self, tmp_path, age, expected):
+        """A too-fresh sample makes the trend needle jitter; a too-old one
+        makes it report weather from two days ago."""
+        ts = NOW_UTC - age
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1008.0}]})
+        )
+        prev, _ = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == expected
+
+    def test_prefers_the_oldest_in_window_sample(self, tmp_path):
+        """The trend is most legible against the furthest-back valid reading."""
+        samples = [
+            {"ts": (NOW_UTC - timedelta(hours=2)).isoformat(), "hPa": 1011.0},
+            {"ts": (NOW_UTC - timedelta(hours=20)).isoformat(), "hPa": 1002.0},
+            {"ts": (NOW_UTC - timedelta(hours=8)).isoformat(), "hPa": 1006.0},
+        ]
+        (tmp_path / _PRESSURE_FILE).write_text(json.dumps({"samples": samples}))
+        prev, ts = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1002.0
+        assert ts == datetime.fromisoformat(samples[1]["ts"])
+
+    def test_skips_unusable_entries_but_keeps_reading(self, tmp_path):
+        """One corrupt row must not discard the rest of the history."""
+        good_ts = NOW_UTC - timedelta(hours=5)
+        samples = [
+            "not a dict",
+            {"ts": 12345, "hPa": 1000.0},  # ts not a string
+            {"ts": (NOW_UTC - timedelta(hours=9)).isoformat(), "hPa": "high"},
+            {"ts": "not-a-timestamp", "hPa": 1000.0},
+            {"hPa": 1000.0},  # no ts
+            {"ts": good_ts.isoformat()},  # no hPa
+            {"ts": good_ts.isoformat(), "hPa": 1004.0},
+        ]
+        (tmp_path / _PRESSURE_FILE).write_text(json.dumps({"samples": samples}))
+        prev, ts = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1004.0
+        assert ts == good_ts
+
+    def test_naive_stored_timestamp_is_read_as_utc(self, tmp_path):
+        """Legacy rows written without an offset must not be read as local
+        time — on a UTC-7 host that would shift every sample by 7 hours."""
+        ts = (NOW_UTC - timedelta(hours=6)).replace(tzinfo=None)
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1007.0}]})
+        )
+        prev, _ = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1007.0
+
+    def test_naive_now_is_treated_as_utc(self, tmp_path):
+        ts = NOW_UTC - timedelta(hours=6)
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1009.0}]})
+        )
+        prev, _ = _load_prev_pressure(str(tmp_path), NOW_UTC.replace(tzinfo=None))
+        assert prev == 1009.0
+
+    def test_offset_aware_now_is_normalised(self, tmp_path):
+        """A caller in UTC-7 must resolve the same sample as a UTC caller."""
+        ts = NOW_UTC - timedelta(hours=6)
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1005.0}]})
+        )
+        local_now = NOW_UTC.astimezone(timezone(timedelta(hours=-7)))
+        prev, _ = _load_prev_pressure(str(tmp_path), local_now)
+        assert prev == 1005.0
+
+    def test_integer_pressure_is_accepted(self, tmp_path):
+        ts = NOW_UTC - timedelta(hours=4)
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": ts.isoformat(), "hPa": 1010}]})
+        )
+        prev, _ = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1010.0
+        assert isinstance(prev, float)
+
+
+# ---------------------------------------------------------------------------
+# Pressure history — save
+# ---------------------------------------------------------------------------
+
+
+class TestSavePressureSample:
+    def test_no_state_dir_is_a_noop(self):
+        _save_pressure_sample(None, 1013.0, NOW_UTC)  # must not raise
+
+    def test_none_pressure_is_not_recorded(self, tmp_path):
+        _save_pressure_sample(str(tmp_path), None, NOW_UTC)
+        assert not (tmp_path / _PRESSURE_FILE).exists()
+
+    def test_creates_state_dir_and_file(self, tmp_path):
+        target = tmp_path / "nested" / "state"
+        _save_pressure_sample(str(target), 1013.0, NOW_UTC)
+        samples = _history(target / _PRESSURE_FILE)
+        assert samples == [{"ts": NOW_UTC.isoformat(), "hPa": 1013.0}]
+
+    def test_appends_when_the_gap_is_wide_enough(self, tmp_path):
+        _save_pressure_sample(str(tmp_path), 1010.0, NOW_UTC - timedelta(hours=6))
+        _save_pressure_sample(str(tmp_path), 1015.0, NOW_UTC)
+        samples = _history(tmp_path / _PRESSURE_FILE)
+        assert [s["hPa"] for s in samples] == [1010.0, 1015.0]
+
+    @pytest.mark.parametrize(
+        "gap,appended",
+        [
+            (timedelta(minutes=5), False),
+            (_MIN_APPEND_GAP - timedelta(seconds=1), False),
+            (_MIN_APPEND_GAP, True),
+            (timedelta(hours=1), True),
+        ],
+    )
+    def test_min_append_gap(self, tmp_path, gap, appended):
+        """The renderer ticks every 5 minutes; without the gap the history
+        would hold 12 near-identical samples an hour and the trend window
+        would only ever span the last few minutes."""
+        _save_pressure_sample(str(tmp_path), 1010.0, NOW_UTC)
+        _save_pressure_sample(str(tmp_path), 1020.0, NOW_UTC + gap)
+        samples = _history(tmp_path / _PRESSURE_FILE)
+        assert len(samples) == (2 if appended else 1)
+
+    def test_trims_to_the_sample_cap(self, tmp_path):
+        existing = [
+            {"ts": (NOW_UTC - timedelta(hours=200 - i)).isoformat(), "hPa": 1000.0 + i}
+            for i in range(120)
+        ]
+        (tmp_path / _PRESSURE_FILE).write_text(json.dumps({"samples": existing}))
+        _save_pressure_sample(str(tmp_path), 1099.0, NOW_UTC)
+        samples = _history(tmp_path / _PRESSURE_FILE)
+        assert len(samples) == _MAX_SAMPLES
+        assert samples[-1]["hPa"] == 1099.0, "the newest sample must survive the trim"
+
+    def test_malformed_existing_file_is_replaced_not_propagated(self, tmp_path):
+        (tmp_path / _PRESSURE_FILE).write_text("{corrupt")
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        assert _history(tmp_path / _PRESSURE_FILE) == [{"ts": NOW_UTC.isoformat(), "hPa": 1013.0}]
+
+    def test_non_dict_rows_are_dropped_on_rewrite(self, tmp_path):
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": ["junk", 5, {"ts": "bad", "hPa": 1000.0}]})
+        )
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        samples = _history(tmp_path / _PRESSURE_FILE)
+        assert all(isinstance(s, dict) for s in samples)
+        assert samples[-1]["hPa"] == 1013.0
+
+    def test_unparseable_last_timestamp_does_not_block_the_append(self, tmp_path):
+        (tmp_path / _PRESSURE_FILE).write_text(
+            json.dumps({"samples": [{"ts": "not-a-timestamp", "hPa": 1000.0}]})
+        )
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        assert len(_history(tmp_path / _PRESSURE_FILE)) == 2
+
+    def test_naive_now_is_persisted_as_aware_utc(self, tmp_path):
+        """Every persisted timestamp in the tree is aware, so that subtracting
+        it from an aware now never raises TypeError."""
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC.replace(tzinfo=None))
+        ts = _history(tmp_path / _PRESSURE_FILE)[0]["ts"]
+        assert datetime.fromisoformat(ts).tzinfo is not None
+
+    def test_unwritable_state_dir_degrades_silently(self, tmp_path):
+        """History bookkeeping must never break a render."""
+        blocker = tmp_path / "state"
+        blocker.write_text("i am a file, not a directory")
+        _save_pressure_sample(str(blocker), 1013.0, NOW_UTC)  # must not raise
+
+    def test_write_leaves_no_temp_files_behind(self, tmp_path):
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name != _PRESSURE_FILE]
+        assert leftovers == []
+
+    def test_failed_rename_cleans_up_its_temp_file(self, tmp_path, monkeypatch):
+        """The write goes through the shared atomic_write_json helper, which
+        re-raises; the panel swallows it locally so a render still completes."""
+        import src._io as io_module
+
+        def _boom(*args, **kwargs):
+            raise OSError("rename failed")
+
+        monkeypatch.setattr(io_module.os, "replace", _boom)
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)  # must not raise
+        assert list(tmp_path.iterdir()) == [], "temp file must not be orphaned"
+
+    def test_uses_the_shared_atomic_write_helper(self, tmp_path, monkeypatch):
+        """src/_io.py is the sanctioned way to persist JSON state here."""
+        import src.render.components.weatherglass_panel as wg
+
+        calls = []
+        real = wg.atomic_write_json
+
+        def _spy(path, data, **kwargs):
+            calls.append((path, data))
+            return real(path, data, **kwargs)
+
+        monkeypatch.setattr(wg, "atomic_write_json", _spy)
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        assert len(calls) == 1
+        assert calls[0][1]["samples"][0]["hPa"] == 1013.0
+
+    def test_round_trip_through_load(self, tmp_path):
+        _save_pressure_sample(str(tmp_path), 1004.0, NOW_UTC - timedelta(hours=6))
+        _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
+        prev, ts = _load_prev_pressure(str(tmp_path), NOW_UTC)
+        assert prev == 1004.0
+        assert ts == NOW_UTC - timedelta(hours=6)
+
+
+# ---------------------------------------------------------------------------
+# Dial mapping
+# ---------------------------------------------------------------------------
+
+
+class TestPressureToAngle:
+    def test_rising_pressure_sweeps_left_to_right(self):
+        assert _pressure_to_angle(950.0) > _pressure_to_angle(1013.0)
+        assert _pressure_to_angle(1013.0) > _pressure_to_angle(1050.0)
+
+    def test_stays_in_the_top_hemisphere(self):
+        for p in (800.0, 950.0, 1013.0, 1050.0, 1200.0):
+            assert 0.0 <= _pressure_to_angle(p) <= 180.0
+
+    def test_clamps_out_of_range_pressures(self):
+        """A sensor spike must pin the needle at the rail, not spin it."""
+        assert _pressure_to_angle(500.0) == _pressure_to_angle(900.0)
+        assert _pressure_to_angle(2000.0) == _pressure_to_angle(1100.0)
+
+
+class TestFmtClock:
+    def test_formats_in_the_supplied_zone(self):
+        dt = datetime(2026, 4, 6, 18, 5, tzinfo=timezone.utc)
+        assert _fmt_clock(dt, timezone(timedelta(hours=-5))) == "1:05p"
+
+    def test_naive_datetime_is_formatted_as_given(self):
+        assert _fmt_clock(datetime(2026, 4, 6, 6, 30), None) == "6:30a"
+
+
+# ---------------------------------------------------------------------------
+# Panel rendering across data shapes
+# ---------------------------------------------------------------------------
+
+
+class TestDrawWeatherglass:
+    def _draw(self, data, *, mode="L", **kwargs):
+        img, draw = _canvas(mode)
+        draw_weatherglass(
+            draw,
+            data,
+            TODAY,
+            FIXED_NOW,
+            image=img,
+            region=ComponentRegion(0, 0, 1600, 960),
+            style=_style(mode),
+            **kwargs,
+        )
+        return img
+
+    @pytest.mark.parametrize("units", ["imperial", "metric", "standard"])
+    def test_renders_in_every_unit_system(self, units):
+        temps = {"imperial": 64.0, "metric": 18.0, "standard": 291.0}[units]
+        data = DashboardData(weather=_weather(units=units, current_temp=temps))
+        img = self._draw(data)
+        assert img.getbbox() is not None
+
+    def test_unit_systems_produce_distinct_plates(self):
+        """The scale, comfort band and wind label all change with units — if
+        two systems hash identically the unit plumbing is not reaching the
+        instruments."""
+        plates = {}
+        for units, temp in (("imperial", 64.0), ("metric", 18.0), ("standard", 291.0)):
+            data = DashboardData(weather=_weather(units=units, current_temp=temp))
+            plates[units] = self._draw(data).tobytes()
+        assert len(set(plates.values())) == 3
+
+    def test_wind_label_matches_the_unit_system(self):
+        """mph vs m/s is drawn text, so the plates must differ on it alone."""
+        imperial = self._draw(DashboardData(weather=_weather(units="imperial")))
+        metric = self._draw(DashboardData(weather=_weather(units="metric")))
+        assert imperial.tobytes() != metric.tobytes()
+
+    def test_renders_without_weather(self):
+        assert self._draw(DashboardData()).getbbox() is not None
+
+    def test_renders_with_every_optional_field_missing(self):
+        data = DashboardData(
+            weather=_weather(
+                feels_like=None,
+                wind_speed=None,
+                wind_deg=None,
+                pressure=None,
+                uv_index=None,
+                location_name=None,
+                units=None,
+            )
+        )
+        assert self._draw(data).getbbox() is not None
+
+    def test_renders_with_air_quality(self):
+        data = DashboardData(
+            weather=_weather(),
+            air_quality=AirQualityData(aqi=142, category="Unhealthy", pm25=52.3),
+        )
+        assert self._draw(data).getbbox() is not None
+
+    @pytest.mark.parametrize("aqi", [0, 25, 75, 125, 175, 250, 400, 500])
+    def test_renders_across_the_aqi_scale(self, aqi):
+        """Each AQI band picks a different ring colour."""
+        data = DashboardData(
+            weather=_weather(),
+            air_quality=AirQualityData(aqi=aqi, category="X", pm25=float(aqi) / 4),
+        )
+        assert self._draw(data).getbbox() is not None
+
+    def test_alert_cartouche_overlays_the_plate(self):
+        plain = self._draw(DashboardData(weather=_weather()))
+        alerted = self._draw(
+            DashboardData(
+                weather=_weather(alerts=[WeatherAlert(event="Severe Thunderstorm Warning")])
+            )
+        )
+        assert plain.tobytes() != alerted.tobytes()
+
+    @pytest.mark.parametrize("temp", [-40.0, 0.0, 32.0, 64.0, 85.0, 110.0, 130.0])
+    def test_temperatures_beyond_the_scale_clamp(self, temp):
+        data = DashboardData(weather=_weather(current_temp=temp))
+        assert self._draw(data).getbbox() is not None
+
+    @pytest.mark.parametrize("deg", [0.0, 45.0, 90.0, 180.0, 270.0, 359.0])
+    def test_wind_compass_across_the_rose(self, deg):
+        data = DashboardData(weather=_weather(wind_deg=deg))
+        assert self._draw(data).getbbox() is not None
+
+    @pytest.mark.parametrize("uv", [0.0, 2.0, 5.5, 8.0, 11.0, 15.0])
+    def test_uv_bar_across_the_scale(self, uv):
+        data = DashboardData(weather=_weather(uv_index=uv))
+        assert self._draw(data).getbbox() is not None
+
+    def test_renders_on_rgb_for_inky(self):
+        data = DashboardData(weather=_weather())
+        assert self._draw(data, mode="RGB").getbbox() is not None
+
+    def test_polar_latitude_renders(self):
+        """Svalbard in April has no sunset — the sun arc must still draw."""
+        data = DashboardData(weather=_weather())
+        assert self._draw(data, latitude=78.2, longitude=15.6).getbbox() is not None
+
+    def test_unset_coordinates_fall_back_to_owm_times(self):
+        data = DashboardData(
+            weather=_weather(
+                sunrise=datetime(2026, 4, 6, 10, 30, tzinfo=timezone.utc),
+                sunset=datetime(2026, 4, 6, 23, 15, tzinfo=timezone.utc),
+            )
+        )
+        # Exact (0.0, 0.0) is the project-wide "unset" convention.
+        assert self._draw(data, latitude=0.0, longitude=0.0).getbbox() is not None
+
+    def test_defaults_are_supplied_when_region_and_style_are_omitted(self):
+        img, draw = _canvas("L", (800, 480))
+        draw_weatherglass(draw, DashboardData(weather=_weather()), TODAY, FIXED_NOW)
+        assert img.getbbox() is not None
+
+
+# ---------------------------------------------------------------------------
+# Pressure history integration through the panel
+# ---------------------------------------------------------------------------
+
+
+class TestPanelPressureIntegration:
+    def _draw_at(self, tmp_path, pressure, now):
+        img, draw = _canvas()
+        draw_weatherglass(
+            draw,
+            DashboardData(weather=_weather(pressure=pressure)),
+            now.date(),
+            now,
+            image=img,
+            region=ComponentRegion(0, 0, 1600, 960),
+            style=_style(),
+            state_dir=str(tmp_path),
+        )
+        return img
+
+    def test_render_records_a_sample(self, tmp_path):
+        self._draw_at(tmp_path, 1013.0, NOW_UTC)
+        assert _history(tmp_path / _PRESSURE_FILE) == [{"ts": NOW_UTC.isoformat(), "hPa": 1013.0}]
+
+    def test_no_state_dir_writes_nothing(self, tmp_path):
+        """--dry-run / --dummy pass state_dir=None so previews never persist."""
+        img, draw = _canvas()
+        draw_weatherglass(
+            draw,
+            DashboardData(weather=_weather()),
+            TODAY,
+            FIXED_NOW,
+            image=img,
+            region=ComponentRegion(0, 0, 1600, 960),
+            style=_style(),
+            state_dir=None,
+        )
+        assert list(tmp_path.iterdir()) == []
+
+    def test_missing_pressure_records_nothing(self, tmp_path):
+        self._draw_at(tmp_path, None, NOW_UTC)
+        assert not (tmp_path / _PRESSURE_FILE).exists()
+
+    def test_first_render_sees_no_trend(self, tmp_path):
+        """The lookup happens before the save, so a cold start must not read
+        back the sample it is about to write."""
+        with_history = self._draw_at(tmp_path, 1013.0, NOW_UTC)
+        fresh = tmp_path / "fresh"
+        fresh.mkdir()
+        without = self._draw_at(fresh, 1013.0, NOW_UTC)
+        assert with_history.tobytes() == without.tobytes()
+
+    @pytest.mark.parametrize(
+        "later_pressure,label",
+        [(1030.0, "rising"), (995.0, "falling"), (1013.4, "steady")],
+    )
+    def test_trend_needle_changes_the_plate(self, tmp_path, later_pressure, label):
+        """A prior sample in the window must visibly add a trend needle."""
+        self._draw_at(tmp_path, 1013.0, NOW_UTC - timedelta(hours=6))
+        with_trend = self._draw_at(tmp_path, later_pressure, NOW_UTC)
+
+        fresh = tmp_path / f"fresh_{label}"
+        fresh.mkdir()
+        without_trend = self._draw_at(fresh, later_pressure, NOW_UTC)
+        assert with_trend.tobytes() != without_trend.tobytes()
+
+    def test_rising_and_falling_trends_differ(self, tmp_path):
+        """Rising is drawn green / falling blue on Inky — they must not
+        collapse to the same plate."""
+        rising_dir = tmp_path / "rising"
+        falling_dir = tmp_path / "falling"
+        for d in (rising_dir, falling_dir):
+            d.mkdir()
+        self._draw_at(rising_dir, 1000.0, NOW_UTC - timedelta(hours=6))
+        self._draw_at(falling_dir, 1030.0, NOW_UTC - timedelta(hours=6))
+        rising = self._draw_at(rising_dir, 1020.0, NOW_UTC)
+        falling = self._draw_at(falling_dir, 1000.0, NOW_UTC)
+        assert rising.tobytes() != falling.tobytes()
+
+    def test_repeated_ticks_do_not_grow_the_history(self, tmp_path):
+        """The default timer fires every 5 minutes."""
+        for minute in range(0, 30, 5):
+            self._draw_at(tmp_path, 1013.0, NOW_UTC + timedelta(minutes=minute))
+        assert len(_history(tmp_path / _PRESSURE_FILE)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Full-theme rendering
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherglassTheme:
+    def test_renders_end_to_end(self):
+        img = _render()
+        assert img.size == (800, 480)
+        assert img.getbbox() is not None
+
+    def test_render_is_deterministic(self):
+        assert _render().tobytes() == _render().tobytes()
+
+    def test_dry_run_render_persists_no_state(self, tmp_path):
+        """render_dashboard defaults state_dir to None."""
+        _render()
+        assert list(tmp_path.iterdir()) == []

--- a/tests/test_web_event_store.py
+++ b/tests/test_web_event_store.py
@@ -409,3 +409,188 @@ class TestCrossProcessSafety:
         monkeypatch.undo()
 
         assert es.read_recent_events(str(tmp_path))[0]["message"] == "still recorded"
+
+
+# ---------------------------------------------------------------------------
+# Cross-process safety
+# ---------------------------------------------------------------------------
+
+
+def _append_burst(state_dir: str, tag: str, count: int, payload: str = "") -> None:
+    """Module-level so it is picklable by multiprocessing's spawn start method."""
+    from src.web.event_store import append_event
+
+    for i in range(count):
+        append_event(state_dir, "run_completed", f"{tag}-{i}", filler=payload)
+
+
+class TestCrossProcessAppends:
+    """The stream has two writers in production and they are separate processes.
+
+    Since #218 the renderer records run events here alongside the long-running
+    web service. The module-level ``threading.Lock`` orders writers inside one
+    process; only the ``fcntl`` sidecar lock orders them across two. These
+    tests exercise the real thing with real processes — the existing coverage
+    only tests the *fallback* taken when ``fcntl`` is unavailable.
+    """
+
+    @staticmethod
+    def _run(procs):
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=60)
+        for p in procs:
+            assert p.exitcode == 0, f"worker failed with exit code {p.exitcode}"
+
+    def test_concurrent_appends_lose_no_records(self, tmp_path):
+        import multiprocessing as mp
+
+        ctx = mp.get_context("spawn")
+        per_proc = 40
+        writers = 4
+        self._run(
+            [
+                ctx.Process(target=_append_burst, args=(str(tmp_path), f"p{n}", per_proc))
+                for n in range(writers)
+            ]
+        )
+
+        lines = (tmp_path / _EVENT_FILE).read_text().splitlines()
+        assert len(lines) == writers * per_proc
+
+    def test_concurrent_appends_produce_no_torn_lines(self, tmp_path):
+        """Every line must still parse as JSON.
+
+        Python's buffered I/O can split one record across several write()
+        syscalls, so without the lock two processes can interleave bytes inside
+        a single record. A long filler payload makes that far more likely.
+        """
+        import multiprocessing as mp
+
+        ctx = mp.get_context("spawn")
+        filler = "x" * 4096
+        self._run(
+            [
+                ctx.Process(target=_append_burst, args=(str(tmp_path), f"p{n}", 30, filler))
+                for n in range(4)
+            ]
+        )
+
+        lines = (tmp_path / _EVENT_FILE).read_text().splitlines()
+        assert len(lines) == 120
+        for line in lines:
+            record = json.loads(line)  # raises on a torn record
+            assert record["details"]["filler"] == filler
+
+    def test_appends_during_a_trim_are_not_dropped(self, tmp_path, monkeypatch):
+        """The trim is read-all → tempfile → rename.
+
+        Anything another process appends inside that window is lost to the
+        rename unless the lock covers the whole critical section. Seed the
+        stream past the trim threshold so every worker's first append triggers
+        a trim, then assert the newest records all survived.
+        """
+        import multiprocessing as mp
+
+        import src.web.event_store as es
+
+        seed = (
+            json.dumps(
+                {
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "kind": "seed",
+                    "message": "x" * 512,
+                    "details": {},
+                }
+            )
+            + "\n"
+        )
+        target = es._TRIM_THRESHOLD_BYTES // len(seed) + 50
+        (tmp_path / _EVENT_FILE).write_text(seed * target)
+        assert (tmp_path / _EVENT_FILE).stat().st_size > es._TRIM_THRESHOLD_BYTES
+
+        ctx = mp.get_context("spawn")
+        per_proc = 20
+        writers = 3
+        self._run(
+            [
+                ctx.Process(target=_append_burst, args=(str(tmp_path), f"p{n}", per_proc))
+                for n in range(writers)
+            ]
+        )
+
+        lines = (tmp_path / _EVENT_FILE).read_text().splitlines()
+        # The trim caps the stream: it keeps the newest _KEEP_EVENTS and each
+        # append that follows a trim adds one more on top.
+        assert len(lines) <= es._KEEP_EVENTS + writers * per_proc
+        records = [json.loads(line) for line in lines]
+        seeds = sum(1 for r in records if r["kind"] == "seed")
+        assert seeds < target, "the trim must actually have dropped old records"
+        # No writer's records may be swallowed by another writer's rename.
+        messages = {r["message"] for r in records}
+        for n in range(writers):
+            for i in range(per_proc):
+                assert f"p{n}-{i}" in messages
+
+    def test_trim_leaves_no_temp_files_behind(self, tmp_path):
+        """Two processes trimming at once must not orphan their tempfiles."""
+        import multiprocessing as mp
+
+        import src.web.event_store as es
+
+        seed = (
+            json.dumps(
+                {
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "kind": "seed",
+                    "message": "x" * 512,
+                    "details": {},
+                }
+            )
+            + "\n"
+        )
+        target = es._TRIM_THRESHOLD_BYTES // len(seed) + 50
+        (tmp_path / _EVENT_FILE).write_text(seed * target)
+
+        ctx = mp.get_context("spawn")
+        self._run(
+            [ctx.Process(target=_append_burst, args=(str(tmp_path), f"p{n}", 10)) for n in range(3)]
+        )
+
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+
+class TestTrimFailureHandling:
+    def test_failed_rename_cleans_up_and_does_not_break_the_append(self, tmp_path, monkeypatch):
+        """A stream that cannot be trimmed is still a stream that logs.
+
+        The trim re-raises so the caller can log it; the temp file must not be
+        left behind either way.
+        """
+        import src.web.event_store as es
+
+        seed = (
+            json.dumps(
+                {
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "kind": "seed",
+                    "message": "x" * 512,
+                    "details": {},
+                }
+            )
+            + "\n"
+        )
+        target = es._TRIM_THRESHOLD_BYTES // len(seed) + 50
+        path = tmp_path / _EVENT_FILE
+        path.write_text(seed * target)
+
+        def _boom(*args, **kwargs):
+            raise OSError("rename failed")
+
+        monkeypatch.setattr(es.os, "replace", _boom)
+        append_event(str(tmp_path), "run_completed", "trim exploded")  # must not raise
+
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == [], "a failed trim must not orphan its temp file"

--- a/tests/test_week_view.py
+++ b/tests/test_week_view.py
@@ -314,22 +314,52 @@ class TestDrawWeek:
         borderless_ink = sum(1 for px in flatten_pixels(borderless.crop(band)) if px == 0)
         assert bordered_ink > borderless_ink, "the underline must add ink under today"
 
-    def test_long_month_name_triggers_font_scale_down(self):
-        """A long month name (SEPTEMBER) in the terminal theme forces the scale-down loop."""
+    @staticmethod
+    def _unscaled_month_width(theme, name):
+        """Width of *name* at the band's starting 33px size, before any shrink."""
+        probe = ImageDraw.Draw(Image.new("1", (10, 10), 1))
+        bbox = probe.textbbox((0, 0), name, font=theme.style.font_month_title(33))
+        return bbox[2] - bbox[0]
+
+    def test_long_month_name_is_scaled_down_to_fit_the_cell(self):
+        """SEPTEMBER overflows the combined Sat/Sun date cell at the starting
+        33px size, so week_view's shrink loop must bring it back inside.
+
+        Measured against the cell, not against a short month: SEPTEMBER has
+        three times MAY's letters and is legitimately wider on the plate even
+        after shrinking. The property that matters is that it *fits*.
+        """
         from src.render.theme import load_theme
 
-        img, draw = self._make_draw()
         theme = load_theme("terminal")
-        # September in the combined Sat/Sun date cell is wider than the default
-        # 33px uesc_display glyph run — forces week_view's month-font shrink loop.
-        long_month = self._month_band(theme, date(2026, 9, 16))  # SEPTEMBER
-        short_month = self._month_band(theme, date(2026, 5, 13))  # MAY
+        cell_w = theme.layout.week_view.w // 7 * 2  # last two columns, merged
 
-        # The band is redrawn at a smaller size rather than overflowing, so the
-        # long name must still fit inside the cell the short one occupies.
-        assert long_month is not None and short_month is not None
-        assert long_month[2] <= short_month[2], (
-            "SEPTEMBER must be scaled down to fit the combined date cell, not drawn wider than MAY"
+        assert self._unscaled_month_width(theme, "SEPTEMBER") > cell_w, (
+            "fixture no longer exercises the shrink loop — pick a longer month"
+        )
+
+        band = self._month_band(theme, date(2026, 9, 16))
+        assert band is not None, "the month band must actually be drawn"
+        assert band[2] <= cell_w, (
+            f"SEPTEMBER renders {band[2]}px wide in a {cell_w}px cell — "
+            f"the font shrink loop did not bring it inside"
+        )
+
+    def test_short_month_name_is_not_scaled_down(self):
+        """MAY already fits, so the shrink loop must leave it at full size."""
+        from src.render.theme import load_theme
+
+        theme = load_theme("terminal")
+        unscaled = self._unscaled_month_width(theme, "MAY")
+        cell_w = theme.layout.week_view.w // 7 * 2
+        assert unscaled <= cell_w, "MAY should fit without shrinking"
+
+        band = self._month_band(theme, date(2026, 5, 13))
+        assert band is not None
+        # Drawn ink is a few px narrower than the advance-width probe.
+        assert band[2] >= unscaled - 8, (
+            f"MAY renders {band[2]}px against a {unscaled}px unscaled width — "
+            f"it was shrunk when it did not need to be"
         )
 
     @staticmethod
@@ -351,7 +381,11 @@ class TestDrawWeek:
             region.x + region.w,
             region.y + region.h,
         )
-        bbox = img.crop(band).getbbox()
+        # getbbox() finds *non-zero* pixels, and in mode "1" the blank canvas
+        # is all 1s — so it would return the full crop even with nothing drawn.
+        # Invert first so the measurement tracks ink.
+        ink = img.crop(band).point(lambda v: 0 if v else 1, mode="1")
+        bbox = ink.getbbox()
         if bbox is None:
             return None
         return (bbox[0], bbox[1], bbox[2] - bbox[0])

--- a/tests/test_week_view.py
+++ b/tests/test_week_view.py
@@ -13,6 +13,7 @@ from src.render.components.week_view import (
     _fonts_for_tier,
     draw_week,
 )
+from src.render.quantize import flatten_pixels
 
 # ---------------------------------------------------------------------------
 # _fmt_time
@@ -204,14 +205,61 @@ class TestDrawWeek:
         draw_week(draw, events, today)
         assert img.getbbox() is not None
 
-    def test_today_column_highlighted(self):
-        """Today's column uses an inverted header — verify black pixels exist."""
-        today = date(2024, 3, 15)
+    @staticmethod
+    def _header_ink_by_column(img, region=None):
+        """Ink fraction of each of the 7 day-header cells.
+
+        ``img.getbbox() is not None`` is true of any non-blank plate, so it
+        cannot tell an inverted today column from a missing one. Measuring the
+        header band per column can.
+        """
+        from src.render.layout import WEEK_H, WEEK_W, WEEK_X, WEEK_Y
+
+        x0, y0, w, h = region or (WEEK_X, WEEK_Y, WEEK_W, WEEK_H)
+        header_h = max(24, h * 32 // 320)
+        col_w = w // 7
+        fractions = []
+        for col in range(7):
+            cell = img.crop((x0 + col * col_w, y0, x0 + col * col_w + col_w, y0 + header_h))
+            pixels = flatten_pixels(cell)
+            fractions.append(sum(1 for px in pixels if px == 0) / len(pixels))
+        return fractions
+
+    def test_today_column_header_is_inverted(self):
+        """Today's header cell is filled with fg, so it is mostly ink.
+
+        Asserted against the other six columns rather than in absolute terms,
+        so the test survives font and padding changes.
+        """
+        today = date(2024, 3, 15)  # a Friday → column index 4 (Monday-first)
         img, draw = self._make_draw()
         draw_week(draw, [], today)
-        # There must be at least one black pixel (inverted today header)
-        bbox = img.getbbox()
-        assert bbox is not None
+
+        ink = self._header_ink_by_column(img)
+        assert ink[4] == max(ink), "today's header must be the most-inked column"
+        others = [v for i, v in enumerate(ink) if i != 4]
+        assert ink[4] > 0.5, "an inverted cell should be more than half ink"
+        assert ink[4] > 2 * max(others), "today must stand out from the other days"
+
+    def test_today_highlight_tracks_the_date(self):
+        """The highlight follows today rather than being drawn at a fixed column."""
+        for offset, expected_col in ((0, 0), (2, 2), (6, 6)):
+            img, draw = self._make_draw()
+            monday = date(2024, 3, 11)
+            draw_week(draw, [], monday + timedelta(days=offset))
+            ink = self._header_ink_by_column(img)
+            assert ink.index(max(ink)) == expected_col
+
+    def test_invert_today_col_false_leaves_the_header_light(self):
+        """Turning the inversion off must actually remove the filled cell."""
+        from src.render.theme import ThemeStyle
+
+        today = date(2024, 3, 15)
+        img, draw = self._make_draw()
+        draw_week(draw, [], today, style=ThemeStyle(invert_today_col=False))
+
+        ink = self._header_ink_by_column(img)
+        assert ink[4] < 0.5, "the today cell must not be filled when inversion is off"
 
     def test_smoke_with_forecast_icons(self):
         """draw_week with forecast data should not crash."""
@@ -232,20 +280,39 @@ class TestDrawWeek:
         assert img.getbbox() is not None
 
     def test_today_bordered_not_inverted_draws_underline(self):
-        """invert_today_col=False + show_borders=True → thick accent underline under today."""
+        """invert_today_col=False + show_borders=True → thick accent underline under today.
+
+        Compared against the borderless variant of the same plate, so the
+        assertion is about the underline itself and not about the plate merely
+        being non-blank.
+        """
         from src.render.theme import ComponentRegion, ThemeStyle
 
-        img, draw = self._make_draw()
-        today = date(2026, 4, 22)  # a Wednesday
-        style = ThemeStyle(invert_today_col=False, show_borders=True)
-        draw_week(
-            draw,
-            [],
-            today,
-            region=ComponentRegion(0, 40, 800, 400),
-            style=style,
-        )
-        assert img.getbbox() is not None
+        today = date(2026, 4, 22)  # a Wednesday → column index 2
+        region = ComponentRegion(0, 40, 800, 400)
+
+        def _render(show_borders):
+            img, draw = self._make_draw()
+            draw_week(
+                draw,
+                [],
+                today,
+                region=region,
+                style=ThemeStyle(invert_today_col=False, show_borders=show_borders),
+            )
+            return img
+
+        bordered = _render(True)
+        borderless = _render(False)
+        assert bordered.tobytes() != borderless.tobytes()
+
+        # The extra ink lands in today's column, in the band just under the header.
+        header_h = max(24, region.h * 32 // 320)
+        col_w = region.w // 7
+        band = (2 * col_w, region.y + header_h - 6, 3 * col_w, region.y + header_h + 6)
+        bordered_ink = sum(1 for px in flatten_pixels(bordered.crop(band)) if px == 0)
+        borderless_ink = sum(1 for px in flatten_pixels(borderless.crop(band)) if px == 0)
+        assert bordered_ink > borderless_ink, "the underline must add ink under today"
 
     def test_long_month_name_triggers_font_scale_down(self):
         """A long month name (SEPTEMBER) in the terminal theme forces the scale-down loop."""
@@ -255,14 +322,39 @@ class TestDrawWeek:
         theme = load_theme("terminal")
         # September in the combined Sat/Sun date cell is wider than the default
         # 33px uesc_display glyph run — forces week_view's month-font shrink loop.
-        draw_week(
-            draw,
-            [],
-            date(2026, 9, 16),
-            region=theme.layout.week_view,
-            style=theme.style,
+        long_month = self._month_band(theme, date(2026, 9, 16))  # SEPTEMBER
+        short_month = self._month_band(theme, date(2026, 5, 13))  # MAY
+
+        # The band is redrawn at a smaller size rather than overflowing, so the
+        # long name must still fit inside the cell the short one occupies.
+        assert long_month is not None and short_month is not None
+        assert long_month[2] <= short_month[2], (
+            "SEPTEMBER must be scaled down to fit the combined date cell, not drawn wider than MAY"
         )
-        assert img.getbbox() is not None
+
+    @staticmethod
+    def _month_band(theme, day):
+        """Bounding box of the ink in the month band, as (x0, y0, width)."""
+        img = Image.new("1", (800, 480), 1)
+        draw = ImageDraw.Draw(img)
+        region = theme.layout.week_view
+        draw_week(draw, [], day, region=region, style=theme.style)
+
+        header_h = max(24, region.h * 32 // 320)
+        body_h = region.h - header_h
+        date_section_h = body_h // 2
+        col_w = region.w // 7
+        # Combined Sat/Sun date cell: the last two columns, lower half of body.
+        band = (
+            5 * col_w,
+            region.y + header_h + body_h - date_section_h,
+            region.x + region.w,
+            region.y + region.h,
+        )
+        bbox = img.crop(band).getbbox()
+        if bbox is None:
+            return None
+        return (bbox[0], bbox[1], bbox[2] - bbox[0])
 
     def test_smoke_spanning_event_excludes_from_per_day(self):
         """Multi-day spanning events don't crash and render as bars."""


### PR DESCRIPTION
## What and why

Coverage was 96.11%, comfortably over the 94% gate — but the misses were concentrated rather than diffuse, and the headline number was hiding that. This closes the four largest gaps and fixes a handful of tests that named a behaviour without checking it.

Coverage 96.11% → **97.64%**; 3,425 → 3,558 tests.

| File | Before | After |
|---|---|---|
| `weatherglass_panel.py` | 70% | **93%** |
| `calendar_ical.py` | 96% | 98% |
| `web/event_store.py` | 94% | 98% |

**`tests/test_weatherglass_panel.py`** (new, 121 tests). `weatherglass_panel.py` held 219 missed statements — 60% of every miss in the repo — and was the only substantive module in `src/` never referenced by name from a test. Two clusters had no protection at all: the rolling pressure history (the only on-disk state written by a component) and every metric/standard branch of the five unit-aware scale functions. The theme was only ever rendered under imperial, so a metric user's thermometer scale, comfort band, freeze/hot thresholds and wind label were entirely unexercised.

**ICS expansion fallback.** The deepest of the three tiers was untested — the one whose blast radius is every recurring series in the feed silently reverting to first-week-only.

**Cross-process event store.** The stream has had two writers in separate processes since #218, but every test was thread-only and the one `fcntl` test covered the *fallback* taken when `fcntl` is absent, not the lock.

**`week_view` assertions.** Three tests asserted only `img.getbbox() is not None`, which is true of any non-blank plate — they passed whether or not the feature they named existed.

**`_save_pressure_sample`** hand-rolled `mkstemp` + `os.replace` instead of the shared `atomic_write_json`, which `CLAUDE.md` documents as the only sanctioned way to persist JSON state from the renderer.

## Notes for the reviewer

**No bugs found — this is unprotected working code, not broken code.** Every path I covered behaves correctly today; I verified each by hand before writing the test. The value here is regression protection, not fixes.

**Two things the investigation turned up that changed what I wrote:**

*The ICS tiers aren't what the missing line numbers implied.* Tier 2 (`_expand_one_by_one`) catches per-component failures and appends the VEVENT unexpanded — it never re-raises. So a malformed *series* can never reach tier 3; only a failure in tier 2's own scaffolding does. My first draft asserted it was exercising tier 3 when it was really hitting tier 2's internal rescue. The tests now drive the real path and the class docstring records the distinction so the next reader doesn't repeat the mistake.

*The `data_pipeline.py:317–321` gap is dead code, not a missing test.* `Fetcher.save_metadata` defaults to the `_no_metadata` callable and is never `None`, so the guard above that `else` is vacuous and the branch is unreachable for any registered fetcher. **I left it alone deliberately** — it's cleanup either way (delete it, or the guard meant `is not _no_metadata`), behaviour is identical today under both since `_metadata_always_valid` returns `True`, but picking one is your call and I didn't want to touch a cache path on a guess.

**The new tests are verified to have teeth.** Assertion strength was one of the findings, so I checked rather than assumed:

- Removing the cross-process `fcntl` lock fails two of the new event-store tests, catching both the torn-record and the trim-drop failure modes.
- Removing the today-column inversion fails two of the rewritten `week_view` tests. The originals passed with the feature deleted.

**The refactor is pixel-neutral and I confirmed it rather than assuming.** The weatherglass plate hashes identically before and after (`86cf927b8d18…`), so no snapshot baselines moved. Sequencing was deliberate: the pressure-history tests landed first, including one for the swallow-on-failure contract, so the refactor was covered before it happened. `atomic_write_json` re-raises where this call site must swallow, hence the local `try`/`except` rather than a bare call.

**Scope I did not take.** ~370 weak assertions remain elsewhere (heaviest in `test_weather_full_component`, `test_weather_panel`, `test_air_quality_panel`). I fixed only the three whose names actively mislead; the rest is a much larger judgment-heavy sweep, better done file by file. The remaining `weatherglass_panel` misses are deep drawing internals where a pixel assertion would be brittle.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate (3,558 passed; 97.64% vs. the 94% gate)
- [x] `python -m mypy src/` is clean — "Success: no issues found in 143 source files"
- [x] Tests added or updated for behaviour changes

If the change touches **themes, components, or anything that renders**:

- [x] Pixel-hash baselines regenerated and committed — **not needed**: the refactor is pixel-neutral, so no baseline moved
- [x] Preview PNGs regenerated for any theme whose appearance changed — **not needed**: no theme's appearance changed
- [x] If a refactor was meant to be pixel-neutral, the unrelated theme hashes are confirmed **unchanged** — verified by rendering `weatherglass` on both sides of the change; byte-identical

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs updated per the Docs Update Policy — no new theme, fetcher or config option, so no inventory change
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

If the change adds a **config option**: n/a — none added.

If the change affects **architecture or contributor workflow**:

- [x] `CLAUDE.md` and `CONTRIBUTING.md` updated — both quoted a now-stale "~96%" coverage figure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019k8tBGuB5wFz41LES5qH9e

---
_Generated by [Claude Code](https://claude.ai/code/session_019k8tBGuB5wFz41LES5qH9e)_