### PR TITLE
Give the render tests assertions that can fail (#229), and fix the unreachable cache branch (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **The staleness badge is no longer dropped when the forecast is empty.** With
+  the forecast strip enabled but no forecast data and no weather alerts,
+  `draw_weather` returned at its `n_cols == 0` early exit before reaching the
+  staleness call at the end of the function — so the "!" badge was silently
+  skipped in precisely the degraded state it exists to announce, an empty
+  forecast usually being a symptom of the stale fetch itself. The parallel
+  no-forecast-strip early return already drew it. (#229)
 - **A malformed `theme_rules` threshold no longer crashes the dashboard.** A
   YAML list or mapping for `temp_at_least` / `temp_at_most` / `aqi_at_least`
   reached `int()`/`float()` as a `TypeError`, which escaped `load_config()` and
@@ -68,6 +75,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **Two dead component parameters removed.** `draw_week` accepted a `forecast`
+  argument it never read, and `draw_air_quality_full` accepted a `today` it
+  threaded two levels down to a function that takes its day names from the
+  forecast entries instead. Both were being fed by the component registry on
+  every render. No rendered output changes. (#229)
+- **The render tests now assert what they claim to.** The suites had settled on
+  `assert img.getbbox() is not None`, which on a white 1-bit plate reports the
+  bounds of non-zero pixels and so returns the full canvas whether or not
+  anything was drawn — whole files passed with their draw function stubbed to a
+  no-op. All 60 such assertions are gone, replaced by per-region ink
+  measurements and differential comparisons, with the shared helpers in
+  `tests/inkutils.py`. The weak-assertion count is down from 403 of 3238 tests
+  to 73. (#229)
+- **`_cache_is_recent` no longer guards on a callable default.** The check
+  `fetcher.save_metadata is not None` was always true — `save_metadata`
+  defaults to a function, not `None` — leaving the branch behind it
+  unreachable, and incoherent besides: it fell through to an `interval_map`
+  lookup that would have raised `KeyError` for the very sources it claimed to
+  serve. Behaviour is unchanged. (#228)
 - **The weatherglass pressure history goes through `atomic_write_json`.**
   `_save_pressure_sample` hand-rolled its own `mkstemp` + `os.replace` instead
   of the shared helper in `src/_io.py`, which is documented as the only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,9 @@ docs/
 ├── upgrading-from-v3.md       # Migration guide from v3
 └── upgrading-from-v4.md       # Migration guide from v4 → v5
 
-tests/                         # test files, extensive mocking
+tests/                         # test files, extensive mocking; `inkutils.py` holds the shared
+                               #   pixel-measurement helpers for render tests (not collected — it is
+                               #   not a `test_*.py`)
 tools/                         # check_naive_datetime.py — AST guard enforcing aware-datetime discipline
 fonts/                         # Bundled TTF fonts
 deploy/                        # Systemd service + timer + configure.sh + logrotate
@@ -295,6 +297,8 @@ The cooldown is `display.min_refresh_interval_seconds` (config), defaulting to 6
 - **Config mirrors YAML**: dataclass hierarchy in `config.py` matches YAML structure; all fields optional with defaults
 - **Max line length**: 100 characters
 - **Testing**: heavy use of `unittest.mock.patch`; fixtures for temp dirs and dummy data; every public render function has dedicated smoke tests plus logic unit tests. Coverage gate is `fail_under = 94` in `pyproject.toml` (`[tool.coverage.report]`). Run `make coverage` to print missing lines and write an HTML report to `htmlcov/`. `src/_version.py` and `src/main.py` are omitted from coverage
+- **Render-test assertions**: measure ink, never `Image.getbbox()`. On the white mode-`"1"` plates these tests build, `getbbox()` reports the bounds of *non-zero* pixels — every pixel — so it returns the full canvas whether or not anything was drawn, and an `assert img.getbbox() is not None` has no failing input. The suite had 60 of them; whole files passed with their draw function stubbed to a no-op (#229). Use the helpers in `tests/inkutils.py`: `marks()` (pixels differing from the background — the only form that works across all four canvas polarities here: white `"1"`, white `"L"`, black `"L"`, and the mid-grey moon-render plate), plus `ink()`, `ink_bbox()`, `ink_x_extent()`, `text_line_heights()` and `ink_clusters()`. Two traps to know: **polarity** — the header, weather, environment and quote bands are inverted (`filled_rect` in `fg` with text knocked out in `bg`), so there *more content means less ink*; and **style** — a panel that draws white-on-black (`constellation_map`, `moonphase`) must be rendered with its own theme style, since the default `ThemeStyle` has `fg=0` and leaves the plate essentially blank. Prefer differential assertions (render with and without the feature, compare the band it owns) over hardcoded pixel counts, which font and padding changes invalidate
+- **Verify a render test by deleting what it names**: write the assertion, delete the behaviour it is named for, and confirm it goes red before trusting it. This is not optional diligence — it is the step that works. During #229 it caught a rewritten assertion that was still vacuous (the AQI clamp is invisible on a 1-bit plate, so the test passed with `min(aqi, _AQI_MAX)` deleted) and four fixtures that did not match how the code is really invoked, including an all-day event built with a `date` start that an earlier `isinstance` guard rejects before the guard under test is reached. A test that asserts something is *not* drawn cannot detect a no-op by construction; check those by breaking the suppression instead
 - **Thread safety**: cache operations use `threading.Lock()`
 - **Graceful degradation**: fetch failure → load cached → use stale data → staleness indicator in header
 - **Error boundaries**: credential loading failures, malformed API responses, and cache write errors are caught and logged without crashing the app. A top-level `try/except` in `DashboardApp.run()` writes `output/last_error.txt` (read by the web UI for "is the last run current?") and re-raises so the failure propagates to systemd

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -291,34 +291,34 @@ class DataPipeline:
         if self.force_refresh:
             return None, False
         fetcher = get_fetcher(source)
-        if fetcher is not None and fetcher.save_metadata is not None:
-            cached_with_meta = load_cached_source_with_metadata_from_blob(source, self._cache_blob)
-            if cached_with_meta is None:
-                return None, False
-            data, cached_at, metadata = cached_with_meta
-            if not fetcher.cache_metadata_valid(metadata, self._fetch_context()):
-                # Events-style window mismatch — log helpful detail without
-                # forcing every fetcher to surface its own log.
-                if source == "events":
-                    requested_start = (
-                        self.event_window_start.isoformat()
-                        if self.event_window_start is not None
-                        else None
-                    )
-                    logger.info(
-                        "events cache window mismatch; cached=(%s, %s) requested=(%s, %s), "
-                        "refetching",
-                        metadata.get("window_start"),
-                        metadata.get("window_days"),
-                        requested_start,
-                        self.event_window_days,
-                    )
-                return None, False
-        else:
-            cached = load_cached_source_from_blob(source, self._cache_blob)
-            if cached is None:
-                return None, False
-            data, cached_at = cached
+        # Type narrowing only: get_fetcher returns Fetcher | None, and the
+        # metadata call below needs a Fetcher. Not a behavioural branch —
+        # every caller reaches this via all_fetchers(), and an unregistered
+        # source would fail the blob decode two lines down anyway (its
+        # deserialize lives on the same missing fetcher).
+        if fetcher is None:
+            return None, False
+        cached_with_meta = load_cached_source_with_metadata_from_blob(source, self._cache_blob)
+        if cached_with_meta is None:
+            return None, False
+        data, cached_at, metadata = cached_with_meta
+        if not fetcher.cache_metadata_valid(metadata, self._fetch_context()):
+            # Events-style window mismatch — log helpful detail without
+            # forcing every fetcher to surface its own log.
+            if source == "events":
+                requested_start = (
+                    self.event_window_start.isoformat()
+                    if self.event_window_start is not None
+                    else None
+                )
+                logger.info(
+                    "events cache window mismatch; cached=(%s, %s) requested=(%s, %s), refetching",
+                    metadata.get("window_start"),
+                    metadata.get("window_days"),
+                    requested_start,
+                    self.event_window_days,
+                )
+            return None, False
         age_minutes = (self.fetched_at - cached_at).total_seconds() / 60
         interval = self.interval_map[source]
         if age_minutes < interval:

--- a/src/render/components/_builtins.py
+++ b/src/render/components/_builtins.py
@@ -65,7 +65,6 @@ def _week_view(ctx: RenderContext) -> None:
         ctx.draw,
         ctx.data.events,
         ctx.today,
-        forecast=ctx.data.weather.forecast if ctx.data.weather else None,
         region=ctx.layout.week_view,
         style=ctx.style,
     )
@@ -192,7 +191,6 @@ def _air_quality_full(ctx: RenderContext) -> None:
     air_quality_panel.draw_air_quality_full(
         ctx.draw,
         ctx.data,
-        ctx.today,
         region=ctx.layout.air_quality_full,
         style=ctx.style,
     )

--- a/src/render/components/air_quality_panel.py
+++ b/src/render/components/air_quality_panel.py
@@ -35,8 +35,6 @@ Layout (800 × 480):
 
 from __future__ import annotations
 
-from datetime import date
-
 from PIL import ImageDraw
 
 from src.data.models import AirQualityData, DashboardData, WeatherData
@@ -82,7 +80,6 @@ def _aqi_accent(style: ThemeStyle, aqi: int) -> Fill:
 def draw_air_quality_full(
     draw: ImageDraw.ImageDraw,
     data: DashboardData,
-    today: date | None = None,
     *,
     region: ComponentRegion | None = None,
     style: ThemeStyle | None = None,
@@ -125,7 +122,7 @@ def draw_air_quality_full(
     _draw_pm_row(draw, aq, x0, pm_top, W, pm_h, style)
     if has_ambient:
         _draw_ambient_cards(draw, aq, x0, cards_top, W, cards_h, style)
-    _draw_weather_strip(draw, data.weather, today, x0, weather_top, W, weather_h, style)
+    _draw_weather_strip(draw, data.weather, x0, weather_top, W, weather_h, style)
 
 
 # ---------------------------------------------------------------------------
@@ -427,7 +424,6 @@ def _draw_ambient_cards(
 def _draw_weather_strip(
     draw: ImageDraw.ImageDraw,
     wx: WeatherData | None,
-    today: date | None,
     x0: int,
     y0: int,
     W: int,
@@ -458,7 +454,7 @@ def _draw_weather_strip(
     vline(draw, forecast_x, y0 + 8, y0 + H - 8, fill=fg)
 
     _draw_current_conditions(draw, wx, x0, y0, current_w, H, style)
-    _draw_forecast_columns(draw, wx, today, forecast_x, y0, forecast_w, H, style)
+    _draw_forecast_columns(draw, wx, forecast_x, y0, forecast_w, H, style)
 
 
 def _draw_current_conditions(
@@ -519,7 +515,6 @@ def _draw_current_conditions(
 def _draw_forecast_columns(
     draw: ImageDraw.ImageDraw,
     wx: WeatherData,
-    today: date | None,
     x0: int,
     y0: int,
     W: int,

--- a/src/render/components/weather_panel.py
+++ b/src/render/components/weather_panel.py
@@ -240,6 +240,12 @@ def draw_weather(
         show_aqi_col = False
 
     if n_cols == 0:
+        # No forecast and no alerts — nothing to column up, but the staleness
+        # badge still has to be emitted here, exactly as the no-forecast-strip
+        # early return above does. An empty forecast is itself usually a
+        # symptom of the stale fetch the badge exists to announce.
+        if staleness in (StalenessLevel.STALE, StalenessLevel.EXPIRED):
+            draw_staleness_glyph(draw, region, style)
         return
 
     col_w = w // n_cols

--- a/src/render/components/week_view.py
+++ b/src/render/components/week_view.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 
 from PIL import ImageDraw
 
-from src.data.models import CalendarEvent, DayForecast
+from src.data.models import CalendarEvent
 from src.render import layout as L
 from src.render.primitives import (
     dashed_vline,
@@ -97,7 +97,6 @@ def draw_week(
     draw: ImageDraw.ImageDraw,
     events: list[CalendarEvent],
     today: date,
-    forecast: list[DayForecast] | None = None,
     *,
     region: ComponentRegion | None = None,
     style: ThemeStyle | None = None,

--- a/tests/inkutils.py
+++ b/tests/inkutils.py
@@ -1,0 +1,116 @@
+"""Pixel-measurement helpers shared by the render-component tests.
+
+Why this exists (#229)
+----------------------
+The render suites used to assert ``img.getbbox() is not None``. On the plates
+these tests build that assertion has no failing input: ``getbbox`` reports the
+bounds of *non-zero* pixels, so on a white mode-``"1"`` canvas (filled with 1)
+it returns the full canvas whether or not anything was drawn. Whole files
+passed with their draw function stubbed to a no-op.
+
+These helpers replace it. ``marks`` is the general form — pixels differing
+from the background — which is the only one that works across the four canvas
+polarities in this suite: white ``"1"``, white ``"L"``, black ``"L"``, and the
+mid-grey plate used by the moon-render tests. ``ink`` is the common special
+case of zero-valued pixels on a light plate.
+
+Watch the polarity when writing assertions. On an *inverted* band — a
+filled_rect in ``fg`` with its text knocked out in ``bg`` — more content means
+*less* ink, so "more data draws more" is backwards there.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from src.render.quantize import flatten_pixels
+
+Box = tuple[int, int, int, int]
+
+
+def _pixels(img: Image.Image):
+    return flatten_pixels(img), img.width
+
+
+def marks(img: Image.Image, box: Box | None = None, background=None) -> int:
+    """Count pixels differing from *background*, optionally inside *box*.
+
+    *background* defaults to the value at (0, 0), which is the canvas fill for
+    every plate in this suite. Pass it explicitly when the corner is drawn on.
+    """
+    px, width = _pixels(img)
+    if background is None:
+        background = px[0]
+    if box is None:
+        return sum(1 for v in px if v != background)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] != background)
+
+
+def ink(img: Image.Image, box: Box | None = None) -> int:
+    """Count ink (value-0) pixels — the light-plate special case of `marks`."""
+    px, width = _pixels(img)
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def ink_bbox(img: Image.Image, box: Box | None = None):
+    """Bounding box of ink as (x0, y0, x1, y1), or None if there is none.
+
+    The honest replacement for ``Image.getbbox()`` on a light plate.
+    """
+    px, width = _pixels(img)
+    x0, y0, x1, y1 = box if box else (0, 0, img.width, img.height)
+    xs, ys = [], []
+    for y in range(y0, y1):
+        row = y * width
+        for x in range(x0, x1):
+            if px[row + x] == 0:
+                xs.append(x)
+                ys.append(y)
+    if not xs:
+        return None
+    return (min(xs), min(ys), max(xs) + 1, max(ys) + 1)
+
+
+def ink_x_extent(img: Image.Image, box: Box):
+    """(left, right) x-extent of ink inside *box*, or None if there is none."""
+    px, width = _pixels(img)
+    x0, y0, x1, y1 = box
+    xs = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+def text_line_heights(img: Image.Image, box: Box, min_h: int = 3) -> list[int]:
+    """Heights of the horizontal bands of ink inside *box*.
+
+    One band per rendered text line; each band's height tracks the font size,
+    which is how "this was set larger" becomes measurable.
+    """
+    px, width = _pixels(img)
+    x0, y0, x1, y1 = box
+    hot = [any(px[y * width + x] == 0 for x in range(x0, x1)) for y in range(y0, y1)]
+    runs: list[int] = []
+    start = None
+    for i, is_hot in enumerate(hot):
+        if is_hot and start is None:
+            start = i
+        elif not is_hot and start is not None:
+            if i - start >= min_h:
+                runs.append(i - start)
+            start = None
+    if start is not None and len(hot) - start >= min_h:
+        runs.append(len(hot) - start)
+    return runs
+
+
+def ink_clusters(img: Image.Image, box: Box, min_gap: int = 12) -> int:
+    """Count horizontally separated groups of ink — e.g. forecast columns."""
+    px, width = _pixels(img)
+    x0, y0, x1, y1 = box
+    cols = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    if not cols:
+        return 0
+    return 1 + sum(1 for p, q in zip(cols, cols[1:]) if q - p > min_gap)

--- a/tests/test_air_quality_panel.py
+++ b/tests/test_air_quality_panel.py
@@ -19,15 +19,18 @@ panel is actually *for* rather than that it drew something:
   the reading and clamp at 500.
 
 Verification (the step that makes the rewrite worth anything): with
-``draw_air_quality_full`` stubbed to a no-op, 42 of the 52 tests here fail.
-Of the 10 survivors, 7 are ``TestAirQualityTheme`` cases that exercise the
-theme factory and never draw through this entry point. The other three
-assert an equivalence, which two blank plates satisfy by construction —
-``test_returns_none``, ``test_default_region_and_style`` and
-``test_today_does_not_affect_the_panel``. Each was checked the other way
-instead, by breaking what it names (returning a value, defaulting to a
-different region, making ``today`` alter the output) and confirming it goes
-red. If you add a test here, do the same before you trust it.
+``draw_air_quality_full`` stubbed to a no-op, most of the tests here fail.
+The survivors are the ``TestAirQualityTheme`` cases, which exercise the
+theme factory and never draw through this entry point, plus two that assert
+an equivalence which two blank plates satisfy by construction —
+``test_returns_none`` and ``test_default_region_and_style``. Both were
+checked the other way instead, by breaking what they name (returning a
+value; defaulting to a different region) and confirming they go red. If you
+add a test here, do the same before you trust it.
+
+A third such test, ``test_today_does_not_affect_the_panel``, is gone: it
+pinned a ``today`` parameter that this panel accepted and never read, and
+that parameter has since been removed.
 """
 
 from datetime import date, timedelta
@@ -160,7 +163,6 @@ def _scale_bar_crop_greyscale(aqi: int):
     draw_air_quality_full(
         draw,
         DashboardData(events=[], weather=None, birthdays=[], air_quality=aq),
-        date(2024, 3, 15),
         style=style,
     )
     split = int(CANVAS_W * 0.28)
@@ -217,12 +219,12 @@ def _make_data(**overrides) -> DashboardData:
     return data
 
 
-def _render(data=None, today=date(2024, 3, 15), *, region=None, style=None, **aq_overrides):
+def _render(data=None, *, region=None, style=None, **aq_overrides):
     """Render onto a fresh plate. Leftover kwargs override the AirQualityData."""
     if data is None:
         data = _make_data(air_quality=_make_aq(**aq_overrides)) if aq_overrides else _make_data()
     img, draw = _make_draw()
-    draw_air_quality_full(draw, data, today, region=region, style=style)
+    draw_air_quality_full(draw, data, region=region, style=style)
     return img
 
 
@@ -244,7 +246,7 @@ class TestDrawAirQualityFullSmoke:
         """Contract check. A no-op also returns None; verified instead by
         making the component return a value and watching this fail."""
         _, draw = _make_draw()
-        assert draw_air_quality_full(draw, _make_data(), date(2024, 3, 15)) is None
+        assert draw_air_quality_full(draw, _make_data()) is None
 
     def test_produces_non_blank_image(self):
         """Genuinely non-blank: ink pixels exist, which getbbox could never show."""
@@ -363,17 +365,6 @@ class TestWeatherStrip:
         high = _ink(_render(_make_data(weather=_fc(1.0))), self.BAND)
         low = _ink(_render(_make_data(weather=_fc(0.1))), self.BAND)
         assert high != low, "the precipitation chance is not being drawn"
-
-    def test_today_does_not_affect_the_panel(self):
-        """`today` is threaded through this panel but never read.
-
-        draw_air_quality_full passes it to _draw_weather_strip, which passes
-        it to _draw_forecast_columns, which does not use it — the forecast
-        columns take their dates from the DayForecast entries. Asserted as an
-        equality rather than described as a rendering behaviour, because that
-        is what is actually true today.
-        """
-        assert _render(today=None).tobytes() == _render(today=date(2024, 3, 15)).tobytes()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_air_quality_panel.py
+++ b/tests/test_air_quality_panel.py
@@ -1,5 +1,34 @@
 """Tests for src/render/components/air_quality_panel.py
-and src/render/themes/air_quality.py."""
+and src/render/themes/air_quality.py.
+
+Assertion discipline (see #229)
+-------------------------------
+These tests used to assert ``img.getbbox() is not None``, or nothing at all.
+On the mode-``"1"`` canvas built below that assertion has no failing input:
+the plate is filled with 1, ``getbbox()`` reports the bounds of *non-zero*
+pixels, so it returns the full canvas even for a plate nothing was drawn to.
+All 47 tests passed with ``draw_air_quality_full`` stubbed to a no-op.
+
+Ink here therefore means **zero-valued** pixels, measured per zone. Three
+structural measures carry most of the weight, because they check what the
+panel is actually *for* rather than that it drew something:
+
+* ``_card_count`` — ambient cards counted from their rounded-rect outlines.
+* ``_pm_separator_count`` — PM columns counted from the rules between them.
+* ``_scale_bar_fill`` — the AQI health bar's filled width, which must track
+  the reading and clamp at 500.
+
+Verification (the step that makes the rewrite worth anything): with
+``draw_air_quality_full`` stubbed to a no-op, 42 of the 52 tests here fail.
+Of the 10 survivors, 7 are ``TestAirQualityTheme`` cases that exercise the
+theme factory and never draw through this entry point. The other three
+assert an equivalence, which two blank plates satisfy by construction —
+``test_returns_none``, ``test_default_region_and_style`` and
+``test_today_does_not_affect_the_panel``. Each was checked the other way
+instead, by breaking what it names (returning a value, defaulting to a
+different region, making ``today`` alter the output) and confirming it goes
+red. If you add a test here, do the same before you trust it.
+"""
 
 from datetime import date, timedelta
 
@@ -8,16 +37,137 @@ from PIL import Image, ImageDraw
 
 from src.data.models import AirQualityData, DashboardData, DayForecast, WeatherData
 from src.render.components.air_quality_panel import draw_air_quality_full
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion, ThemeStyle
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+CANVAS_W, CANVAS_H = 800, 480
 
-def _make_draw(w: int = 800, h: int = 480):
+# Zone geometry, mirrored from draw_air_quality_full's own proportions.
+_HERO_H = int(CANVAS_H * 0.375)
+_PM_H = int(CANVAS_H * 0.146)
+_CARDS_H = int(CANVAS_H * 0.208)
+
+HERO = (0, 0, CANVAS_W, _HERO_H)
+PM = (0, _HERO_H, CANVAS_W, _HERO_H + _PM_H)
+CARDS = (0, _HERO_H + _PM_H, CANVAS_W, _HERO_H + _PM_H + _CARDS_H)
+
+
+def _weather_band(has_ambient: bool) -> tuple[int, int, int, int]:
+    """The weather strip starts after the ambient cards, which collapse to
+    zero height when the sensor reports none of temp/humidity/pressure."""
+    top = _HERO_H + _PM_H + (_CARDS_H if has_ambient else 0)
+    return (0, top, CANVAS_W, CANVAS_H)
+
+
+def _make_draw(w: int = CANVAS_W, h: int = CANVAS_H):
     img = Image.new("1", (w, h), 1)
     return img, ImageDraw.Draw(img)
+
+
+def _ink(img: Image.Image, box: tuple[int, int, int, int] | None = None) -> int:
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_x_extent(img: Image.Image, box: tuple[int, int, int, int]):
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    xs = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+def _card_count(img: Image.Image) -> int:
+    """Ambient cards, counted from their rounded-rect outlines.
+
+    A scanline through the card bodies crosses each card's left and right
+    edge, so the run count is exactly twice the number of cards.
+
+    Only meaningful when the panel reserved a cards zone at all: with no
+    ambient readings the zone collapses to zero height and this scanline
+    lands in the weather strip instead. Use _has_cards_zone for that case.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    y = _HERO_H + _PM_H + 20
+    runs = 0
+    prev = False
+    for x in range(CANVAS_W):
+        cur = px[y * width + x] == 0
+        if cur and not prev:
+            runs += 1
+        prev = cur
+    return runs // 2
+
+
+def _has_cards_zone(img: Image.Image) -> bool:
+    """Whether the ambient-cards zone was reserved.
+
+    Both candidate rules land on the same y when the zone collapses, so
+    presence alone cannot tell them apart — they are distinguished by span.
+    The cards rule is inset 20px each side; the weather strip's rule, which
+    takes that y when there are no ambient readings, runs the full width. So
+    an inked pixel at x=5 means the zone collapsed.
+    """
+    px = flatten_pixels(img)
+    y = _HERO_H + _PM_H
+    return px[y * img.width + 5] != 0
+
+
+def _pm_separator_count(img: Image.Image) -> int:
+    """Full-height vertical rules in the PM zone: one fewer than the columns."""
+    px = flatten_pixels(img)
+    width = img.width
+    top, bottom = _HERO_H + 12, _HERO_H + _PM_H - 12
+    return sum(
+        1 for x in range(CANVAS_W) if all(px[y * width + x] == 0 for y in range(top, bottom))
+    )
+
+
+def _pm_column_count(img: Image.Image) -> int:
+    return _pm_separator_count(img) + 1
+
+
+def _scale_bar_fill(img: Image.Image) -> int:
+    """Ink inside the AQI scale bar, which fills left-to-right with the reading."""
+    split = int(CANVAS_W * 0.28)
+    bar_x = split + 8
+    bar_w = CANVAS_W - split - 16
+    bar_y = int(_HERO_H * 0.28)
+    return _ink(img, (bar_x, bar_y + 2, bar_x + bar_w, bar_y + 38))
+
+
+def _scale_bar_crop_greyscale(aqi: int):
+    """The scale-bar region rendered on an L plate with a distinct accent.
+
+    On the 1-bit plate every accent collapses to ``fg``, which hides anything
+    the panel expresses through colour alone — including whether an
+    out-of-range AQI was clamped. A greyscale plate with accents at mid-grey
+    separates the two so the difference is visible.
+    """
+    aq = AirQualityData(aqi=aqi, category="Hazardous", pm25=9.8)
+    img = Image.new("L", (CANVAS_W, CANVAS_H), 255)
+    draw = ImageDraw.Draw(img)
+    style = ThemeStyle(fg=0, bg=255, accent_good=128, accent_warn=128, accent_alert=128)
+    draw_air_quality_full(
+        draw,
+        DashboardData(events=[], weather=None, birthdays=[], air_quality=aq),
+        date(2024, 3, 15),
+        style=style,
+    )
+    split = int(CANVAS_W * 0.28)
+    bar_x = split + 8
+    bar_w = CANVAS_W - split - 16
+    bar_y = int(_HERO_H * 0.28)
+    return img.crop((bar_x, bar_y, bar_x + bar_w, bar_y + 62)).tobytes()
 
 
 def _make_aq(**overrides) -> AirQualityData:
@@ -61,13 +211,19 @@ def _make_weather(**overrides) -> WeatherData:
 
 
 def _make_data(**overrides) -> DashboardData:
-    data = DashboardData(
-        air_quality=_make_aq(),
-        weather=_make_weather(),
-    )
+    data = DashboardData(air_quality=_make_aq(), weather=_make_weather())
     for k, v in overrides.items():
         setattr(data, k, v)
     return data
+
+
+def _render(data=None, today=date(2024, 3, 15), *, region=None, style=None, **aq_overrides):
+    """Render onto a fresh plate. Leftover kwargs override the AirQualityData."""
+    if data is None:
+        data = _make_data(air_quality=_make_aq(**aq_overrides)) if aq_overrides else _make_data()
+    img, draw = _make_draw()
+    draw_air_quality_full(draw, data, today, region=region, style=style)
+    return img
 
 
 # ---------------------------------------------------------------------------
@@ -77,33 +233,46 @@ def _make_data(**overrides) -> DashboardData:
 
 class TestDrawAirQualityFullSmoke:
     def test_renders_with_full_data(self):
-        _, draw = _make_draw()
-        draw_air_quality_full(draw, _make_data(), date(2024, 3, 15))
+        """Every zone receives content."""
+        img = _render()
+        assert _ink(img, HERO) > 0, "hero zone empty"
+        assert _ink(img, PM) > 0, "PM row empty"
+        assert _ink(img, CARDS) > 0, "ambient cards empty"
+        assert _ink(img, _weather_band(has_ambient=True)) > 0, "weather strip empty"
 
     def test_returns_none(self):
+        """Contract check. A no-op also returns None; verified instead by
+        making the component return a value and watching this fail."""
         _, draw = _make_draw()
-        result = draw_air_quality_full(draw, _make_data(), date(2024, 3, 15))
-        assert result is None
+        assert draw_air_quality_full(draw, _make_data(), date(2024, 3, 15)) is None
 
     def test_produces_non_blank_image(self):
-        img, draw = _make_draw()
-        draw_air_quality_full(draw, _make_data(), date(2024, 3, 15))
-        assert img.getbbox() is not None
+        """Genuinely non-blank: ink pixels exist, which getbbox could never show."""
+        assert _ink(_render()) > 0
 
     def test_default_region_and_style(self):
-        """Passing region=None and style=None triggers default-assignment branches."""
-        _, draw = _make_draw()
-        draw_air_quality_full(draw, _make_data(), region=None, style=None)
+        """region=None/style=None fill in the full-canvas defaults."""
+        explicit = _render(region=ComponentRegion(0, 0, CANVAS_W, CANVAS_H), style=ThemeStyle())
+        assert _render(region=None, style=None).tobytes() == explicit.tobytes()
 
-    def test_custom_region(self):
-        _, draw = _make_draw()
-        region = ComponentRegion(10, 10, 780, 460)
-        draw_air_quality_full(draw, _make_data(), region=region, style=ThemeStyle())
+    def test_custom_region_offset_moves_the_content(self):
+        at_origin = _render(region=ComponentRegion(0, 0, 400, 240))
+        offset = _render(region=ComponentRegion(120, 0, 400, 240))
+        assert _ink(at_origin) > 0
+        left_a = _ink_x_extent(at_origin, (0, 0, CANVAS_W, CANVAS_H))
+        left_b = _ink_x_extent(offset, (0, 0, CANVAS_W, CANVAS_H))
+        assert left_a is not None and left_b is not None
+        assert left_b[0] > left_a[0], "region.x offset did not move the content"
 
-    def test_custom_style(self):
-        _, draw = _make_draw()
-        style = ThemeStyle()
-        draw_air_quality_full(draw, _make_data(), style=style)
+    def test_custom_style_changes_the_plate(self):
+        """An inverted style is not the same plate as the default.
+
+        Note it is inverted fg/bg rather than show_borders=False: this panel
+        rules its zone separators unconditionally and never reads
+        show_borders, so that flag would render an identical plate.
+        """
+        inverted = _render(style=ThemeStyle(fg=1, bg=0))
+        assert inverted.tobytes() != _render().tobytes()
 
 
 # ---------------------------------------------------------------------------
@@ -113,204 +282,190 @@ class TestDrawAirQualityFullSmoke:
 
 class TestDrawAirQualityUnavailable:
     def test_renders_when_air_quality_is_none(self):
-        _, draw = _make_draw()
-        data = _make_data(air_quality=None)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """The fallback message is drawn and none of the zones are."""
+        img = _render(_make_data(air_quality=None))
+        assert _ink(img) > 0, "no fallback message drawn"
+        assert _card_count(img) == 0, "ambient cards drawn without air quality"
+        assert _pm_separator_count(img) == 0, "PM columns drawn without air quality"
+        assert _scale_bar_fill(img) == 0, "AQI scale bar drawn without air quality"
 
-    def test_unavailable_produces_non_blank_image(self):
-        img, draw = _make_draw()
-        data = _make_data(air_quality=None)
-        draw_air_quality_full(draw, data)
-        assert img.getbbox() is not None
+    def test_unavailable_message_is_centred(self):
+        img = _render(_make_data(air_quality=None))
+        extent = _ink_x_extent(img, (0, 0, CANVAS_W, CANVAS_H))
+        assert extent is not None
+        midpoint = (extent[0] + extent[1]) / 2
+        assert abs(midpoint - CANVAS_W / 2) < 12, f"message off-centre: midpoint {midpoint}"
 
     def test_unavailable_does_not_crash_with_weather_also_none(self):
-        _, draw = _make_draw()
-        data = _make_data(air_quality=None, weather=None)
-        draw_air_quality_full(draw, data)
+        """Weather is irrelevant once air quality is missing — same plate."""
+        no_aq = _render(_make_data(air_quality=None))
+        neither = _render(_make_data(air_quality=None, weather=None))
+        assert _ink(neither) > 0
+        assert neither.tobytes() == no_aq.tobytes()
 
 
 # ---------------------------------------------------------------------------
-# Weather strip variations
+# Weather strip
 # ---------------------------------------------------------------------------
 
 
 class TestWeatherStrip:
+    BAND = _weather_band(has_ambient=True)
+
     def test_renders_without_weather(self):
-        """Weather=None shows fallback message in strip."""
-        _, draw = _make_draw()
-        data = _make_data(weather=None)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """No weather leaves the strip nearly bare, but does not break the panel."""
+        no_wx = _render(_make_data(weather=None))
+        assert _ink(no_wx, self.BAND) < _ink(_render(), self.BAND)
+        assert _ink(no_wx, HERO) > 0, "losing weather should not cost the AQI hero"
 
     def test_renders_without_forecast(self):
-        _, draw = _make_draw()
-        wx = _make_weather(forecast=[])
-        data = _make_data(weather=wx)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """An empty forecast drops the columns but keeps current conditions."""
+        no_fc = _render(_make_data(weather=_make_weather(forecast=[])))
+        assert 0 < _ink(no_fc, self.BAND) < _ink(_render(), self.BAND)
 
     def test_renders_with_empty_precip_chance(self):
-        """Forecast items with precip_chance=None or < 0.05 render without precip string."""
-        _, draw = _make_draw()
-        wx = _make_weather(
+        """precip_chance=None omits the percentage from each column."""
+        none_precip = _make_weather(
             forecast=[
                 DayForecast(
-                    date=date(2024, 3, 17),
+                    date=date(2024, 3, 16) + timedelta(days=i),
                     high=70.0,
                     low=55.0,
                     icon="01d",
                     description="clear",
                     precip_chance=None,
-                ),
-                DayForecast(
-                    date=date(2024, 3, 18),
-                    high=68.0,
-                    low=52.0,
-                    icon="02d",
-                    description="cloudy",
-                    precip_chance=0.02,
-                ),
+                )
+                for i in range(4)
             ]
         )
-        data = _make_data(weather=wx)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _ink(_render(_make_data(weather=none_precip)), self.BAND) < _ink(
+            _render(), self.BAND
+        )
 
     def test_renders_with_high_precip_chance(self):
-        _, draw = _make_draw()
-        wx = _make_weather(
-            forecast=[
-                DayForecast(
-                    date=date(2024, 3, 17),
-                    high=65.0,
-                    low=50.0,
-                    icon="10d",
-                    description="rain",
-                    precip_chance=0.90,
-                ),
-            ]
-        )
-        data = _make_data(weather=wx)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """A high chance draws a wider percentage than a low one."""
 
-    def test_renders_without_today_date(self):
-        """today=None (default) still renders the full layout."""
-        _, draw = _make_draw()
-        draw_air_quality_full(draw, _make_data())
+        def _fc(chance):
+            return _make_weather(
+                forecast=[
+                    DayForecast(
+                        date=date(2024, 3, 16) + timedelta(days=i),
+                        high=70.0,
+                        low=55.0,
+                        icon="10d",
+                        description="rain",
+                        precip_chance=chance,
+                    )
+                    for i in range(4)
+                ]
+            )
+
+        high = _ink(_render(_make_data(weather=_fc(1.0))), self.BAND)
+        low = _ink(_render(_make_data(weather=_fc(0.1))), self.BAND)
+        assert high != low, "the precipitation chance is not being drawn"
+
+    def test_today_does_not_affect_the_panel(self):
+        """`today` is threaded through this panel but never read.
+
+        draw_air_quality_full passes it to _draw_weather_strip, which passes
+        it to _draw_forecast_columns, which does not use it — the forecast
+        columns take their dates from the DayForecast entries. Asserted as an
+        equality rather than described as a rendering behaviour, because that
+        is what is actually true today.
+        """
+        assert _render(today=None).tobytes() == _render(today=date(2024, 3, 15)).tobytes()
 
 
 # ---------------------------------------------------------------------------
-# PM row variations
+# PM row
 # ---------------------------------------------------------------------------
 
 
 class TestPMRow:
     def test_only_pm25_when_pm1_and_pm10_absent(self):
-        """With pm1=None and pm10=None, only PM2.5 column is drawn."""
-        _, draw = _make_draw()
-        aq = _make_aq(pm1=None, pm10=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """One reading means one column and no separators."""
+        img = _render(pm1=None, pm10=None)
+        assert _pm_column_count(img) == 1
+        assert _ink(img, PM) > 0
 
     def test_pm25_and_pm10_only(self):
-        _, draw = _make_draw()
-        aq = _make_aq(pm1=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _pm_column_count(_render(pm1=None)) == 2
+
+    def test_pm1_and_pm25_only(self):
+        assert _pm_column_count(_render(pm10=None)) == 2
 
     def test_all_three_pm_columns(self):
-        _, draw = _make_draw()
-        aq = _make_aq(pm1=3.2, pm25=9.8, pm10=15.0)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _pm_column_count(_render()) == 3
 
     def test_zero_pm_values(self):
-        _, draw = _make_draw()
-        aq = _make_aq(pm1=0.0, pm25=0.0, pm10=0.0)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """Zero is a real reading, not a missing one — the columns stay."""
+        img = _render(pm1=0.0, pm25=0.0, pm10=0.0)
+        assert _pm_column_count(img) == 3
+        assert _ink(img, PM) != _ink(_render(), PM), "PM values are not being drawn"
 
 
 # ---------------------------------------------------------------------------
-# Ambient sensor cards variations
+# Ambient cards
 # ---------------------------------------------------------------------------
 
 
 class TestAmbientCards:
     def test_no_ambient_fields(self):
-        """When temperature, humidity, and pressure are all None, no cards are drawn."""
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=None, humidity=None, pressure=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """With no ambient readings the zone collapses and the weather moves up."""
+        img = _render(temperature=None, humidity=None, pressure=None)
+        assert not _has_cards_zone(img), "a cards zone was reserved with nothing to put in it"
+        assert _has_cards_zone(_render()), "sanity: the full-data plate does reserve one"
+        assert _ink(img, _weather_band(has_ambient=False)) > 0, "weather strip did not move up"
+        assert img.tobytes() != _render().tobytes()
 
     def test_temperature_only(self):
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=72.0, humidity=None, pressure=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _card_count(_render(humidity=None, pressure=None)) == 1
 
     def test_humidity_only(self):
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=None, humidity=60.0, pressure=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _card_count(_render(temperature=None, pressure=None)) == 1
 
     def test_pressure_only(self):
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=None, humidity=None, pressure=1013.0)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _card_count(_render(temperature=None, humidity=None)) == 1
+
+    def test_each_single_card_draws_its_own_reading(self):
+        """The three one-card cases are not interchangeable plates."""
+        temp = _render(humidity=None, pressure=None)
+        humid = _render(temperature=None, pressure=None)
+        press = _render(temperature=None, humidity=None)
+        inks = {_ink(temp, CARDS), _ink(humid, CARDS), _ink(press, CARDS)}
+        assert len(inks) == 3, "two ambient cards rendered identically"
 
     def test_temp_and_humidity_only(self):
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=70.0, humidity=55.0, pressure=None)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _card_count(_render(pressure=None)) == 2
 
     def test_all_three_cards(self):
-        _, draw = _make_draw()
-        aq = _make_aq(temperature=68.0, humidity=50.0, pressure=1015.0)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        assert _card_count(_render()) == 3
 
     def test_temperature_hidden_when_from_fallback(self):
-        """When temperature is from OWM fallback, the temp card is hidden."""
-        _, draw = _make_draw()
-        # Temperature and pressure from fallback, humidity from sensor
-        aq = _make_aq(
-            temperature=68.0,
-            humidity=55.0,
-            pressure=1013.0,
-            fallback_fields={"temperature", "pressure"},
-        )
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """A temperature sourced from OWM rather than the sensor is suppressed."""
+        fallback = _render(fallback_fields={"temperature"})
+        assert _card_count(fallback) == 2, "the fallback temperature card was drawn"
+        assert _card_count(_render()) == 3
 
     def test_only_humidity_shown_when_temp_from_fallback(self):
-        """Only humidity card shown when temperature is fallback and pressure is None."""
-        _, draw = _make_draw()
-        aq = _make_aq(
-            temperature=68.0,
-            humidity=55.0,
-            pressure=None,
-            fallback_fields={"temperature"},
-        )
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        """Suppressed temp + no pressure leaves exactly the humidity card.
+
+        Equal to the plate where temperature was never reported at all —
+        which is the point of the suppression.
+        """
+        fallback = _render(pressure=None, fallback_fields={"temperature"})
+        never_had = _render(temperature=None, pressure=None)
+        assert _card_count(fallback) == 1
+        assert _ink(fallback, CARDS) == _ink(never_had, CARDS)
 
     def test_humidity_and_pressure_shown_without_temperature(self):
-        """Humidity and pressure cards centered when temperature is fallback."""
-        _, draw = _make_draw()
-        aq = _make_aq(
-            temperature=68.0,
-            humidity=55.0,
-            pressure=1013.0,
-            fallback_fields={"temperature"},
-        )
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+        img = _render(temperature=None)
+        assert _card_count(img) == 2
+        assert _ink(img, CARDS) > 0
 
 
 # ---------------------------------------------------------------------------
-# AQI scale bar — various AQI values covering all six zones
+# AQI hero + scale bar
 # ---------------------------------------------------------------------------
 
 
@@ -330,30 +485,57 @@ class TestAqiHeroAndScaleBar:
             (500, "Hazardous"),
         ],
     )
-    def test_aqi_zones_render_without_error(self, aqi, category):
-        _, draw = _make_draw()
-        aq = _make_aq(aqi=aqi, category=category)
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+    def test_aqi_zones_render_the_reading_and_the_bar(self, aqi, category):
+        img = _render(aqi=aqi, category=category)
+        assert _ink(img, HERO) > 0, f"hero empty for AQI {aqi}"
+        # AQI 0 leaves the bar outline only; every other reading fills some of it.
+        assert _scale_bar_fill(img) > 0
 
-    def test_aqi_zero_does_not_crash(self):
-        _, draw = _make_draw()
-        aq = _make_aq(aqi=0, category="Good")
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+    def test_scale_bar_fill_tracks_the_reading(self):
+        """The bar is a gauge: a worse reading fills strictly more of it."""
+        fills = [_scale_bar_fill(_render(aqi=v)) for v in (0, 50, 150, 300, 500)]
+        assert fills == sorted(fills), f"scale bar not monotonic in AQI: {fills}"
+        assert fills[0] < fills[-1]
+        assert len(set(fills)) == len(fills), "different readings drew the same bar"
 
-    def test_aqi_max_does_not_crash(self):
-        _, draw = _make_draw()
-        aq = _make_aq(aqi=500, category="Hazardous")
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+    def test_aqi_zero_renders_an_empty_bar(self):
+        """Zero is the floor — the bar outline is there but nothing is filled."""
+        zero = _scale_bar_fill(_render(aqi=0))
+        assert zero < _scale_bar_fill(_render(aqi=50))
 
-    def test_aqi_large_number_renders(self):
-        """Three-digit AQI renders; auto-scale loop doesn't hang."""
-        _, draw = _make_draw()
-        aq = _make_aq(aqi=350, category="Hazardous")
-        data = _make_data(air_quality=aq)
-        draw_air_quality_full(draw, data, date(2024, 3, 15))
+    def test_aqi_max_fills_the_bar(self):
+        assert _scale_bar_fill(_render(aqi=500)) > _scale_bar_fill(_render(aqi=300))
+
+    def test_aqi_above_max_is_clamped(self):
+        """Readings past 500 clamp to 500 rather than running off the scale.
+
+        Measured on a greyscale plate: on the 1-bit canvas the fill saturates
+        the bar either way (PIL clips the overflowing rectangle) and every
+        accent collapses to fg, so the clamp is invisible there — an earlier
+        version of this test passed with `min(aqi, _AQI_MAX)` deleted. With a
+        distinct accent the zone labels expose it.
+        """
+        at_max = _scale_bar_crop_greyscale(500)
+        assert _scale_bar_crop_greyscale(900) == at_max, "AQI 900 did not clamp to 500"
+        assert _scale_bar_crop_greyscale(1500) == at_max, "AQI 1500 did not clamp to 500"
+        assert _scale_bar_crop_greyscale(300) != at_max, (
+            "sanity: an in-range reading should not match the top of the scale"
+        )
+
+    def test_aqi_number_stays_inside_its_column(self):
+        """The hero numeral is capped to the left column across the real range."""
+        split = int(CANVAS_W * 0.28)
+        max_w = split - 40  # column width minus 2×pad, per _draw_aqi_hero
+        for value in (5, 42, 350, 500):
+            extent = _ink_x_extent(_render(aqi=value), (0, 60, split, _HERO_H - 40))
+            assert extent is not None, f"nothing drawn for AQI {value}"
+            assert extent[1] - extent[0] <= max_w, (
+                f"AQI {value} rendered {extent[1] - extent[0]}px wide, over the {max_w} cap"
+            )
+
+    def test_category_text_is_drawn(self):
+        """A longer category leaves more ink than a short one."""
+        assert _ink(_render(category="Hazardous"), HERO) > _ink(_render(category="Good"), HERO)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_almanac_panel.py
+++ b/tests/test_almanac_panel.py
@@ -21,13 +21,28 @@ from src.render.components.almanac_panel import (
     _upcoming_calendar_summary,
     draw_almanac,
 )
-from src.render.theme import AVAILABLE_THEMES, load_theme
+from src.render.quantize import flatten_pixels
+from src.render.theme import AVAILABLE_THEMES, ComponentRegion, ThemeStyle, load_theme
 
 NYC_LAT = 40.7128
 NYC_LON = -74.0060
 TZ = ZoneInfo("America/New_York")
 FIXED_NOW = datetime(2026, 4, 23, 9, 30, tzinfo=TZ)
 TODAY = FIXED_NOW.date()
+
+
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels.
+
+    (#229) The direct-draw tests below asserted `img.getbbox() is not None`
+    on a mode-"1" plate filled with 1, where getbbox can never return None.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -296,14 +311,26 @@ class TestAlmanacRender:
 
 
 class TestDrawAlmanacDirect:
-    def test_defaults_region_and_style(self):
+    def _draw(self, data=None, today=TODAY, now=FIXED_NOW, **kwargs):
         img, d = _make_draw()
-        data = DashboardData(events=[], weather=None)
-        draw_almanac(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        draw_almanac(
+            d,
+            data if data is not None else DashboardData(events=[], weather=None),
+            today,
+            now,
+            **kwargs,
+        )
+        return img
+
+    def test_defaults_region_and_style(self):
+        """region=None/style=None fill in the defaults and draw the page."""
+        img = self._draw()
+        assert _ink(img) > 0, "nothing drawn at all"
+        explicit = self._draw(region=ComponentRegion(0, 0, 800, 480), style=ThemeStyle())
+        assert img.tobytes() == explicit.tobytes()
 
     def test_with_full_weather_data(self):
-        img, d = _make_draw()
+        """Every editorial field populated draws more than none of them."""
         w = WeatherData(
             current_temp=60.0,
             current_icon="01d",
@@ -317,18 +344,21 @@ class TestDrawAlmanacDirect:
             sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
             alerts=[WeatherAlert(event="Wind Advisory")],
         )
-        data = DashboardData(events=[], weather=w)
-        draw_almanac(d, data, TODAY, FIXED_NOW, latitude=NYC_LAT, longitude=NYC_LON)
-        assert img.getbbox() is not None
+        full = self._draw(DashboardData(events=[], weather=w), latitude=NYC_LAT, longitude=NYC_LON)
+        bare = self._draw(latitude=NYC_LAT, longitude=NYC_LON)
+        assert _ink(full) > _ink(bare), "the weather editorial block is not drawn"
 
     def test_with_lat_lon(self):
-        img, d = _make_draw()
-        data = DashboardData(events=[], weather=None)
-        draw_almanac(d, data, TODAY, FIXED_NOW, latitude=NYC_LAT, longitude=NYC_LON)
-        assert img.getbbox() is not None
+        """Coordinates enable the computed almanac figures."""
+        with_coords = self._draw(latitude=NYC_LAT, longitude=NYC_LON)
+        without = self._draw()
+        assert _ink(with_coords) > 0
+        assert with_coords.tobytes() != without.tobytes(), (
+            "the coordinates make no difference to the page"
+        )
 
     def test_with_zero_zero_lat_lon_falls_back(self):
-        img, d = _make_draw()
+        """(0,0) is the project-wide 'unset' convention — falls back to OWM times."""
         w = WeatherData(
             current_temp=60.0,
             current_icon="01d",
@@ -340,12 +370,15 @@ class TestDrawAlmanacDirect:
             sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
         )
         data = DashboardData(events=[], weather=w)
-        draw_almanac(d, data, TODAY, FIXED_NOW, latitude=0.0, longitude=0.0)
-        assert img.getbbox() is not None
+        zero = self._draw(data, latitude=0.0, longitude=0.0)
+        unset = self._draw(data)
+        assert _ink(zero) > 0
+        assert zero.tobytes() == unset.tobytes(), (
+            "(0,0) was treated as a real location rather than as unset"
+        )
 
     def test_weather_with_no_wind_or_alerts(self):
-        """Weather missing the optional editorial fields still renders."""
-        img, d = _make_draw()
+        """Weather missing the optional editorial fields draws less, not nothing."""
         w = WeatherData(
             current_temp=55.0,
             current_icon="01d",
@@ -354,20 +387,40 @@ class TestDrawAlmanacDirect:
             low=None,
             humidity=50,
         )
-        data = DashboardData(events=[], weather=w)
-        draw_almanac(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        minimal = self._draw(DashboardData(events=[], weather=w))
+        assert _ink(minimal) > 0
+        assert _ink(minimal) < _ink(
+            self._draw(
+                DashboardData(
+                    events=[],
+                    weather=WeatherData(
+                        current_temp=55.0,
+                        current_icon="01d",
+                        current_description="clear",
+                        high=70.0,
+                        low=50.0,
+                        humidity=50,
+                        wind_speed=9.0,
+                        wind_deg=90.0,
+                        alerts=[WeatherAlert(event="Wind Advisory")],
+                    ),
+                )
+            )
+        ), "the optional editorial fields are not being drawn when present"
 
     def test_polar_day_handles_missing_day_length_delta(self):
-        """At extreme latitudes day_length_delta returns None — must not crash."""
-        img, d = _make_draw()
-        data = DashboardData(events=[], weather=None)
-        draw_almanac(
-            d,
-            data,
-            date(2026, 6, 21),
-            datetime(2026, 6, 21, 12, 0, tzinfo=TZ),
+        """At 85°N day_length_delta is None — the page still typesets."""
+        polar = self._draw(
+            today=date(2026, 6, 21),
+            now=datetime(2026, 6, 21, 12, 0, tzinfo=TZ),
             latitude=85.0,
             longitude=0.0,
         )
-        assert img.getbbox() is not None
+        temperate = self._draw(
+            today=date(2026, 6, 21),
+            now=datetime(2026, 6, 21, 12, 0, tzinfo=TZ),
+            latitude=NYC_LAT,
+            longitude=NYC_LON,
+        )
+        assert _ink(polar) > 0, "the polar page rendered blank"
+        assert polar.tobytes() != temperate.tobytes()

--- a/tests/test_astronomy_theme.py
+++ b/tests/test_astronomy_theme.py
@@ -19,6 +19,7 @@ from src.render.components.astronomy_panel import (
     draw_astronomy,
 )
 from src.render.theme import AVAILABLE_THEMES, load_theme
+from tests.inkutils import ink
 
 NYC_LAT = 40.7128
 NYC_LON = -74.0060
@@ -160,7 +161,7 @@ class TestDrawAstronomyDirect:
         img, d = _make_draw()
         data = DashboardData(events=[], weather=None)
         draw_astronomy(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the default-style panel drew nothing"
 
     def test_with_weather_supplied_sun_times(self):
         """With weather data providing sunrise/sunset, no coords needed."""
@@ -177,7 +178,9 @@ class TestDrawAstronomyDirect:
         )
         data = DashboardData(events=[], weather=w)
         draw_astronomy(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        bare, bd = _make_draw()
+        draw_astronomy(bd, DashboardData(events=[], weather=None), TODAY, FIXED_NOW)
+        assert ink(img) != ink(bare), "the weather block is not drawn"
 
     def test_polar_day_gracefully_handled(self):
         """At very high latitudes the sun never sets — panel still renders."""
@@ -191,4 +194,4 @@ class TestDrawAstronomyDirect:
             latitude=85.0,
             longitude=0.0,
         )
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the polar page rendered blank"

--- a/tests/test_birthday_bar.py
+++ b/tests/test_birthday_bar.py
@@ -1,11 +1,33 @@
-"""Tests for src/render/components/birthday_bar.py"""
+"""Tests for src/render/components/birthday_bar.py
+
+Assertion discipline (see #229)
+-------------------------------
+These tests asserted ``img.getbbox() is not None`` on a mode-``"1"`` plate
+filled with 1, where every pixel is non-zero and getbbox can never return
+None. 13 of the 14 tests passed with ``draw_birthdays`` stubbed to a no-op.
+
+Ink means **zero-valued** pixels, counted inside the bar's own region. The
+strongest signal here is the today-birthday row, which is inverted — a
+filled_rect with its text knocked out — so it inks roughly five times what
+an ordinary row does.
+
+Verification: with ``draw_birthdays`` stubbed to a no-op, every test in this
+file fails.
+"""
 
 from datetime import date, timedelta
 
 from PIL import Image, ImageDraw
 
-from src.data.models import Birthday
+from src.data.models import Birthday, StalenessLevel
+from src.render import layout as L
 from src.render.components.birthday_bar import draw_birthdays
+from src.render.quantize import flatten_pixels
+from src.render.theme import ComponentRegion
+
+TODAY = date(2024, 3, 15)
+REGION = ComponentRegion(L.BIRTHDAY_X, L.BIRTHDAY_Y, L.BIRTHDAY_W, L.BIRTHDAY_H)
+BOX = (REGION.x, REGION.y, REGION.x + REGION.w, REGION.y + REGION.h)
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -13,140 +35,145 @@ def _make_draw(w: int = 800, h: int = 480):
     return img, ImageDraw.Draw(img)
 
 
+def _ink(img: Image.Image, box: tuple[int, int, int, int] = BOX) -> int:
+    """Count ink (value-0) pixels inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _render(birthdays=None, today=TODAY, **kwargs) -> Image.Image:
+    img, draw = _make_draw()
+    draw_birthdays(draw, birthdays or [], today, **kwargs)
+    return img
+
+
+def _b(name: str, when: date, age: int | None = None) -> Birthday:
+    return Birthday(name=name, date=when, age=age)
+
+
 class TestDrawBirthdays:
     def test_no_birthdays_renders_empty_message(self):
-        """No birthdays should display 'No upcoming birthdays' without crashing."""
-        img, draw = _make_draw()
-        draw_birthdays(draw, [], date(2024, 3, 15))
-        assert img.getbbox() is not None
+        """The empty state is a message, not a blank bar."""
+        empty = _render()
+        assert _ink(empty) > 0
+        assert _ink(empty) != _ink(_render([_b("Alice", TODAY + timedelta(days=3))])), (
+            "the empty-state message is indistinguishable from a listed birthday"
+        )
 
     def test_today_birthday_renders(self):
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Alice", date=today)]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """Today's birthday inverts its whole row, so it inks far more."""
+        today_row = _ink(_render([_b("Alice", TODAY)]))
+        future_row = _ink(_render([_b("Alice", TODAY + timedelta(days=5))]))
+        assert today_row > future_row * 3, (
+            f"today's row is not inverted ({today_row} vs {future_row})"
+        )
 
     def test_tomorrow_birthday_renders(self):
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Bob", date=today + timedelta(days=1))]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """'Tomorrow' is its own label, distinct from a day count."""
+        tomorrow = _ink(_render([_b("Alice", TODAY + timedelta(days=1))]))
+        in_nine = _ink(_render([_b("Alice", TODAY + timedelta(days=9))]))
+        assert tomorrow > 0
+        assert tomorrow != in_nine
 
     def test_future_birthday_shows_days_countdown(self):
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Carol", date=today + timedelta(days=10))]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """The countdown is drawn from the gap, so different gaps differ."""
+        inks = {
+            days: _ink(_render([_b("Alice", TODAY + timedelta(days=days))])) for days in (3, 9, 40)
+        }
+        assert len(set(inks.values())) > 1, f"the day countdown is not drawn: {inks}"
 
     def test_birthday_with_age_renders(self):
-        today = date(2024, 3, 15)
-        # age=27 is not a milestone age, so normal "(27)" format is used
-        birthdays = [Birthday(name="Dave", date=today + timedelta(days=5), age=27)]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """An age adds to the row."""
+        with_age = _ink(_render([_b("Alice", TODAY + timedelta(days=9), 34)]))
+        without = _ink(_render([_b("Alice", TODAY + timedelta(days=9))]))
+        assert with_age > without, "the age is not drawn"
 
     def test_milestone_age_renders(self):
-        """Milestone ages (30, 40, 50…) should render as bold with '·' prefix."""
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Eve", date=today + timedelta(days=3), age=30)]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """A milestone age is set in the heavier font than a neighbouring age."""
+        milestone = _ink(_render([_b("Alice", TODAY + timedelta(days=9), 30)]))
+        ordinary = _ink(_render([_b("Alice", TODAY + timedelta(days=9), 31)]))
+        assert milestone > ordinary, (
+            f"age 30 was not emphasised over 31 ({milestone} vs {ordinary})"
+        )
 
     def test_birthday_past_this_year_rolls_to_next_year(self):
-        """A birthday that has already passed this year should show a positive countdown."""
-        today = date(2024, 3, 15)
-        # Birthday was March 1 — already passed, should roll to next year
-        past_bday = date(2024, 3, 1)
-        birthdays = [Birthday(name="Frank", date=past_bday)]
-        img, draw = _make_draw()
-        # Should not crash — rolls forward
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """A date already past this year is shown as next year's, not dropped."""
+        past = _render([_b("Alice", date(2024, 1, 10))])
+        assert _ink(past) > 0
+        assert _ink(past) != _ink(_render()), "a past birthday fell back to the empty state"
 
     def test_overflow_count_shown_when_more_than_max(self):
-        """When more than 3 birthdays are provided, overflow count should be shown."""
-        today = date(2024, 3, 15)
-        birthdays = [
-            Birthday(name=f"Person {i}", date=today + timedelta(days=i + 1)) for i in range(6)
-        ]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """Rows cap at three; the surplus becomes a '+N more' line."""
+
+        def with_n(n):
+            return _ink(_render([_b(f"P{i}", TODAY + timedelta(days=i + 1)) for i in range(n)]))
+
+        three = with_n(3)
+        four = with_n(4)
+        assert four > three, "the overflow line is not drawn"
+        assert with_n(6) != four, "the overflow count does not track how many are hidden"
 
     def test_exactly_three_birthdays_no_overflow(self):
-        today = date(2024, 3, 15)
-        birthdays = [
-            Birthday(name=f"Person {i}", date=today + timedelta(days=i + 1)) for i in range(3)
-        ]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """Three fit exactly — no overflow line, and each row is drawn."""
+
+        def with_n(n):
+            return _ink(_render([_b(f"P{i}", TODAY + timedelta(days=i + 1)) for i in range(n)]))
+
+        assert with_n(3) > with_n(2) > with_n(1), "rows are not accumulating"
 
     def test_birthday_with_no_age_renders(self):
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Grace", date=today + timedelta(days=7), age=None)]
-        img, draw = _make_draw()
-        draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        """age=None omits the age rather than printing a placeholder."""
+        no_age = _render([_b("Grace", TODAY + timedelta(days=7))])
+        assert _ink(no_age) > 0
+        assert _ink(no_age) < _ink(_render([_b("Grace", TODAY + timedelta(days=7), 41)]))
 
     def test_today_birthday_inverts_row(self):
-        """A birthday today should produce different pixels than a non-today birthday."""
-        today = date(2024, 3, 15)
-
-        img_today, draw_today = _make_draw()
-        draw_birthdays(draw_today, [Birthday(name="Alice", date=today)], today)
-
-        img_future, draw_future = _make_draw()
-        draw_birthdays(draw_future, [Birthday(name="Alice", date=today + timedelta(days=5))], today)
-
-        # Today's birthday row is inverted (has black fill), future is not
-        # Simply verify both render differently
-        assert img_today.tobytes() != img_future.tobytes()
+        """The inverted row knocks its text out of the fill."""
+        named = _ink(_render([_b("Alice", TODAY)]))
+        blank = _ink(_render([_b("", TODAY)]))
+        assert named < blank, "the name is not knocked out of the inverted row"
 
     def test_stale_birthdays_renders_glyph(self):
-        """STALE staleness draws the '!' badge without crashing."""
-        from src.data.models import StalenessLevel
-        from src.render.theme import ComponentRegion
+        """STALE draws the '!' badge in the region's bottom-right corner."""
+        region = ComponentRegion(300, 360, 250, 120)
+        box = (region.x, region.y, region.x + region.w, region.y + region.h)
+        birthdays = [_b("Alice", TODAY + timedelta(days=3))]
+        stale = _render(birthdays, region=region, staleness=StalenessLevel.STALE)
+        none = _render(birthdays, region=region, staleness=None)
+        assert _ink(stale, box) > _ink(none, box), "no staleness badge drawn"
 
-        today = date(2024, 3, 15)
-        birthdays = [Birthday(name="Alice", date=today + timedelta(days=3))]
-        img, draw = _make_draw()
-        draw_birthdays(
-            draw,
-            birthdays,
-            today,
-            region=ComponentRegion(300, 360, 250, 120),
-            staleness=StalenessLevel.STALE,
-        )
-        assert img.getbbox() is not None
+    def test_fresh_staleness_draws_no_glyph(self):
+        """FRESH is not a warning — measured against STALE, which is."""
+        birthdays = [_b("Alice", TODAY + timedelta(days=3))]
+        fresh = _ink(_render(birthdays, staleness=StalenessLevel.FRESH))
+        stale = _ink(_render(birthdays, staleness=StalenessLevel.STALE))
+        assert fresh < stale, "FRESH drew a staleness badge"
 
     def test_none_staleness_no_crash(self):
-        """staleness=None (default) must not crash."""
-        today = date(2024, 3, 15)
-        img, draw = _make_draw()
-        draw_birthdays(draw, [], today, staleness=None)
-        assert img.getbbox() is not None
+        """The default draws the bar without a badge."""
+        assert _ink(_render([], staleness=None)) > 0
 
     def test_early_break_when_layout_too_small(self):
-        """The break fires when y + line_h exceeds available space (line 43).
+        """A region too short for a row breaks out instead of overflowing.
 
-        Achieved by passing a small region (h=50) so the condition triggers:
-        y = y0+32, line_h=22, h=50, pad=8 → 32+22=54 > 50-8=42 → break at i=0
+        y = y0+32, line_h=22, h=50, pad=8 → 32+22 = 54 > 50-8 = 42, so the
+        loop breaks at i=0 and no birthday rows are drawn — only the label.
         """
-        from src.render.theme import ComponentRegion
-
-        today = date(2024, 3, 15)
-        birthdays = [
-            Birthday(name="Alice", date=today + timedelta(days=1)),
-            Birthday(name="Bob", date=today + timedelta(days=2)),
-            Birthday(name="Carol", date=today + timedelta(days=3)),
-        ]
-        img, draw = _make_draw()
-        small_region = ComponentRegion(x=300, y=360, w=250, h=50)
-        draw_birthdays(draw, birthdays, today, region=small_region)
-        assert img.getbbox() is not None
+        small = ComponentRegion(x=300, y=360, w=250, h=50)
+        box = (small.x, small.y, small.x + small.w, small.y + small.h)
+        birthdays = [_b(name, TODAY + timedelta(days=i + 1)) for i, name in enumerate("ABC")]
+        cramped = _render(birthdays, region=small)
+        assert _ink(cramped, box) > 0, "not even the section label was drawn"
+        # No *content* spilled below the region. The right separator is drawn
+        # to y0+h inclusive, so it puts one pixel on the row below — the same
+        # convention weather_panel uses, so the border column is excluded here
+        # rather than treated as an overflow.
+        below = (small.x, small.y + small.h, small.x + small.w - 1, 480)
+        assert _ink(cramped, below) == 0
+        roomy = ComponentRegion(x=300, y=360, w=250, h=120)
+        roomy_box = (roomy.x, roomy.y, roomy.x + roomy.w, roomy.y + roomy.h)
+        assert _ink(cramped, box) < _ink(_render(birthdays, region=roomy), roomy_box), (
+            "the cramped region listed as much as the roomy one"
+        )

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -123,20 +123,24 @@ class TestFeb29Birthday:
         from PIL import Image, ImageDraw
 
         from src.render.components.birthday_bar import draw_birthdays
+        from tests.inkutils import ink
 
         img = Image.new("1", (800, 480), 1)
         draw = ImageDraw.Draw(img)
         # 2025 is not a leap year
         today = date(2025, 3, 15)
         birthdays = [Birthday(name="Leapy", date=date(2000, 2, 29))]
-        # Should not raise ValueError
+        # Should not raise ValueError, and the birthday must still be listed.
         draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        empty = Image.new("1", img.size, 1)
+        draw_birthdays(ImageDraw.Draw(empty), [], today)
+        assert ink(img) != ink(empty), "the Feb-29 birthday was dropped"
 
     def test_feb29_birthday_next_year_non_leap(self):
         from PIL import Image, ImageDraw
 
         from src.render.components.birthday_bar import draw_birthdays
+        from tests.inkutils import ink
 
         img = Image.new("1", (800, 480), 1)
         draw = ImageDraw.Draw(img)
@@ -144,7 +148,9 @@ class TestFeb29Birthday:
         today = date(2025, 3, 15)
         birthdays = [Birthday(name="Leapy", date=date(2000, 2, 29))]
         draw_birthdays(draw, birthdays, today)
-        assert img.getbbox() is not None
+        empty = Image.new("1", img.size, 1)
+        draw_birthdays(ImageDraw.Draw(empty), [], today)
+        assert ink(img) != ink(empty), "the rolled-over Feb-29 birthday was dropped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_constellation_map_panel.py
+++ b/tests/test_constellation_map_panel.py
@@ -287,7 +287,7 @@ class TestDrawConstellationMapDirect:
         draw_constellation_map(
             d, data, TODAY, FIXED_NOW, style=style, latitude=NYC_LAT, longitude=NYC_LON
         )
-        assert img.getbbox() is not None
+        assert _bright(img) > 0
         # A dark-canvas chart drawn with fg=255 should fill many pixels.
         bright = sum(1 for p in img.tobytes() if p > 200)
         assert bright > 50, "expected stars + chrome to brighten the canvas"

--- a/tests/test_constellation_map_panel.py
+++ b/tests/test_constellation_map_panel.py
@@ -18,6 +18,7 @@ from src.render.components.constellation_map_panel import (
     _utc,
     draw_constellation_map,
 )
+from src.render.quantize import flatten_pixels
 from src.render.star_catalog import (
     CONSTELLATIONS,
     LABELED_STARS,
@@ -32,6 +33,17 @@ TZ = ZoneInfo("America/New_York")
 # A clear winter night so Orion + Big Dipper are both up at NYC.
 FIXED_NOW = datetime(2026, 1, 15, 22, 0, tzinfo=TZ)
 TODAY = FIXED_NOW.date()
+
+
+def _bright(img, threshold: int = 200) -> int:
+    """Count lit pixels on the dark chart.
+
+    (#229) This panel draws white-on-black, so "did it render" means lit
+    pixels — and it must be drawn with the *theme's* style to mean anything:
+    under the default ThemeStyle (fg=0) the whole chart is black on black and
+    nothing is visible, which is what several tests here were doing.
+    """
+    return sum(1 for p in flatten_pixels(img) if p > threshold)
 
 
 def _make_draw(w: int = 800, h: int = 480, mode: str = "L"):
@@ -281,12 +293,32 @@ class TestDrawConstellationMapDirect:
         assert bright > 50, "expected stars + chrome to brighten the canvas"
 
     def test_with_lat_lon_during_day_uses_solar_midnight(self):
-        """Renders without crashing during daylight (uses tonight's projection)."""
+        """During daylight the chart projects for tonight, not for now.
+
+        Rendered with the theme style — under the default style the whole
+        chart is fg=0 on a black canvas and nothing is visible at all.
+        """
+        style = load_theme("constellation_map").style
         img, d = _make_draw()
         noon = datetime(2026, 4, 23, 16, 0, tzinfo=ZoneInfo("America/New_York"))
         data = DashboardData(events=[], weather=None)
-        draw_constellation_map(d, data, noon.date(), noon, latitude=NYC_LAT, longitude=NYC_LON)
-        assert img.getbbox() is not None
+        draw_constellation_map(
+            d, data, noon.date(), noon, style=style, latitude=NYC_LAT, longitude=NYC_LON
+        )
+        assert _bright(img) > 50, "daylight render produced no visible chart"
+
+        night, nd = _make_draw()
+        night_now = datetime(2026, 4, 23, 22, 0, tzinfo=ZoneInfo("America/New_York"))
+        draw_constellation_map(
+            nd,
+            data,
+            night_now.date(),
+            night_now,
+            style=style,
+            latitude=NYC_LAT,
+            longitude=NYC_LON,
+        )
+        assert img.tobytes() != night.tobytes(), "the projection ignores the time of day"
 
     def test_with_zero_zero_lat_lon_falls_back_to_message(self):
         """(0,0) coordinates trigger the explanatory message branch."""
@@ -297,7 +329,13 @@ class TestDrawConstellationMapDirect:
         # canvas and getbbox would be None despite the branch having executed.
         style = load_theme("constellation_map").style
         draw_constellation_map(d, data, TODAY, FIXED_NOW, style=style, latitude=0.0, longitude=0.0)
-        assert img.getbbox() is not None
+        assert _bright(img) > 0, "the explanatory message did not render"
+
+        chart, cd = _make_draw()
+        draw_constellation_map(
+            cd, data, TODAY, FIXED_NOW, style=style, latitude=NYC_LAT, longitude=NYC_LON
+        )
+        assert _bright(img) < _bright(chart), "the (0,0) fallback drew as much as a real star chart"
 
     def test_with_weather_location_name_in_footer(self):
         """Weather with a location name should render its footer label."""
@@ -311,28 +349,48 @@ class TestDrawConstellationMapDirect:
             humidity=60,
             location_name="Brooklyn",
         )
+        style = load_theme("constellation_map").style
         data = DashboardData(events=[], weather=w)
-        draw_constellation_map(d, data, TODAY, FIXED_NOW, latitude=NYC_LAT, longitude=NYC_LON)
-        assert img.getbbox() is not None
-
-    def test_polar_observer_renders_without_crashing(self):
-        """At extreme latitudes most stars stay above/below the horizon."""
-        img, d = _make_draw()
-        data = DashboardData(events=[], weather=None)
         draw_constellation_map(
-            d,
-            data,
+            d, data, TODAY, FIXED_NOW, style=style, latitude=NYC_LAT, longitude=NYC_LON
+        )
+        without, wd = _make_draw()
+        draw_constellation_map(
+            wd,
+            DashboardData(events=[], weather=None),
             TODAY,
             FIXED_NOW,
-            latitude=85.0,
-            longitude=0.0,
+            style=style,
+            latitude=NYC_LAT,
+            longitude=NYC_LON,
         )
-        assert img.getbbox() is not None
+        assert _bright(img) > _bright(without), "the location label is not drawn"
+
+    def test_polar_observer_renders_without_crashing(self):
+        """At 85°N the chart still draws, and differs from a mid-latitude one."""
+        style = load_theme("constellation_map").style
+        data = DashboardData(events=[], weather=None)
+        img, d = _make_draw()
+        draw_constellation_map(d, data, TODAY, FIXED_NOW, style=style, latitude=85.0, longitude=0.0)
+        nyc, nd = _make_draw()
+        draw_constellation_map(
+            nd, data, TODAY, FIXED_NOW, style=style, latitude=NYC_LAT, longitude=NYC_LON
+        )
+        assert _bright(img) > 50, "polar render produced no visible chart"
+        assert img.tobytes() != nyc.tobytes(), "latitude does not affect the projection"
 
     def test_southern_hemisphere_observer(self):
-        """A southern observer projects correctly (most northern stars below horizon)."""
-        img, d = _make_draw()
+        """A southern observer gets a different sky from a northern one."""
+        style = load_theme("constellation_map").style
         data = DashboardData(events=[], weather=None)
         sydney = datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)
-        draw_constellation_map(d, data, sydney.date(), sydney, latitude=-33.87, longitude=151.21)
-        assert img.getbbox() is not None
+        img, d = _make_draw()
+        draw_constellation_map(
+            d, data, sydney.date(), sydney, style=style, latitude=-33.87, longitude=151.21
+        )
+        north, nd = _make_draw()
+        draw_constellation_map(
+            nd, data, sydney.date(), sydney, style=style, latitude=33.87, longitude=151.21
+        )
+        assert _bright(img) > 50, "southern render produced no visible chart"
+        assert img.tobytes() != north.tobytes(), "the hemisphere is not reflected in the chart"

--- a/tests/test_countdown_theme.py
+++ b/tests/test_countdown_theme.py
@@ -15,6 +15,7 @@ from src.render.components.countdown_panel import (
     draw_countdown,
 )
 from src.render.theme import AVAILABLE_THEMES, load_theme
+from tests.inkutils import ink
 
 FIXED_NOW = datetime(2026, 4, 23, 12, 0)
 TODAY = FIXED_NOW.date()
@@ -159,12 +160,16 @@ class TestDrawCountdownDirect:
         img, d = _make_draw()
         draw_countdown(d, [], TODAY)
         # Empty state should still produce pixels
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the empty countdown state drew nothing"
 
     def test_none_events_treated_as_empty(self):
         img, d = _make_draw()
         draw_countdown(d, None, TODAY)  # type: ignore[arg-type]
-        assert img.getbbox() is not None
+        empty, ed = _make_draw()
+        draw_countdown(ed, [], TODAY)
+        assert img.tobytes() == empty.tobytes(), (
+            "events=None was not treated the same as an empty list"
+        )
 
     def test_resolved_dataclass_instance(self):
         r = _Resolved(name="X", target=date(2026, 5, 1), days_until=8)

--- a/tests/test_data_pipeline_coverage.py
+++ b/tests/test_data_pipeline_coverage.py
@@ -665,3 +665,76 @@ class TestRegistryFetcherSkipDecisions:
             fetch_fn.assert_called_once()
         finally:
             unregister_fetcher("__review_209b__")
+
+
+# ---------------------------------------------------------------------------
+# Regression (#228): _cache_is_recent guarded on `save_metadata is not None`,
+# but save_metadata defaults to the _no_metadata *function*, so that test was
+# always true and the non-metadata branch behind it was unreachable. It was
+# also incoherent — it fell through to interval_map[source], which is built
+# from all_fetchers() and would KeyError on the very sources the branch
+# claimed to serve. The load-bearing test is the second one below: the
+# sources that branch nominally served must keep reading their cache.
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIsRecentUnregisteredSource:
+    def test_unregistered_source_returns_not_recent(self, tmp_path):
+        """Characterization, NOT a guard test — it passes either way.
+
+        Deliberately labelled: this still passes with the `fetcher is None`
+        branch deleted, because an unregistered source also fails the blob
+        decode (_decode_v2_block returns None when get_fetcher does). The
+        branch survives for mypy, which cannot see that. Verified by
+        deleting it and re-running. Don't read this as proof the guard works.
+        """
+        cfg = Config()
+        cfg.purpleair = PurpleAirConfig()
+        pipeline = DataPipeline(cfg, cache_dir=str(tmp_path))
+        pipeline._cache_blob = {}
+
+        assert pipeline._cache_is_recent("__not_registered__") == (None, False)
+
+    def test_registered_source_without_custom_metadata_uses_cache(self, tmp_path):
+        """A fetcher that never set save_metadata still reads its cache.
+
+        This is the case the deleted branch nominally existed for. It has
+        always gone through the metadata path (cache_metadata_valid defaults
+        to always-True), and must keep doing so.
+        """
+        from datetime import timedelta
+
+        from src.fetchers.cache import save_source
+
+        cfg = Config()
+        cfg.purpleair = PurpleAirConfig()
+        register_fetcher(
+            Fetcher(
+                name="__no_meta_228__",
+                fetch=lambda ctx: {"v": 1},
+                serialize=lambda d: d,
+                deserialize=lambda b: b,
+                ttl_minutes=lambda cfg: 60,
+                interval_minutes=lambda cfg: 60,
+            )
+        )
+        try:
+            pipeline = DataPipeline(cfg, cache_dir=str(tmp_path))
+            # Cached 5 minutes ago, well inside the 60-minute interval.
+            save_source(
+                "__no_meta_228__",
+                {"v": 1},
+                pipeline.fetched_at - timedelta(minutes=5),
+                str(tmp_path),
+            )
+            from src.fetchers.cache import load_cache_blob
+
+            # fetch() normally seeds both; this calls the helper directly.
+            pipeline._cache_blob = load_cache_blob(str(tmp_path))
+            pipeline._content_at = {}
+
+            data, recent = pipeline._cache_is_recent("__no_meta_228__")
+            assert recent is True
+            assert data == {"v": 1}
+        finally:
+            unregister_fetcher("__no_meta_228__")

--- a/tests/test_day_arc_theme.py
+++ b/tests/test_day_arc_theme.py
@@ -53,6 +53,7 @@ from src.render.theme import (
     ThemeStyle,
     load_theme,
 )
+from tests.inkutils import marks
 
 FIXED_NOW = datetime(2026, 4, 6, 10, 30)
 TODAY = FIXED_NOW.date()
@@ -723,7 +724,7 @@ def test_draw_day_arc_default_style_does_not_crash():
     # draw handle's backing image.
     image = Image.new("L", (800, 480), 255)
     draw_day_arc(ImageDraw.Draw(image), _data_for(), TODAY, FIXED_NOW)
-    assert image.getbbox() is not None
+    assert marks(image) > 0, "the default-style plate rendered blank"
 
 
 def test_draw_day_arc_accepts_an_explicit_style():
@@ -738,7 +739,7 @@ def test_draw_day_arc_accepts_an_explicit_style():
         latitude=NYC[0],
         longitude=NYC[1],
     )
-    assert image.getbbox() is not None
+    assert marks(image) > 0, "the coordinate path rendered blank"
 
 
 def test_draw_day_arc_with_aware_now():
@@ -747,4 +748,9 @@ def test_draw_day_arc_with_aware_now():
     image = Image.new("L", (800, 480), 255)
     aware = FIXED_NOW.replace(tzinfo=timezone.utc)
     draw_day_arc(ImageDraw.Draw(image), _data_for(), TODAY, aware, image=image)
-    assert image.getbbox() is not None
+    assert marks(image) > 0, "the aware-now path rendered blank"
+    # An aware `now` must resolve against its own zone, not the host's, so the
+    # plate is stable regardless of where the suite runs.
+    again = Image.new("L", (800, 480), 255)
+    draw_day_arc(ImageDraw.Draw(again), _data_for(), TODAY, aware, image=again)
+    assert image.tobytes() == again.tobytes()

--- a/tests/test_diags_theme.py
+++ b/tests/test_diags_theme.py
@@ -19,8 +19,18 @@ from src.data.models import (
     WeatherData,
 )
 from src.render.canvas import render_dashboard
+from src.render.quantize import flatten_pixels
 from src.render.theme import AVAILABLE_THEMES, load_theme
 from src.render.themes.diags import diags_theme
+
+# Assertion discipline (see #229): the render tests here asserted only
+# isinstance/size, or nothing at all — all 40 passed with draw_diags stubbed
+# to a no-op. They now measure ink per column: the panel is two columns split
+# by a vertical divider at x=400, weather/forecast/host on the left and
+# calendar/air-quality/birthdays/status on the right, so each test measures
+# the column that owns what it changes. The three truncation caps
+# (_MAX_BIRTHDAYS=5, _MAX_FORECAST=6, _MAX_ALERTS=2) are pinned by asserting
+# that going past each one renders byte-identically to hitting it exactly.
 
 # ---------------------------------------------------------------------------
 # Shared fixture
@@ -97,6 +107,46 @@ def _make_data(today: date | None = None) -> DashboardData:
 
 
 # ---------------------------------------------------------------------------
+# Ink measurement
+# ---------------------------------------------------------------------------
+
+# Column geometry, from diags_panel's own layout constants.
+HEADER = (0, 0, 800, 28)
+LEFT_COL = (10, 34, 388, 480)
+RIGHT_COL = (412, 34, 788, 480)
+_DIVIDER_X = 400
+
+
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _divider_height(img) -> int:
+    """Inked rows in the vertical column divider."""
+    px = flatten_pixels(img)
+    width = img.width
+    return sum(1 for y in range(28, img.height - 1) if px[y * width + _DIVIDER_X] == 0)
+
+
+def _section_rules(img, column) -> int:
+    """Full-width horizontal separator rules inside a column."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = column
+    return sum(
+        1
+        for y in range(y0, y1)
+        if sum(1 for x in range(x0, x1) if px[y * width + x] == 0) > (x1 - x0) * 0.9
+    )
+
+
+# ---------------------------------------------------------------------------
 # Theme structure
 # ---------------------------------------------------------------------------
 
@@ -153,57 +203,90 @@ class TestDiagsTheme:
 
 
 class TestDiagsRender:
+    """Rendered content, measured per column.
+
+    The panel is two columns split by a vertical divider at x=400: weather /
+    forecast / host on the left, calendar / air quality / birthdays / status
+    on the right. Each test measures the column that owns what it changes.
+    """
+
+    def _render(self, data=None, config=None, theme=None) -> Image.Image:
+        return render_dashboard(
+            data if data is not None else _make_data(),
+            config or DisplayConfig(),
+            theme=theme or diags_theme(),
+        )
+
     def test_render_returns_image(self):
-        result = render_dashboard(_make_data(), DisplayConfig(), theme=diags_theme())
-        assert isinstance(result, Image.Image)
+        assert isinstance(self._render(), Image.Image)
 
     def test_render_correct_size(self):
-        result = render_dashboard(
-            _make_data(),
-            DisplayConfig(width=800, height=480),
-            theme=diags_theme(),
-        )
+        result = self._render(config=DisplayConfig(width=800, height=480))
         assert result.size == (800, 480)
 
+    def test_render_draws_both_columns_and_the_divider(self):
+        """The two-column structure is present, not just some ink somewhere."""
+        img = self._render()
+        assert _ink(img, LEFT_COL) > 0, "left column empty"
+        assert _ink(img, RIGHT_COL) > 0, "right column empty"
+        assert _divider_height(img) > 300, "no vertical column divider"
+        assert _section_rules(img, LEFT_COL) == 2, "left column section rules missing"
+        assert _section_rules(img, RIGHT_COL) == 3, "right column section rules missing"
+
     def test_render_no_weather(self):
+        """Weather and forecast both live in the left column, so it loses ink."""
         data = _make_data()
+        full = _ink(self._render(data), LEFT_COL)
         data.weather = None
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(self._render(data), LEFT_COL) < full, "weather section still drawn"
 
     def test_render_no_air_quality(self):
+        """Air quality is a right-column section."""
         data = _make_data()
+        full = _ink(self._render(data), RIGHT_COL)
         data.air_quality = None
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        without = _ink(self._render(data), RIGHT_COL)
+        assert without != full, "the air-quality section is not being drawn"
+        assert _section_rules(self._render(data), RIGHT_COL) == 3, "a section rule disappeared"
 
     def test_render_empty_events(self):
         data = _make_data()
+        full = _ink(self._render(data), RIGHT_COL)
         data.events = []
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(self._render(data), RIGHT_COL) != full
 
     def test_render_empty_birthdays(self):
         data = _make_data()
+        full = _ink(self._render(data), RIGHT_COL)
         data.birthdays = []
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(self._render(data), RIGHT_COL) != full
 
     def test_render_stale_data(self):
+        """Staleness surfaces in the right-hand status section."""
         data = _make_data()
+        fresh = _ink(self._render(data), RIGHT_COL)
         data.is_stale = True
         data.stale_sources = ["weather"]
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        data.source_staleness = {"weather": StalenessLevel.STALE}
+        assert _ink(self._render(data), RIGHT_COL) != fresh, "staleness is not reported"
 
     def test_render_all_sources_stale(self):
+        """Each staleness level prints its own label, so the three differ."""
         data = _make_data()
-        data.is_stale = True
-        data.source_staleness = {
-            "weather": StalenessLevel.STALE,
-            "events": StalenessLevel.EXPIRED,
-            "air_quality": StalenessLevel.AGING,
-        }
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        plates = set()
+        for levels in (
+            {"weather": StalenessLevel.FRESH},
+            {"weather": StalenessLevel.STALE},
+            {"weather": StalenessLevel.EXPIRED},
+        ):
+            data.source_staleness = levels
+            plates.add(self._render(data).tobytes())
+        assert len(plates) == 3, "different staleness levels rendered the same"
 
     def test_render_minimal_weather(self):
-        """Weather with only required fields (no optional fields)."""
+        """Weather with no optional fields draws less than the full record."""
         data = _make_data()
+        full = _ink(self._render(data), LEFT_COL)
         data.weather = WeatherData(
             current_temp=60.0,
             current_icon="01d",
@@ -212,22 +295,41 @@ class TestDiagsRender:
             low=50.0,
             humidity=45,
         )
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        minimal = _ink(self._render(data), LEFT_COL)
+        assert minimal < full, "optional weather fields are not being drawn"
+        assert minimal > 0
 
     def test_render_weather_with_alerts(self):
         data = _make_data()
+        without = _ink(self._render(data), LEFT_COL)
         data.weather.alerts = [WeatherAlert(event="Flood Watch")]
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(self._render(data), LEFT_COL) > without, "alerts are not drawn"
+
+    def test_alerts_capped_at_two(self):
+        """_MAX_ALERTS=2 — a third alert must not reach the plate."""
+        data = _make_data()
+
+        def with_alerts(n):
+            data.weather.alerts = [WeatherAlert(event=f"Alert {i}") for i in range(n)]
+            return _ink(self._render(data), LEFT_COL)
+
+        two = with_alerts(2)
+        assert with_alerts(5) == two, "more than two alerts were drawn"
+        assert two > with_alerts(1), "the second alert was dropped too"
 
     def test_render_aq_partial_fields(self):
-        """AirQualityData with only required fields (no pm1, pm10, temp, etc.)."""
+        """Only the required AQ fields draws less than the full sensor record."""
         data = _make_data()
+        full = _ink(self._render(data), RIGHT_COL)
         data.air_quality = AirQualityData(aqi=55, category="Moderate", pm25=12.5)
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        partial = _ink(self._render(data), RIGHT_COL)
+        assert 0 < partial < full, "the optional sensor fields are not being drawn"
 
     def test_render_aq_all_sensor_fields(self):
-        """AirQualityData with all new PurpleAir sensor fields populated."""
+        """Every PurpleAir field populated draws the most of the three cases."""
         data = _make_data()
+        data.air_quality = AirQualityData(aqi=42, category="Good", pm25=9.8)
+        bare = _ink(self._render(data), RIGHT_COL)
         data.air_quality = AirQualityData(
             aqi=42,
             category="Good",
@@ -239,21 +341,52 @@ class TestDiagsRender:
             humidity=48.0,
             pressure=1012.5,
         )
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(self._render(data), RIGHT_COL) > bare
 
-    def test_render_many_birthdays(self):
-        """Test with max birthdays to ensure no vertical overflow crash."""
+    def test_birthdays_capped_at_five(self):
+        """_MAX_BIRTHDAYS=5 — the sixth and later entries are dropped."""
         data = _make_data()
         today = data.fetched_at.date()
-        data.birthdays = [
-            Birthday(name=f"Person {i}", date=today + timedelta(days=i + 1), age=30 + i)
-            for i in range(5)
-        ]
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+
+        def with_birthdays(n):
+            data.birthdays = [
+                Birthday(name=f"Person {i}", date=today + timedelta(days=i + 1), age=30 + i)
+                for i in range(n)
+            ]
+            return _ink(self._render(data), RIGHT_COL)
+
+        five = with_birthdays(5)
+        assert with_birthdays(9) == five, "more than five birthdays were drawn"
+        assert five > with_birthdays(4), "the fifth birthday was dropped too"
+
+    def test_forecast_capped_at_six(self):
+        """_MAX_FORECAST=6 — a seventh day must not reach the plate."""
+        data = _make_data()
+        today = data.fetched_at.date()
+
+        def with_days(n):
+            data.weather.forecast = [
+                DayForecast(
+                    date=today + timedelta(days=i + 1),
+                    high=70.0 + i,
+                    low=55.0 + i,
+                    icon="02d",
+                    description="partly cloudy",
+                    precip_chance=0.20,
+                )
+                for i in range(n)
+            ]
+            return _ink(self._render(data), LEFT_COL)
+
+        six = with_days(6)
+        assert with_days(10) == six, "more than six forecast days were drawn"
+        assert six > with_days(5), "the sixth day was dropped too"
 
     def test_render_via_load_theme(self):
-        result = render_dashboard(_make_data(), DisplayConfig(), theme=load_theme("diags"))
-        assert isinstance(result, Image.Image)
+        """The registry's theme renders the same plate as the factory's."""
+        via_registry = self._render(theme=load_theme("diags"))
+        assert isinstance(via_registry, Image.Image)
+        assert via_registry.tobytes() == self._render().tobytes()
 
 
 # ---------------------------------------------------------------------------
@@ -342,7 +475,7 @@ class TestAirQualityCacheRoundtrip:
 
 
 class TestDiagsPanelDefaults:
-    """Call draw_diags directly to cover default region/style/today branches."""
+    """draw_diags called directly: default region/style/today branches."""
 
     def _make_draw(self):
         from PIL import ImageDraw
@@ -351,41 +484,68 @@ class TestDiagsPanelDefaults:
         return img, ImageDraw.Draw(img)
 
     def test_default_region_and_style(self):
-        """region=None and style=None trigger the default assignment branches."""
-        from src.render.components.diags_panel import draw_diags
-
-        _, draw = self._make_draw()
-        draw_diags(draw, _make_data(), region=None, style=None)
-
-    def test_today_derived_from_datetime_fetched_at(self):
-        """today=None with a datetime fetched_at uses now.date()."""
+        """region=None/style=None fill in the full-canvas defaults."""
         from src.render.components.diags_panel import draw_diags
         from src.render.theme import ComponentRegion, ThemeStyle
 
-        _, draw = self._make_draw()
-        data = _make_data()
+        img_default, draw = self._make_draw()
+        draw_diags(draw, _make_data(), region=None, style=None)
+        img_explicit, draw2 = self._make_draw()
         draw_diags(
-            draw, data, today=None, region=ComponentRegion(0, 0, 800, 480), style=ThemeStyle()
+            draw2,
+            _make_data(),
+            region=ComponentRegion(0, 0, 800, 480),
+            style=ThemeStyle(),
         )
+        assert _ink(img_default) > 0
+        assert img_default.tobytes() == img_explicit.tobytes()
+
+    def test_today_derived_from_datetime_fetched_at(self):
+        """today=None with a datetime fetched_at uses now.date().
+
+        Checked against the same date passed explicitly. Note the resolution:
+        `today` reaches the plate only through _calendar_section, which
+        buckets by ISO week, so this detects a derivation off by a week but
+        not one off by a day or two. Verified by shifting the derived date —
+        +3 days still passes, +7 fails. The birthday section ignores `today`
+        entirely.
+        """
+        from src.render.components.diags_panel import draw_diags
+
+        data = _make_data()
+        derived, draw = self._make_draw()
+        draw_diags(draw, data, today=None)
+        explicit, draw2 = self._make_draw()
+        draw_diags(draw2, data, today=data.fetched_at.date())
+        assert derived.tobytes() == explicit.tobytes(), "today was not derived from fetched_at"
 
     def test_today_derived_from_date_fetched_at(self):
-        """today=None with a plain date fetched_at falls back to date.today() (line 60)."""
-        from datetime import date
+        """A plain-date fetched_at falls back to date.today() rather than raising."""
+        from datetime import date as _date
 
         from src.render.components.diags_panel import draw_diags
 
-        _, draw = self._make_draw()
         data = _make_data()
-        data.fetched_at = date(2026, 3, 24)  # plain date, not datetime
+        data.fetched_at = _date(2026, 3, 24)
+        img, draw = self._make_draw()
         draw_diags(draw, data, today=None)
+        explicit, draw2 = self._make_draw()
+        draw_diags(draw2, data, today=_date.today())
+        assert _ink(img) > 0
+        assert img.tobytes() == explicit.tobytes(), "the date.today() fallback was not taken"
 
     def test_header_non_datetime_fetched_at(self):
-        """fetched_at as a plain date renders header via str(now) branch (line 126)."""
-        from datetime import date
+        """A plain date in the header renders via the str(now) branch.
 
+        It must differ from the datetime header — that branch exists because
+        a date has no time to format.
+        """
         data = _make_data()
+        with_datetime = render_dashboard(data, DisplayConfig(), theme=diags_theme())
         data.fetched_at = date(2026, 3, 24)
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        with_date = render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        assert _ink(with_date, HEADER) > 0
+        assert _ink(with_date, HEADER) != _ink(with_datetime, HEADER)
 
 
 class TestFmtUptime:
@@ -414,13 +574,13 @@ class TestFmtUptime:
 
 
 class TestHostSectionFullData:
-    """Render diags with a fully populated HostData to cover _host_section lines."""
+    """The host section is the bottom of the left column."""
 
-    def test_render_with_all_host_fields(self):
+    @staticmethod
+    def _full_host():
         from src.data.models import HostData
 
-        data = _make_data()
-        data.host_data = HostData(
+        return HostData(
             hostname="pi-dashboard",
             uptime_seconds=90061.0,  # 1d 1h 1m — exercises the days branch
             load_1m=0.42,
@@ -433,13 +593,27 @@ class TestHostSectionFullData:
             cpu_temp_c=42.7,
             ip_address="192.168.1.100",
         )
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+
+    def _left_ink(self, host) -> int:
+        data = _make_data()
+        data.host_data = host
+        return _ink(render_dashboard(data, DisplayConfig(), theme=diags_theme()), LEFT_COL)
+
+    def test_render_with_all_host_fields(self):
+        """Every field populated draws more than the unavailable row."""
+        assert self._left_ink(self._full_host()) > self._left_ink(None)
 
     def test_render_with_none_host_data(self):
-        """host_data=None renders the 'unavailable' row."""
-        data = _make_data()
-        data.host_data = None
-        render_dashboard(data, DisplayConfig(), theme=diags_theme())
+        """host_data=None renders the 'unavailable' row, not a blank section."""
+        assert self._left_ink(None) > 0
+
+    def test_partial_host_data_is_distinguishable(self):
+        """Fields that are None are omitted rather than printed as placeholders."""
+        from src.data.models import HostData
+
+        partial = HostData(hostname="pi-dashboard", uptime_seconds=90061.0)
+        assert self._left_ink(partial) != self._left_ink(self._full_host())
+        assert self._left_ink(partial) != self._left_ink(None)
 
 
 class TestDiagsNotInRandomPool:

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -19,7 +19,7 @@ these pixels on every tick and force an eInk refresh for content that has
 not moved.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from PIL import Image, ImageDraw
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,11 +1,37 @@
-"""Tests for src/render/components/header.py."""
+"""Tests for src/render/components/header.py.
 
-from datetime import datetime
+Assertion discipline (see #229)
+-------------------------------
+These tests asserted ``img.getbbox() is not None`` on a mode-``"1"`` plate
+filled with 1, where every pixel is non-zero and getbbox can never return
+None. All 10 passed with ``draw_header`` stubbed to a no-op.
+
+Ink means **zero-valued** pixels. Note the polarity: with the default style
+the header is an inverted band — filled in ``fg`` with its text knocked out
+in ``bg`` — so *more text means less ink*, and the staleness assertions are
+written in that direction.
+
+The load-bearing test here is ``test_updated_stamp_reads_content_at_not_now``.
+CLAUDE.md's idle-tick rule requires this label to be drawn from
+``DashboardData.content_at`` rather than the render clock: ``now`` advances
+every run whether or not anything was fetched, so reading it would change
+these pixels on every tick and force an eInk refresh for content that has
+not moved.
+"""
+
+from datetime import datetime, timedelta
 
 from PIL import Image, ImageDraw
 
 from src.data.models import StalenessLevel
+from src.render import layout as L
 from src.render.components.header import draw_header
+from src.render.quantize import flatten_pixels
+from src.render.theme import ComponentRegion, ThemeStyle
+
+REGION = ComponentRegion(0, L.HEADER_Y, L.WIDTH, L.HEADER_H)
+BOX = (REGION.x, REGION.y, REGION.x + REGION.w, REGION.y + REGION.h)
+AREA = REGION.w * REGION.h
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -13,95 +39,129 @@ def _make_draw(w: int = 800, h: int = 480):
     return img, ImageDraw.Draw(img)
 
 
+def _ink(img: Image.Image, box: tuple[int, int, int, int] = BOX) -> int:
+    """Count ink (value-0) pixels inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
 class TestDrawHeader:
     def _now(self):
         return datetime(2026, 3, 18, 9, 30)
 
-    def test_smoke_renders_without_error(self):
+    def _render(self, now=None, **kwargs) -> Image.Image:
         img, draw = _make_draw()
-        draw_header(draw, self._now())
-        assert img.getbbox() is not None
+        draw_header(draw, now or self._now(), **kwargs)
+        return img
+
+    def test_smoke_renders_without_error(self):
+        """The default style fills the band and knocks its text out of it."""
+        img = self._render()
+        assert _ink(img) > AREA * 0.5, "header band is not inverted"
+        assert _ink(img) < AREA, "no text was knocked out of the fill"
+
+    def test_uninverted_header_draws_a_rule_instead_of_a_band(self):
+        """invert_header=False leaves ink for the text and border only."""
+        plain = self._render(style=ThemeStyle(invert_header=False))
+        assert 0 < _ink(plain) < AREA * 0.5, "the band was filled despite invert_header=False"
 
     def test_fresh_staleness_shows_updated_label(self):
-        """No stale sources → header shows 'Updated' (no alert prefix)."""
-        img, draw = _make_draw()
-        draw_header(
-            draw,
-            self._now(),
-            source_staleness={"events": StalenessLevel.FRESH, "weather": StalenessLevel.FRESH},
-        )
-        assert img.getbbox() is not None  # rendered without crash
+        """FRESH draws the plain 'Updated' label, not a warning."""
+        fresh = self._render(source_staleness={"weather": StalenessLevel.FRESH})
+        stale = self._render(source_staleness={"weather": StalenessLevel.STALE})
+        assert _ink(fresh) != _ink(stale), "FRESH and STALE drew the same label"
 
     def test_aging_staleness_does_not_show_stale(self):
-        """AGING staleness does not trigger '! Stale' label (lines 39-47 severity logic)."""
-        img, draw = _make_draw()
-        # AGING is below the threshold for '! Stale' label
-        draw_header(
-            draw,
-            self._now(),
-            source_staleness={"weather": StalenessLevel.AGING},
-        )
-        assert img.getbbox() is not None
+        """AGING is below the warning threshold — same label as FRESH."""
+        aging = self._render(source_staleness={"weather": StalenessLevel.AGING})
+        fresh = self._render(source_staleness={"weather": StalenessLevel.FRESH})
+        stale = self._render(source_staleness={"weather": StalenessLevel.STALE})
+        assert _ink(aging) == _ink(fresh), "AGING was escalated to a warning label"
+        assert _ink(aging) != _ink(stale)
 
     def test_stale_staleness_renders(self):
-        """STALE source triggers '! Stale' label (lines 39-49)."""
-        img, draw = _make_draw()
-        draw_header(
-            draw,
-            self._now(),
-            source_staleness={"weather": StalenessLevel.STALE},
-        )
-        assert img.getbbox() is not None
+        """STALE swaps in the '! Stale' label, which is wider than 'Updated'.
+
+        The band is inverted, so a wider label knocks out more and leaves
+        *less* ink.
+        """
+        stale = self._render(source_staleness={"weather": StalenessLevel.STALE})
+        fresh = self._render(source_staleness={"weather": StalenessLevel.FRESH})
+        assert stale != fresh
+        assert _ink(stale) > _ink(fresh), "'! Stale' did not replace 'Updated'"
 
     def test_expired_staleness_renders(self):
-        """EXPIRED source also triggers '! Stale' label."""
-        img, draw = _make_draw()
-        draw_header(
-            draw,
-            self._now(),
-            source_staleness={"events": StalenessLevel.EXPIRED},
-        )
-        assert img.getbbox() is not None
+        """EXPIRED shares the '! Stale' label with STALE."""
+        expired = self._render(source_staleness={"weather": StalenessLevel.EXPIRED})
+        stale = self._render(source_staleness={"weather": StalenessLevel.STALE})
+        assert _ink(expired) == _ink(stale)
+        assert _ink(expired) != _ink(self._render())
 
     def test_is_stale_without_severe_levels_shows_cached(self):
-        """is_stale=True with no STALE/EXPIRED sources triggers '! Cached' label (line 50)."""
-        img, draw = _make_draw()
-        # is_stale=True but no source_staleness with STALE/EXPIRED
-        draw_header(
-            draw,
-            self._now(),
-            is_stale=True,
-            source_staleness={"weather": StalenessLevel.FRESH},
-        )
-        assert img.getbbox() is not None
+        """is_stale=True with only AGING sources draws '! Cached', its own label."""
+        cached = self._render(is_stale=True, source_staleness={"weather": StalenessLevel.AGING})
+        assert _ink(cached) != _ink(self._render()), "'! Cached' was not drawn"
+        assert _ink(cached) != _ink(
+            self._render(source_staleness={"weather": StalenessLevel.STALE})
+        ), "'! Cached' is indistinguishable from '! Stale'"
 
     def test_is_stale_no_source_staleness_shows_cached(self):
-        """is_stale=True with no source_staleness dict triggers '! Cached' (line 50)."""
-        img, draw = _make_draw()
-        draw_header(draw, self._now(), is_stale=True)
-        assert img.getbbox() is not None
+        """No per-source map at all still yields the '! Cached' label."""
+        assert _ink(self._render(is_stale=True)) == _ink(
+            self._render(is_stale=True, source_staleness={"weather": StalenessLevel.AGING})
+        )
 
     def test_severity_ordering_multiple_sources(self):
-        """Worst staleness level wins: STALE beats AGING (lines 39-47)."""
-        img, draw = _make_draw()
-        draw_header(
-            draw,
-            self._now(),
-            source_staleness={
-                "events": StalenessLevel.AGING,
-                "weather": StalenessLevel.STALE,
-                "birthdays": StalenessLevel.FRESH,
-            },
+        """The worst level across sources wins, regardless of dict order."""
+        worst_last = self._render(
+            source_staleness={"a": StalenessLevel.AGING, "b": StalenessLevel.STALE}
         )
-        assert img.getbbox() is not None
+        worst_first = self._render(
+            source_staleness={"a": StalenessLevel.STALE, "b": StalenessLevel.AGING}
+        )
+        only_stale = self._render(source_staleness={"b": StalenessLevel.STALE})
+        assert _ink(worst_last) == _ink(worst_first) == _ink(only_stale), (
+            "the label depends on iteration order rather than severity"
+        )
 
     def test_custom_title_renders(self):
-        img, draw = _make_draw()
-        draw_header(draw, self._now(), title="My Dashboard")
-        assert img.getbbox() is not None
+        """The title is drawn from the argument, not hardcoded."""
+        assert _ink(self._render(title="My Dashboard")) != _ink(self._render())
 
     def test_pm_time_format(self):
-        """Timestamps should render correctly for PM times."""
-        img, draw = _make_draw()
-        draw_header(draw, datetime(2026, 3, 18, 15, 45))
-        assert img.getbbox() is not None
+        """Morning and evening stamps format differently (a vs p)."""
+        morning = self._render(now=datetime(2026, 3, 18, 9, 43))
+        evening = self._render(now=datetime(2026, 3, 18, 21, 43))
+        assert _ink(morning) != _ink(evening)
+
+    def test_updated_stamp_reads_content_at_not_now(self):
+        """The stamp must track when the data changed, not when we painted.
+
+        This is CLAUDE.md's idle-tick rule. If this label were drawn from
+        `now`, every tick of the 5-minute timer would change these pixels,
+        the image hash would differ, and the panel would be rewritten to
+        repaint a timestamp for data that had not moved.
+        `tests/test_idle_tick_no_redraw.py` guards the whole-plate version of
+        this; here it is pinned at the component.
+        """
+        content_at = datetime(2026, 3, 18, 9, 0)
+        early = self._render(now=datetime(2026, 3, 18, 9, 30), content_at=content_at)
+        later = self._render(now=datetime(2026, 3, 18, 10, 7), content_at=content_at)
+        assert early.tobytes() == later.tobytes(), (
+            "the header changed on an idle tick — it is reading the render clock"
+        )
+
+    def test_updated_stamp_moves_when_the_content_does(self):
+        """The converse: a newer content_at must reach the plate."""
+        now = datetime(2026, 3, 18, 10, 7)
+        old = self._render(now=now, content_at=datetime(2026, 3, 18, 9, 0))
+        fresh = self._render(now=now, content_at=datetime(2026, 3, 18, 10, 5))
+        assert old.tobytes() != fresh.tobytes(), "content_at is not being drawn at all"
+
+    def test_now_is_used_when_content_at_is_absent(self):
+        """Without content_at the stamp falls back to the render clock."""
+        a = self._render(now=datetime(2026, 3, 18, 9, 30))
+        b = self._render(now=datetime(2026, 3, 18, 10, 7))
+        assert a.tobytes() != b.tobytes()

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -8,6 +8,7 @@ from src.render.icons import (
     OWM_ICON_MAP,
     draw_weather_icon,
 )
+from src.render.quantize import flatten_pixels
 
 
 def _make_draw(w: int = 200, h: int = 200):
@@ -77,32 +78,65 @@ class TestFallbackIcon:
 
 
 class TestDrawWeatherIcon:
+    """Ink means zero-valued pixels; the plate is white, so getbbox on it
+    reports the full canvas whether or not a glyph was drawn (#229)."""
+
+    @staticmethod
+    def _ink(img) -> int:
+        return sum(1 for v in flatten_pixels(img) if v == 0)
+
+    @staticmethod
+    def _ink_bbox(img):
+        px = flatten_pixels(img)
+        width = img.width
+        xs, ys = [], []
+        for y in range(img.height):
+            row = y * width
+            for x in range(width):
+                if px[row + x] == 0:
+                    xs.append(x)
+                    ys.append(y)
+        return (min(xs), min(ys), max(xs) + 1, max(ys) + 1) if xs else None
+
+    def _draw(self, code, size=48, fill=0, w=200, h=200):
+        img, draw = _make_draw(w=w, h=h)
+        draw_weather_icon(draw, (10, 10), code, size=size, fill=fill)
+        return img
+
     def test_smoke_valid_code(self):
-        """draw_weather_icon with a known OWM code should not raise."""
-        img, draw = _make_draw()
-        draw_weather_icon(draw, (10, 10), "01d")
-        assert img.getbbox() is not None
+        """A known code puts a glyph on the plate, at the requested origin."""
+        img = self._draw("01d")
+        assert self._ink(img) > 0, "no glyph drawn"
+        bbox = self._ink_bbox(img)
+        assert bbox is not None and bbox[0] >= 10 and bbox[1] >= 10
 
     def test_smoke_unknown_code_uses_fallback(self):
-        """Unknown codes should silently use FALLBACK_ICON."""
-        img, draw = _make_draw()
-        draw_weather_icon(draw, (10, 10), "99z")
-        assert img.getbbox() is not None
+        """Two different unknown codes render identically — and unlike a known one.
+
+        That is what "uses the fallback" means; the previous assertion could
+        not distinguish a fallback glyph from any other.
+        """
+        assert self._draw("99z").tobytes() == self._draw("qqq").tobytes()
+        assert self._draw("99z").tobytes() != self._draw("01d").tobytes()
 
     def test_empty_code_uses_fallback(self):
-        img, draw = _make_draw()
-        draw_weather_icon(draw, (10, 10), "")
-        assert img.getbbox() is not None
+        """An empty code takes the same path as an unrecognised one."""
+        assert self._draw("").tobytes() == self._draw("99z").tobytes()
 
     def test_custom_size(self):
-        img, draw = _make_draw(w=400, h=400)
-        draw_weather_icon(draw, (10, 10), "01d", size=64)
-        assert img.getbbox() is not None
+        """A larger size draws a proportionally larger glyph."""
+        small = self._ink_bbox(self._draw("01d", size=48))
+        large = self._ink_bbox(self._draw("01d", size=64, w=400, h=400))
+        assert small is not None and large is not None
+        assert (large[2] - large[0]) > (small[2] - small[0]), "size= did not widen the glyph"
+        assert (large[3] - large[1]) > (small[3] - small[1]), "size= did not heighten the glyph"
 
     def test_small_size(self):
-        img, draw = _make_draw()
-        draw_weather_icon(draw, (5, 5), "02d", size=16)
-        assert img.getbbox() is not None
+        """A 16px glyph is smaller than the 48px default, not merely present."""
+        tiny = self._ink_bbox(self._draw("02d", size=16))
+        default = self._ink_bbox(self._draw("02d", size=48))
+        assert tiny is not None and default is not None
+        assert (tiny[2] - tiny[0]) < (default[2] - default[0])
 
     def test_custom_fill_color(self):
         """Render with both fill=0 and fill=1, verify outputs differ."""
@@ -117,13 +151,24 @@ class TestDrawWeatherIcon:
 
     @pytest.mark.parametrize("code", ["01d", "02d", "10d", "11n", "50n"])
     def test_various_valid_codes(self, code):
-        img, draw = _make_draw()
-        draw_weather_icon(draw, (10, 10), code)
-        assert img.getbbox() is not None
+        """Each known code draws, and draws something other than the fallback."""
+        img = self._draw(code)
+        assert self._ink(img) > 0
+        assert img.tobytes() != self._draw("99z").tobytes(), (
+            f"{code} fell through to the fallback glyph"
+        )
 
     def test_all_map_codes_render(self):
-        """Every code in OWM_ICON_MAP should render without raising."""
+        """Every mapped code draws a glyph, and the map is not one glyph repeated."""
+        inks = {}
+        fallback = self._draw("99z").tobytes()
         for code in OWM_ICON_MAP:
-            img, draw = _make_draw()
-            draw_weather_icon(draw, (10, 10), code)
-            assert img.getbbox() is not None, f"Failed to render icon for code {code}"
+            img = self._draw(code)
+            assert self._ink(img) > 0, f"Failed to render icon for code {code}"
+            assert img.tobytes() != fallback, f"{code} rendered as the fallback"
+            inks[code] = self._ink(img)
+        # Day/night pairs legitimately share a glyph, so this is a floor rather
+        # than one-distinct-per-code.
+        assert len(set(inks.values())) > len(OWM_ICON_MAP) // 2, (
+            f"the icon map collapses to too few glyphs: {sorted(set(inks.values()))}"
+        )

--- a/tests/test_info_panel.py
+++ b/tests/test_info_panel.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from PIL import Image, ImageDraw
 
 from src.render.components.info_panel import _quote_for_today, draw_info
+from tests.inkutils import ink
 
 
 class TestQuoteForToday:
@@ -72,15 +73,18 @@ class TestDrawInfo:
     def test_smoke_draws_something(self):
         img, draw = self._make_draw()
         draw_info(draw, date(2024, 3, 15))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the info panel drew nothing"
 
     def test_smoke_various_dates(self):
         import datetime
 
+        plates = set()
         for offset in range(7):
             img, draw = self._make_draw()
             draw_info(draw, date(2024, 1, 1) + datetime.timedelta(days=offset))
-            assert img.getbbox() is not None
+            assert ink(img) > 0, f"day +{offset} drew nothing"
+            plates.add(img.tobytes())
+        assert len(plates) > 1, "the quote never changed across a week"
 
     def test_long_quote_adapts_to_smaller_font(self, tmp_path):
         """A very long quote triggers the smaller font (regular(12)) path (lines 62-65)."""
@@ -101,7 +105,7 @@ class TestDrawInfo:
             img, draw = self._make_draw()
             # Use a unique date to avoid the lru_cache returning a stale result
             draw_info(draw, date(2099, 12, 31))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the custom quote store rendered nothing"
 
     def test_corrupt_quotes_json_falls_back_gracefully(self, tmp_path):
         """Corrupt quotes.json triggers except path (lines 62-63) in _quote_for_today."""
@@ -114,7 +118,7 @@ class TestDrawInfo:
             _quote_for_today.cache_clear()
             img, draw = self._make_draw()
             draw_info(draw, date(2098, 6, 15))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the corrupt-store fallback rendered nothing"
 
     def test_missing_quotes_file_uses_defaults(self, tmp_path):
         """Missing quotes.json triggers else path (lines 64-65) in _quote_for_today."""
@@ -126,7 +130,7 @@ class TestDrawInfo:
             _quote_for_today.cache_clear()
             img, draw = self._make_draw()
             draw_info(draw, date(2097, 11, 22))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the missing-store fallback rendered nothing"
 
 
 class TestQuoteRefreshModes:

--- a/tests/test_light_cycle_panel.py
+++ b/tests/test_light_cycle_panel.py
@@ -19,7 +19,8 @@ from src.render.components.light_cycle_panel import (
     _to_local_naive,
     draw_light_cycle,
 )
-from src.render.theme import AVAILABLE_THEMES, load_theme
+from src.render.quantize import flatten_pixels
+from src.render.theme import AVAILABLE_THEMES, ComponentRegion, ThemeStyle, load_theme
 
 NYC_LAT = 40.7128
 NYC_LON = -74.0060
@@ -176,6 +177,22 @@ class TestResolveSunTimes:
 # ---------------------------------------------------------------------------
 
 
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*.
+
+    (#229) The tests below asserted `img.getbbox() is not None` on a
+    mode-"1" plate filled with 1, where every pixel is non-zero and getbbox
+    can never return None — 33 of 34 passed with draw_light_cycle stubbed to
+    a no-op. This counts actual marks instead.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
 class TestLightCycleRender:
     def test_renders_correct_size(self):
         img = _render(latitude=NYC_LAT, longitude=NYC_LON)
@@ -187,14 +204,21 @@ class TestLightCycleRender:
         assert not all(p == 255 for p in img.tobytes())
 
     def test_renders_without_lat_lon(self):
-        img = _render()
-        assert img.size == (800, 480)
+        """No coordinates falls back to OWM sun times, drawing a simpler dial."""
+        without = _render()
+        with_coords = _render(latitude=NYC_LAT, longitude=NYC_LON)
+        assert without.size == (800, 480)
+        assert _ink(without) > 0, "nothing drawn without coordinates"
+        assert without.tobytes() != with_coords.tobytes(), (
+            "the coordinates make no difference to the dial"
+        )
 
     def test_renders_with_no_weather_and_no_coords(self):
+        """Neither weather nor coordinates still draws the dial chrome."""
         data = DashboardData(events=[], weather=None)
-        theme = load_theme("light_cycle")
-        img = render_dashboard(data, DisplayConfig(), theme=theme)
+        img = render_dashboard(data, DisplayConfig(), theme=load_theme("light_cycle"))
         assert img.size == (800, 480)
+        assert _ink(img) > 0, "the dial chrome is missing entirely"
 
 
 # ---------------------------------------------------------------------------
@@ -202,12 +226,35 @@ class TestLightCycleRender:
 # ---------------------------------------------------------------------------
 
 
+def _weather_with_range():
+    """The same weather as the no-range case but with high/low populated."""
+    return WeatherData(
+        current_temp=60.0,
+        current_icon="01d",
+        current_description="clear",
+        high=70.0,
+        low=50.0,
+        humidity=50,
+        sunrise=datetime(2026, 4, 23, 6, 5, tzinfo=TZ),
+        sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
+    )
+
+
+def _direct(data, now=None, **kwargs):
+    """Draw the panel alone onto a fresh plate."""
+    img, d = _make_draw()
+    draw_light_cycle(d, data, TODAY, now or FIXED_NOW, **kwargs)
+    return img
+
+
 class TestDrawLightCycleDirect:
     def test_defaults_region_and_style(self):
-        img, d = _make_draw()
+        """region=None/style=None fill in the defaults and draw the dial."""
         data = DashboardData(events=[], weather=None)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        img = _direct(data)
+        assert _ink(img) > 0, "nothing drawn at all"
+        explicit = _direct(data, region=ComponentRegion(0, 0, 800, 480), style=ThemeStyle())
+        assert img.tobytes() == explicit.tobytes()
 
     def test_with_weather_only(self):
         img, d = _make_draw()
@@ -222,15 +269,16 @@ class TestDrawLightCycleDirect:
             sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
             location_name="Brooklyn",
         )
-        data = DashboardData(events=[], weather=w)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        with_weather = _direct(DashboardData(events=[], weather=w))
+        without = _direct(DashboardData(events=[], weather=None))
+        assert _ink(with_weather) > _ink(without), "the weather summary is not drawn"
 
     def test_with_lat_lon_full_twilight_bands(self):
-        img, d = _make_draw()
+        """Coordinates enable the computed twilight rings, which add ink."""
         data = DashboardData(events=[], weather=None)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW, latitude=NYC_LAT, longitude=NYC_LON)
-        assert img.getbbox() is not None
+        with_coords = _direct(data, latitude=NYC_LAT, longitude=NYC_LON)
+        without = _direct(data)
+        assert _ink(with_coords) > _ink(without), "no twilight bands drawn from the coordinates"
 
     def test_with_timed_events_renders_event_ticks(self):
         img, d = _make_draw()
@@ -248,27 +296,32 @@ class TestDrawLightCycleDirect:
                 calendar_name="Personal",
             ),
         ]
-        data = DashboardData(events=events, weather=None)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        with_events = _direct(DashboardData(events=events, weather=None))
+        without = _direct(DashboardData(events=[], weather=None))
+        assert _ink(with_events) > _ink(without), "no event ticks drawn"
 
     def test_skips_all_day_events(self):
-        """All-day events should not produce event ticks."""
-        img, d = _make_draw()
+        """All-day events produce no tick — they have no hour to plot at.
+
+        The start is a *datetime*, which is how every fetcher produces an
+        all-day event (see today_view's `_all_day` helper and the ICS path in
+        CLAUDE.md). The previous fixture passed a bare `date`, which the
+        `isinstance(start, datetime)` guard rejects one line later — so it
+        could not tell whether the `is_all_day` guard worked. Verified by
+        deleting that guard: this shape then draws a tick, the old one did not.
+        """
         events = [
             CalendarEvent(
                 summary="Holiday",
-                start=date(2026, 4, 23),
-                end=date(2026, 4, 24),
+                start=datetime(2026, 4, 23, 0, 0),
+                end=datetime(2026, 4, 24, 0, 0),
                 calendar_name="Holidays",
                 is_all_day=True,
             ),
         ]
-        data = DashboardData(events=events, weather=None)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        # Image is non-blank from the rest of the chrome, but we just want this
-        # to not crash on the all-day branch.
-        assert img.getbbox() is not None
+        all_day = _direct(DashboardData(events=events, weather=None))
+        none = _direct(DashboardData(events=[], weather=None))
+        assert all_day.tobytes() == none.tobytes(), "an all-day event produced a tick on the dial"
 
     def test_no_op_band_returns_early(self):
         """Density 0 or zero-width band should be a no-op (no exceptions)."""
@@ -279,7 +332,14 @@ class TestDrawLightCycleDirect:
         assert img.tobytes() == before  # nothing drawn
 
     def test_event_far_outside_dial_is_skipped(self):
-        """Events more than a day away can't be plotted — must be silently skipped."""
+        """An event days away leaves the dial untouched.
+
+        Note the mechanism: `events_for_day` filters it out before the tick
+        code runs, so this pins the panel's *observable* behaviour rather than
+        its internal `hr is None` guard, which the event never reaches. That
+        guard is a backstop for a same-day event whose hour cannot be
+        resolved, and is not what this test covers.
+        """
         img, d = _make_draw()
         events = [
             CalendarEvent(
@@ -289,9 +349,11 @@ class TestDrawLightCycleDirect:
                 calendar_name="Misc",
             ),
         ]
-        data = DashboardData(events=events, weather=None)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        distant = _direct(DashboardData(events=events, weather=None))
+        none = _direct(DashboardData(events=[], weather=None))
+        assert distant.tobytes() == none.tobytes(), (
+            "an event days away was plotted onto a 24-hour dial"
+        )
 
     def test_weather_with_no_high_low_renders(self):
         """Weather missing high/low still renders (just shows current temp)."""
@@ -306,9 +368,11 @@ class TestDrawLightCycleDirect:
             sunrise=datetime(2026, 4, 23, 6, 5, tzinfo=TZ),
             sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
         )
-        data = DashboardData(events=[], weather=w)
-        draw_light_cycle(d, data, TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        no_range = _direct(DashboardData(events=[], weather=w))
+        assert _ink(no_range) > 0
+        assert _ink(no_range) < _ink(
+            _direct(DashboardData(events=[], weather=_weather_with_range()))
+        ), "the hi/lo range is not being drawn when present"
 
     def test_night_glyph_when_now_outside_daylight(self):
         """At midnight the moon glyph branch is hit instead of the sun."""
@@ -325,5 +389,7 @@ class TestDrawLightCycleDirect:
             sunset=datetime(2026, 4, 23, 19, 43, tzinfo=TZ),
         )
         data = DashboardData(events=[], weather=w)
-        draw_light_cycle(d, data, TODAY, midnight)
-        assert img.getbbox() is not None
+        night = _direct(data, now=midnight)
+        noon = _direct(data, now=datetime(2026, 4, 23, 12, 30, tzinfo=TZ))
+        assert _ink(night) > 0
+        assert night.tobytes() != noon.tobytes(), "the same glyph was drawn at midnight and midday"

--- a/tests/test_message_panel.py
+++ b/tests/test_message_panel.py
@@ -1,8 +1,23 @@
-"""Tests for src/render/components/message_panel.py."""
+"""Tests for src/render/components/message_panel.py.
+
+Assertion discipline (see #229)
+-------------------------------
+The smoke tests here asserted ``img.getbbox() is not None`` on a mode-``"1"``
+plate filled with 1, where every pixel is non-zero and getbbox can never
+return None. 10 of the 14 tests passed with ``draw_message`` stubbed to a
+no-op.
+
+Ink means **zero-valued** pixels. The typography measure is
+``_text_line_heights``: one band of ink per rendered line, whose height
+tracks the chosen font size — which is how the responsive size-selection
+loop, and its size-20 fallback, become things a test can check rather than
+describe.
+"""
 
 from PIL import Image, ImageDraw
 
 from src.render.components.message_panel import draw_message
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion, ThemeStyle
 
 
@@ -16,109 +31,156 @@ def _make_draw(w: int = 800, h: int = 400):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Ink measurement
+# ---------------------------------------------------------------------------
+
+BOX = (0, 0, 800, 400)
+
+
+def _ink(img: Image.Image, box: tuple[int, int, int, int] = BOX) -> int:
+    """Count ink (value-0) pixels inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _text_line_heights(img: Image.Image, box: tuple[int, int, int, int] = BOX, min_h: int = 3):
+    """Heights of the horizontal bands of ink inside *box*.
+
+    One band per rendered line; each band's height tracks the font size.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    hot = [any(px[y * width + x] == 0 for x in range(x0, x1)) for y in range(y0, y1)]
+    runs = []
+    start = None
+    for i, is_hot in enumerate(hot):
+        if is_hot and start is None:
+            start = i
+        elif not is_hot and start is not None:
+            if i - start >= min_h:
+                runs.append(i - start)
+            start = None
+    if start is not None and len(hot) - start >= min_h:
+        runs.append(len(hot) - start)
+    return runs
+
+
+def _render(message: str, **kwargs) -> Image.Image:
+    img, draw = _make_draw()
+    draw_message(draw, message, **kwargs)
+    return img
+
+
+_LONG = " ".join(["extraordinary"] * 40)
+
+
 class TestDrawMessageSmoke:
     def test_smoke_short_message(self):
-        img, draw = _make_draw()
-        draw_message(draw, "Hello, world!")
-        assert img.getbbox() is not None
+        """A short message is drawn, on few lines."""
+        img = _render("Hello")
+        assert _ink(img) > 0
+        assert len(_text_line_heights(img)) <= 3
 
     def test_smoke_default_args(self):
-        img, draw = _make_draw()
-        draw_message(draw, "Test message")
-        # Should not raise and should produce output
-        assert img.getbbox() is not None
+        """region=None/style=None fill in the documented defaults."""
+        explicit = _render("Hello", region=ComponentRegion(0, 0, 800, 400), style=ThemeStyle())
+        assert _render("Hello").tobytes() == explicit.tobytes()
 
     def test_smoke_custom_region(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(0, 0, 800, 400)
-        draw_message(draw, "Custom region", region=region)
-        assert img.getbbox() is not None
+        """A smaller region keeps the text inside it."""
+        region = ComponentRegion(0, 0, 400, 200)
+        img = _render("Hello", region=region)
+        assert _ink(img, (0, 0, 400, 200)) > 0
+        assert _ink(img, (400, 0, 800, 400)) == 0, "text escaped a 400px-wide region"
 
     def test_smoke_small_region_does_not_crash(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(100, 100, 200, 100)
-        draw_message(draw, "Tiny region", region=region)
-        assert img.getbbox() is not None
+        """A region too small for any candidate size still draws via the fallback."""
+        img = _render("Hello", region=ComponentRegion(0, 0, 120, 50))
+        assert _ink(img, (0, 0, 120, 60)) > 0, "the fallback path drew nothing"
 
     def test_smoke_custom_style(self):
-        img, draw = _make_draw()
-        style = ThemeStyle()
-        draw_message(draw, "Custom style", style=style)
-        assert img.getbbox() is not None
+        """An inverted style is not the same plate as the default."""
+        assert (
+            _render("Hello", style=ThemeStyle(fg=1, bg=0)).tobytes() != _render("Hello").tobytes()
+        )
 
-
-# ---------------------------------------------------------------------------
-# Empty / whitespace message
-# ---------------------------------------------------------------------------
-
-
-class TestDrawMessageEmpty:
     def test_empty_string_shows_placeholder(self):
-        img, draw = _make_draw()
-        draw_message(draw, "")
-        # "(no message)" placeholder should produce pixels
-        assert img.getbbox() is not None
+        """An empty message falls back to the placeholder, not a blank plate."""
+        empty = _render("")
+        assert _ink(empty) > 0
+        assert _ink(empty) != _ink(_render("Hello")), "the placeholder is not distinguishable"
 
     def test_whitespace_only_shows_placeholder(self):
-        img, draw = _make_draw()
-        draw_message(draw, "   \t\n  ")
-        assert img.getbbox() is not None
+        """Whitespace is stripped first, so it takes the same path as empty."""
+        assert _render("   ").tobytes() == _render("").tobytes()
 
     def test_empty_and_nonempty_differ(self):
-        img_empty, draw_empty = _make_draw()
-        draw_message(draw_empty, "")
+        assert _render("").tobytes() != _render("Real message").tobytes()
 
-        img_text, draw_text = _make_draw()
-        draw_message(draw_text, "A real message")
+    def test_very_long_message_wraps_to_many_lines(self):
+        """A 40-word message wraps rather than being dropped or set on one line."""
+        img = _render(_LONG)
+        lines = _text_line_heights(img)
+        assert len(lines) > 3, f"a 40-word message did not wrap: {lines}"
+        assert len(lines) > len(_text_line_heights(_render("Hello")))
 
-        assert img_empty.tobytes() != img_text.tobytes()
+    def test_short_messages_are_set_larger_than_long_ones(self):
+        """The size-selection loop picks the largest size that fits.
 
+        Font size shows up as the height of each band of ink, so the short
+        message's tallest band must beat the long one's. The old version of
+        this test only compared plate bytes, which differ for any reason.
+        """
+        short_lines = _text_line_heights(_render("Hello"))
+        long_lines = _text_line_heights(_render(_LONG))
+        assert max(short_lines) > max(long_lines), (
+            f"short message not set larger: {max(short_lines)} vs {max(long_lines)}"
+        )
+        assert len(short_lines) < len(long_lines)
 
-# ---------------------------------------------------------------------------
-# Font-size fitting algorithm
-# ---------------------------------------------------------------------------
+    def test_narrow_region_overflows_rather_than_wrapping(self):
+        """A very narrow region renders but does NOT stay inside itself.
 
+        Documenting the real behaviour, because the old name for this test
+        ("falls back gracefully") claimed the opposite and its assertion could
+        not tell. Two causes compound: `h_pad` is a hardcoded 52px each side,
+        so `max_w` goes negative below a 105px region; and `_wrap_lines` never
+        breaks inside a word, so any word wider than `max_w` overflows
+        regardless. Measured overflow past the region edge: 2475px at w=60,
+        629 at w=120, 47 at w=200, and 0 by w=300.
 
-class TestDrawMessageFontSizing:
-    def test_very_long_message_does_not_crash(self):
-        """Extremely long message should hit the size-20 fallback without raising."""
-        long_msg = " ".join(["extraordinary"] * 60)
-        img, draw = _make_draw()
-        draw_message(draw, long_msg)
-        assert img.getbbox() is not None
-
-    def test_short_and_long_messages_differ(self):
-        """Short message (large font) and long message (small font) render differently."""
-        img_short, draw_short = _make_draw()
-        draw_message(draw_short, "Hi")
-
-        img_long, draw_long = _make_draw()
-        draw_message(draw_long, " ".join(["word"] * 50))
-
-        assert img_short.tobytes() != img_long.tobytes()
-
-    def test_narrow_region_falls_back_gracefully(self):
-        """Very narrow region should not crash even when wrapping fails."""
-        img, draw = _make_draw(800, 400)
-        region = ComponentRegion(0, 0, 60, 400)
-        draw_message(draw, "Hello world this is a longer message", region=region)
-        assert img.getbbox() is not None
+        No theme configures a narrow message region — the message theme uses
+        the full canvas — so this is characterised rather than fixed. If that
+        ever changes, this test says what has to be dealt with.
+        """
+        text = "Hello world this is a longer message"
+        narrow = _render(text, region=ComponentRegion(0, 0, 60, 400))
+        assert _ink(narrow, (0, 0, 60, 400)) > 0, "nothing drawn at all"
+        assert _ink(narrow, (60, 0, 800, 400)) > 0, "the overflow this documents is gone"
+        # Wider regions overflow strictly less, and 300px is clean.
+        assert _ink(
+            _render(text, region=ComponentRegion(0, 0, 120, 400)), (120, 0, 800, 400)
+        ) < _ink(narrow, (60, 0, 800, 400))
+        assert _ink(_render(text, region=ComponentRegion(0, 0, 300, 400)), (300, 0, 800, 400)) == 0
 
     def test_unfittable_message_uses_size_20_fallback(self):
-        """Message too tall even at the smallest size → size-20 fallback path.
+        """Too tall at every candidate size → the size-20, 8-line fallback.
 
-        A very short region (below two lines at size 20) combined with a long,
-        wrapping message forces the ``if not best_lines`` fallback to run.
+        Checked by the cap rather than by "it rendered": the fallback slices
+        to 8 lines, so a message long enough to wrap past that draws the same
+        as one much longer still.
         """
-        img, draw = _make_draw(800, 200)
-        # Narrow + short region: vertical budget < one-line height at size 20,
-        # so no size in the loop fits and the fallback limits to 8 lines.
         region = ComponentRegion(0, 0, 200, 60)
-        long_msg = " ".join(["extraordinary"] * 40)
-        draw_message(draw, long_msg, region=region)
-        # We only care that the call completes and produces pixels; the exact
-        # wrap count isn't asserted because it depends on font metrics.
-        assert img.getbbox() is not None
+        forty = _render(_LONG, region=region)
+        eighty = _render(" ".join(["extraordinary"] * 80), region=region)
+        assert _ink(forty, (0, 0, 200, 400)) > 0, "the fallback drew nothing"
+        assert _ink(forty, (0, 0, 200, 400)) == _ink(eighty, (0, 0, 200, 400)), (
+            "the 8-line fallback cap is not being applied"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -127,15 +189,17 @@ class TestDrawMessageFontSizing:
 
 
 class TestDrawMessageQuoteMarks:
+    def test_quote_marks_frame_the_text_block(self):
+        """The marks sit outside the text's own column, one high and one low."""
+        img = _render("Short")
+        bands = _text_line_heights(img)
+        assert len(bands) >= 2, f"expected a mark band and a text band: {bands}"
+
     def test_with_and_without_message_differ(self):
-        """Two different messages should produce different output (quote marks shift)."""
-        img_a, draw_a = _make_draw()
-        draw_message(draw_a, "Short")
-
-        img_b, draw_b = _make_draw()
-        draw_message(draw_b, "A completely different and longer piece of text here")
-
-        assert img_a.tobytes() != img_b.tobytes()
+        assert (
+            _render("Short").tobytes()
+            != _render("A completely different and longer piece of text here").tobytes()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -145,10 +209,8 @@ class TestDrawMessageQuoteMarks:
 
 class TestDrawMessageRegionStyle:
     def test_different_regions_produce_different_output(self):
-        img_a, draw_a = _make_draw()
-        draw_message(draw_a, "Same text", region=ComponentRegion(0, 0, 800, 400))
-
-        img_b, draw_b = _make_draw()
-        draw_message(draw_b, "Same text", region=ComponentRegion(200, 100, 400, 200))
-
-        assert img_a.tobytes() != img_b.tobytes()
+        """An offset region moves the content rather than being ignored."""
+        at_origin = _render("Same text", region=ComponentRegion(0, 0, 800, 400))
+        offset = _render("Same text", region=ComponentRegion(200, 100, 400, 200))
+        assert at_origin.tobytes() != offset.tobytes()
+        assert _ink(offset, (0, 0, 200, 400)) == 0, "content ignored the region x offset"

--- a/tests/test_moon_render.py
+++ b/tests/test_moon_render.py
@@ -22,6 +22,7 @@ from src.render.moon_render import (
     render_moon_disc,
 )
 from src.render.quantize import flatten_pixels
+from tests.inkutils import marks
 
 # Phase ages (days) for a 29.53059-day synodic month.
 NEW = 0.0
@@ -137,9 +138,11 @@ class TestRenderPhotoDisc:
         assert px[132, 80] > px[28, 80]
 
     def test_photo_full_moon_is_bright(self, fake_photo):
-        img = self._disc_image("L", fake_photo, FULL, dark_canvas=True)
-        assert img.getbbox() is not None
-        assert max(flatten_pixels(img)) > 0
+        """A full moon lights most of the disc, unlike a new moon."""
+        full = self._disc_image("L", fake_photo, FULL, dark_canvas=True)
+        new = self._disc_image("L", fake_photo, NEW, dark_canvas=True)
+        assert marks(full) > marks(new), "the full disc is no brighter than a new one"
+        assert max(flatten_pixels(full)) > 0
 
     def test_photo_new_moon_only_earthshine(self, fake_photo):
         # New moon: no lit region, only faint earthshine.  On the L canvas the
@@ -177,7 +180,7 @@ class TestRenderPhotoDisc:
             use_photo=True,
             photo_path=str(fake_photo),
         )
-        assert img.getbbox() is not None
+        assert marks(img) > 0, "the photo disc rendered nothing"
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +195,7 @@ class TestProceduralPath:
         img = Image.new("L", (160, 160), 0)
         draw = ImageDraw.Draw(img)
         render_moon_disc(img, draw, 80, 80, 60, FULL, MoonTones(lit=255, dark=0, edge=255))
-        assert img.getbbox() is not None
+        assert marks(img) > 0, "the procedural disc rendered nothing"
 
     def test_missing_photo_falls_back_to_procedural(self, tmp_path):
         _load_moon_photo.cache_clear()
@@ -210,7 +213,21 @@ class TestProceduralPath:
             use_photo=True,
             photo_path=str(missing),
         )
-        assert img.getbbox() is not None
+        # A missing asset falls back to the procedural disc rather than blanking.
+        assert marks(img) > 0, "the missing-photo fallback rendered nothing"
+        procedural = Image.new("L", (160, 160), 0)
+        render_moon_disc(
+            procedural,
+            ImageDraw.Draw(procedural),
+            80,
+            80,
+            60,
+            FULL,
+            MoonTones(lit=255, dark=0, edge=255),
+        )
+        assert img.tobytes() == procedural.tobytes(), (
+            "the missing-photo path did not fall back to the procedural disc"
+        )
 
     def test_bilevel_mode_skips_photo(self, fake_photo):
         # "1" canvases always use the flat procedural path even with use_photo.

--- a/tests/test_moonphase_panel.py
+++ b/tests/test_moonphase_panel.py
@@ -50,7 +50,8 @@ from src.render.components.moonphase_panel import (
     draw_moonphase,
 )
 from src.render.quantize import flatten_pixels
-from src.render.theme import ComponentRegion, ThemeStyle
+from src.render.theme import ComponentRegion, ThemeStyle, load_theme
+from tests.inkutils import marks
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -473,6 +474,19 @@ class TestMoonphaseThemeIntegration:
 
 
 class TestDrawMoonphaseProcedural:
+    """Dark-canvas rendering, using the theme's own style.
+
+    (#229) These originally passed the default ThemeStyle, whose fg=0 on this
+    black canvas leaves almost nothing visible — 2828 marked pixels against
+    56541 under the theme's fg=255. Coordinates then made no difference to the
+    plate, so a test asserting they did would have failed for the wrong
+    reason. Same trap as the one recorded in test_constellation_map_panel.py.
+    """
+
+    @staticmethod
+    def _style():
+        return load_theme("moonphase").style
+
     def _l_canvas(self, w=800, h=480):
         img = Image.new("L", (w, h), 0)
         return img, ImageDraw.Draw(img)
@@ -492,8 +506,20 @@ class TestDrawMoonphaseProcedural:
             latitude=37.77,
             longitude=-122.42,
             now=now,
+            style=self._style(),
         )
-        assert img.getbbox() is not None
+        assert marks(img) > 0, "the L-canvas plate rendered blank"
+        # Coordinates add the moonrise/moonset line, so they change the plate.
+        bare, bare_draw = self._l_canvas()
+        draw_moonphase(
+            bare_draw,
+            _make_data(),
+            date(2026, 5, 30),
+            image=bare,
+            now=now,
+            style=self._style(),
+        )
+        assert img.tobytes() != bare.tobytes(), "the coordinates reached nothing"
 
     def test_renders_on_rgb_canvas(self):
         img, draw = self._rgb_canvas()
@@ -507,24 +533,42 @@ class TestDrawMoonphaseProcedural:
             longitude=-122.42,
             now=now,
         )
-        assert img.getbbox() is not None
+        assert marks(img) > 0, "the RGB plate rendered blank"
 
     def test_supermoon_badge_renders(self):
-        """A near-perigee full moon exercises the supermoon branch."""
+        """A near-perigee full moon swaps the illumination subtitle for a badge."""
         img, draw = self._l_canvas()
-        draw_moonphase(draw, _make_data(), date(2025, 11, 5), image=img)
-        assert img.getbbox() is not None
+        draw_moonphase(draw, _make_data(), date(2025, 11, 5), image=img, style=self._style())
+        ordinary, ordinary_draw = self._l_canvas()
+        draw_moonphase(
+            ordinary_draw, _make_data(), date(2025, 11, 20), image=ordinary, style=self._style()
+        )
+        assert marks(img) > 0
+        assert img.tobytes() != ordinary.tobytes(), "the supermoon badge never appeared"
 
     def test_zero_coords_treated_as_unset(self):
         img, draw = self._l_canvas()
         # 0,0 should skip moonrise/moonset and fall back to age only — no crash.
-        draw_moonphase(draw, _make_data(), TODAY, image=img, latitude=0.0, longitude=0.0)
-        assert img.getbbox() is not None
+        draw_moonphase(
+            draw,
+            _make_data(),
+            TODAY,
+            image=img,
+            latitude=0.0,
+            longitude=0.0,
+            style=self._style(),
+        )
+        unset, unset_draw = self._l_canvas()
+        draw_moonphase(unset_draw, _make_data(), TODAY, image=unset, style=self._style())
+        assert marks(img) > 0
+        assert img.tobytes() == unset.tobytes(), (
+            "(0,0) was treated as a real location rather than as unset"
+        )
 
     def test_no_coords_renders(self):
         img, draw = self._l_canvas()
-        draw_moonphase(draw, _make_data(), TODAY, image=img)
-        assert img.getbbox() is not None
+        draw_moonphase(draw, _make_data(), TODAY, image=img, style=self._style())
+        assert marks(img) > 0, "the no-coordinates plate rendered blank"
 
 
 class TestMoonphaseHelpers:

--- a/tests/test_moonphase_panel.py
+++ b/tests/test_moonphase_panel.py
@@ -1,4 +1,39 @@
-"""Tests for src/render/components/moonphase_panel.py."""
+"""Tests for src/render/components/moonphase_panel.py.
+
+Assertion discipline (see #229)
+-------------------------------
+The 1-bit draw tests asserted ``img.getbbox() is not None`` on a plate
+filled with 1, where every pixel is non-zero and getbbox can never return
+None; 54 of the 59 tests passed with ``draw_moonphase`` stubbed to a no-op.
+(The five that already failed use an L canvas with a *black* background,
+where getbbox is genuinely meaningful — just weak.)
+
+Two things shape the measurements here:
+
+* Polarity is not fixed. This panel is drawn on greyscale plates whose
+  background is black (``moonphase``) or white (``moonphase_invert``), so
+  ``_marks`` counts pixels differing from the background rather than a
+  fixed value, and the real theme styles are used. Passing the default
+  ``ThemeStyle`` (``fg=0, bg=1``, a 1-bit style) onto an L canvas — which
+  the pre-existing L tests did — is a combination the themes never produce,
+  and under it the lunar disc renders inverted: bright at new moon, dark at
+  full. Measuring against it would have pinned an artefact.
+* Counting the filmstrip's discs is phase-dependent and unreliable: a
+  near-new flanking moon has almost no lit area, and the hero's outline ring
+  reads as two marks on a scanline. ``_assert_filmstrip`` measures the
+  strip's span and centring instead, which holds at every phase.
+
+The load-bearing test is ``test_hero_disc_tracks_illumination``: the lit
+area of the hero disc must rank the same way the illumination percentage
+does across the cycle. That is the panel's whole job.
+
+Verification: with ``draw_moonphase`` stubbed to a no-op, 28 of the 63
+tests fail. The survivors are pure helpers (``_ordinal_suffix``,
+``_quote_for_panel``, ``_luminance``, ``_coords_set``), theme-factory
+cases, and tests that drive ``moon_render`` directly — none of which go
+through this entry point — plus ``test_returns_none``, which was checked
+by making the component return a value.
+"""
 
 import json
 from datetime import date, datetime, timezone
@@ -14,6 +49,7 @@ from src.render.components.moonphase_panel import (
     _quote_for_panel,
     draw_moonphase,
 )
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion, ThemeStyle
 
 # ---------------------------------------------------------------------------
@@ -148,50 +184,140 @@ class TestQuoteForPanel:
 
 
 # ---------------------------------------------------------------------------
-# draw_moonphase — smoke tests
+# Ink measurement
+#
+# This panel is drawn on greyscale plates whose background may be black
+# (moonphase) or white (moonphase_invert), so "ink" here means "differs from
+# the canvas background" rather than a fixed value. The real theme styles are
+# used below: passing the default ThemeStyle (fg=0, bg=1, a 1-bit style) onto
+# an L canvas is a combination the themes never produce, and under it the
+# lunar disc renders inverted — bright at new moon, dark at full.
 # ---------------------------------------------------------------------------
+
+_HERO_BOX = (250, 96, 550, 290)  # generous box around the hero disc
+
+
+def _dark_style():
+    from src.render.themes.moonphase import moonphase_theme
+
+    return moonphase_theme().style
+
+
+def _light_style():
+    from src.render.themes.moonphase_invert import moonphase_invert_theme
+
+    return moonphase_invert_theme().style
+
+
+def _marks(img, box=None) -> int:
+    """Pixels differing from the canvas background colour."""
+    px = flatten_pixels(img)
+    width = img.width
+    background = px[0]
+    if box is None:
+        return sum(1 for v in px if v != background)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] != background)
+
+
+def _render_l(today=None, data=None, *, style=None, background=0, **kwargs):
+    """Render on an L plate using a real theme style."""
+    img = Image.new("L", (800, 480), background)
+    draw = ImageDraw.Draw(img)
+    draw_moonphase(
+        draw,
+        data if data is not None else _make_data(),
+        today or TODAY,
+        image=img,
+        style=style or _dark_style(),
+        **kwargs,
+    )
+    return img
+
+
+def _hero_lit(img, threshold: int = 140) -> int:
+    """Bright pixels inside the hero disc — the sunlit fraction of the moon."""
+    px = flatten_pixels(img)
+    x0, y0, x1, y1 = _HERO_BOX
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * img.width + x] > threshold)
+
+
+def _moon_row_extent(img, y0: int = 96, y1: int = 290, threshold: int = 40):
+    """(left, right) x-extent of the filmstrip band.
+
+    Counting individual discs would be phase-dependent and unreliable: a
+    near-new flanking moon has almost no lit area to detect, and the hero's
+    outline ring reads as two separate marks on a scanline. The strip's
+    overall span does not have that problem — it is ~670px wide and centred
+    at every phase.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    xs = [x for x in range(width) if any(px[y * width + x] > threshold for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+def _assert_filmstrip(img, note: str = "") -> None:
+    """The hero plus its flanking days span most of the plate, centred."""
+    extent = _moon_row_extent(img)
+    assert extent is not None, f"no filmstrip drawn {note}"
+    left, right = extent
+    assert right - left > 600, f"filmstrip too narrow ({right - left}px) {note}"
+    midpoint = (left + right) / 2
+    assert abs(midpoint - 400) < 30, f"filmstrip off-centre at {midpoint} {note}"
 
 
 class TestDrawMoonphaseSmoke:
     def test_renders_with_full_data(self):
-        _, draw = _make_draw()
-        draw_moonphase(draw, _make_data(), TODAY)
+        assert _marks(_render_l()) > 0
 
     def test_returns_none(self):
         _, draw = _make_draw()
-        result = draw_moonphase(draw, _make_data(), TODAY)
-        assert result is None
+        assert draw_moonphase(draw, _make_data(), TODAY) is None
 
     def test_produces_non_blank_image(self):
-        img, draw = _make_draw()
-        draw_moonphase(draw, _make_data(), TODAY)
-        assert img.getbbox() is not None
+        """Genuinely non-blank: pixels differ from the background."""
+        assert _marks(_render_l()) > 0
+
+    def test_draws_the_hero_and_flanking_moons(self):
+        """The filmstrip is the hero plus three days each side, spanning the plate."""
+        _assert_filmstrip(_render_l())
 
     def test_renders_without_weather(self):
-        """weather=None skips weather and celestial strips without crashing."""
-        _, draw = _make_draw()
-        data = _make_data(weather=None)
-        draw_moonphase(draw, data, TODAY)
+        """weather=None drops the sun/weather line but keeps the rest."""
+        without = _render_l(data=_make_data(weather=None))
+        assert _marks(without) > 0
+        _assert_filmstrip(without, "without weather")
+        assert _marks(without) != _marks(_render_l()), "the weather line is not drawn"
 
     def test_renders_with_default_region_and_style(self):
-        """Passing region=None and style=None triggers default-assignment branches."""
-        _, draw = _make_draw()
+        """region=None/style=None fill in the full-canvas defaults."""
+        img_default, draw = _make_draw()
         draw_moonphase(draw, _make_data(), TODAY, region=None, style=None)
+        img_explicit, draw2 = _make_draw()
+        draw_moonphase(
+            draw2,
+            _make_data(),
+            TODAY,
+            region=ComponentRegion(0, 0, 800, 480),
+            style=ThemeStyle(),
+        )
+        assert _marks(img_default) > 0
+        assert img_default.tobytes() == img_explicit.tobytes()
 
     def test_renders_with_custom_region(self):
-        _, draw = _make_draw()
-        region = ComponentRegion(0, 0, 800, 480)
-        draw_moonphase(draw, _make_data(), TODAY, region=region)
+        """A shifted region moves the content with it."""
+        at_origin = _render_l(region=ComponentRegion(0, 0, 800, 240))
+        lower = _render_l(region=ComponentRegion(0, 120, 800, 240))
+        assert _marks(at_origin) > 0
+        assert at_origin.tobytes() != lower.tobytes()
 
     def test_renders_with_custom_style(self):
-        _, draw = _make_draw()
-        style = ThemeStyle()
-        draw_moonphase(draw, _make_data(), TODAY, style=style)
-
-
-# ---------------------------------------------------------------------------
-# draw_moonphase — date variations covering lunar cycle
-# ---------------------------------------------------------------------------
+        """The dark and light theme styles produce different plates."""
+        dark = _render_l(style=_dark_style(), background=0)
+        light = _render_l(style=_light_style(), background=255)
+        assert _marks(dark) > 0 and _marks(light) > 0
+        assert dark.tobytes() != light.tobytes()
 
 
 class TestDrawMoonphasePhases:
@@ -208,45 +334,73 @@ class TestDrawMoonphasePhases:
         ],
     )
     def test_renders_across_lunar_cycle(self, d):
-        _, draw = _make_draw()
-        draw_moonphase(draw, _make_data(), d)
+        """Every date draws the full filmstrip."""
+        img = _render_l(d)
+        assert _marks(img) > 0
+        _assert_filmstrip(img, f"for {d}")
 
+    def test_hero_disc_tracks_illumination(self):
+        """The sunlit area of the hero disc follows the phase.
 
-# ---------------------------------------------------------------------------
-# draw_moonphase — weather without sunrise/sunset
-# ---------------------------------------------------------------------------
+        This is the panel's whole job, so it is measured rather than assumed:
+        the lit pixel count must rank the same way the illumination percentage
+        does across the cycle.
+        """
+        from src.render.moon import moon_illumination
+
+        dates = [date(2024, 3, 10), date(2024, 3, 17), date(2024, 3, 25), date(2024, 4, 1)]
+        measured = [(moon_illumination(d), _hero_lit(_render_l(d))) for d in dates]
+        by_illumination = sorted(measured, key=lambda pair: pair[0])
+        lit_values = [lit for _, lit in by_illumination]
+        assert lit_values == sorted(lit_values), (
+            f"lit area does not follow illumination: {by_illumination}"
+        )
+        assert lit_values[0] < lit_values[-1] / 10, "new and full moon look nearly the same"
+
+    def test_light_canvas_inverts_the_disc(self):
+        """On the parchment variant the lit region is dark, not bright."""
+        full_moon = date(2024, 3, 25)
+        new_moon = date(2024, 3, 10)
+        light_full = _render_l(full_moon, style=_light_style(), background=255)
+        light_new = _render_l(new_moon, style=_light_style(), background=255)
+        px_full = flatten_pixels(light_full)
+        px_new = flatten_pixels(light_new)
+        x0, y0, x1, y1 = _HERO_BOX
+
+        def dark_px(px):
+            return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * 800 + x] < 120)
+
+        assert dark_px(px_full) > dark_px(px_new) * 10, "the invert theme is not inverting"
 
 
 class TestDrawMoonphaseCelestialStrip:
     def test_renders_without_sunrise(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunrise=None)
-        data = _make_data(weather=wx)
-        draw_moonphase(draw, data, TODAY)
+        base = _marks(_render_l())
+        assert _marks(_render_l(data=_make_data(weather=_make_weather(sunrise=None)))) != base
 
     def test_renders_without_sunset(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunset=None)
-        data = _make_data(weather=wx)
-        draw_moonphase(draw, data, TODAY)
+        base = _marks(_render_l())
+        assert _marks(_render_l(data=_make_data(weather=_make_weather(sunset=None)))) != base
 
     def test_renders_without_sunrise_and_sunset(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunrise=None, sunset=None)
-        data = _make_data(weather=wx)
-        draw_moonphase(draw, data, TODAY)
-
-
-# ---------------------------------------------------------------------------
-# draw_moonphase — quote refresh modes
-# ---------------------------------------------------------------------------
+        """Neither time still renders the rest of the panel."""
+        neither = _render_l(data=_make_data(weather=_make_weather(sunrise=None, sunset=None)))
+        assert _marks(neither) > 0
+        _assert_filmstrip(neither, "without sun times")
+        assert _marks(neither) != _marks(_render_l())
 
 
 class TestDrawMoonphaseQuoteRefresh:
     @pytest.mark.parametrize("mode", ["daily", "hourly", "twice_daily"])
     def test_refresh_mode_renders(self, mode):
-        _, draw = _make_draw()
-        draw_moonphase(draw, _make_data(), TODAY, quote_refresh=mode)
+        assert _marks(_render_l(quote_refresh=mode)) > 0
+
+    def test_refresh_modes_can_select_different_quotes(self):
+        """The three cadences bucket differently, so they do not all agree."""
+        plates = {
+            m: _render_l(quote_refresh=m).tobytes() for m in ("daily", "hourly", "twice_daily")
+        }
+        assert len(set(plates.values())) > 1, "every refresh mode drew the same quote"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_new_themes.py
+++ b/tests/test_new_themes.py
@@ -16,6 +16,7 @@ from src.data.models import Birthday, CalendarEvent, DashboardData
 from src.dummy_data import generate_dummy_data
 from src.render.canvas import render_dashboard
 from src.render.theme import AVAILABLE_THEMES, load_theme
+from tests.inkutils import ink
 
 FIXED_NOW = datetime(2026, 4, 5, 10, 30)  # A Sunday morning
 
@@ -502,7 +503,7 @@ class TestMonthlyPanel:
         draw = ImageDraw.Draw(img)
         data = DashboardData(events=[])
         draw_monthly(draw, data, date(2026, 4, 5))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the month grid drew nothing"
 
     def test_draw_monthly_empty_month_shows_today_marker(self):
         """When today has no events, the cell shows the 'today' word marker."""
@@ -516,4 +517,4 @@ class TestMonthlyPanel:
         # cell) and 212 (meta-text "looks open" branch).
         data = DashboardData(events=[])
         draw_monthly(draw, data, date(2026, 4, 5))
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the empty-month grid drew nothing"

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -16,6 +16,7 @@ from src.render.primitives import (
     text_width,
     vline,
 )
+from tests.inkutils import ink, ink_x_extent
 
 
 # Use a default bitmap font so tests don't require bundled TTF files
@@ -60,14 +61,21 @@ class TestDrawTextTruncated:
         img, draw = canvas
         # Draw "Hi" in a wide space — it should not add ellipsis
         draw_text_truncated(draw, (0, 0), "Hi", font, max_width=200)
-        # Check pixel was drawn (image not all-white)
-        assert img.getbbox() is not None
+        # Short text is drawn in full: no ellipsis, so no wider than "Hi" alone.
+        assert ink(img) > 0, "nothing drawn"
+        wide = Image.new("1", img.size, WHITE)
+        draw_text_truncated(ImageDraw.Draw(wide), (0, 0), "Hi", font, max_width=2000)
+        assert img.tobytes() == wide.tobytes(), "a generous width changed the result"
 
     def test_long_text_is_truncated(self, canvas, font):
         img, draw = canvas
         very_long = "A" * 100
         draw_text_truncated(draw, (0, 0), very_long, font, max_width=30)
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "nothing drawn"
+        extent = ink_x_extent(img, (0, 0, img.width, img.height))
+        assert extent is not None and extent[1] <= 30 + 2, (
+            f"truncated text ran to x={extent[1]}, past its 30px budget"
+        )
 
     def test_returns_width(self, canvas, font):
         _, draw = canvas
@@ -134,7 +142,7 @@ class TestDrawTextWrapped:
     def test_draws_something(self, canvas, font):
         img, draw = canvas
         draw_text_wrapped(draw, (0, 0), "Hello world", font, max_width=200)
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "wrapped text drew nothing"
 
 
 class TestDrawingPrimitives:

--- a/tests/test_qotd_panel.py
+++ b/tests/test_qotd_panel.py
@@ -1,4 +1,26 @@
-"""Tests for src/render/components/qotd_panel.py."""
+"""Tests for src/render/components/qotd_panel.py.
+
+Assertion discipline (see #229)
+-------------------------------
+The draw tests here asserted ``img.getbbox() is not None`` on a mode-``"1"``
+plate filled with 1, where every pixel is non-zero and getbbox can never
+return None. 32 of the 34 tests passed with both draw functions stubbed to
+a no-op.
+
+Ink means **zero-valued** pixels. The weather banner has fixed zone
+boundaries, so each feature is measured in the zone it owns (icon and
+temperature, conditions, forecast columns, moon glyph). For the quote panel
+the measure is ``_text_line_heights``: one band of ink per rendered line,
+whose height tracks the font size — which is how "this quote was set
+larger" becomes something a test can check.
+
+Verification: with ``draw_qotd`` and ``draw_qotd_weather`` stubbed to a
+no-op, 27 of the 38 tests fail. Of the 11 survivors, 10 exercise pure
+helpers (``_wrap_lines``, ``_icon_width``) or the theme's style and never
+draw. The last, ``test_smoke_with_alerts``, asserts the plate does NOT
+change, which a no-op satisfies by construction; it was checked by making
+the banner draw an alert marker and confirming it goes red.
+"""
 
 import json
 from datetime import date, timedelta
@@ -7,7 +29,7 @@ from unittest.mock import patch
 import pytest
 from PIL import Image, ImageDraw
 
-from src.data.models import DayForecast, WeatherData
+from src.data.models import DayForecast, WeatherAlert, WeatherData
 from src.render.components.qotd_panel import (
     _icon_width,
     _wrap_lines,
@@ -15,6 +37,7 @@ from src.render.components.qotd_panel import (
     draw_qotd_weather,
 )
 from src.render.fonts import bold as jakarta_bold
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion
 from src.render.themes.qotd import qotd_theme
 
@@ -114,88 +137,161 @@ class TestIconWidth:
 
 
 # ---------------------------------------------------------------------------
+# Ink measurement
+# ---------------------------------------------------------------------------
+
+
+def _ink(img: Image.Image, box: tuple[int, int, int, int] | None = None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_x_extent(img: Image.Image, box: tuple[int, int, int, int]):
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    xs = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+def _text_line_heights(img: Image.Image, box: tuple[int, int, int, int], min_h: int = 3):
+    """Heights of the horizontal bands of ink inside *box*.
+
+    A proxy for typography: one band per rendered text line, and each band's
+    height tracks the font size. Lets "this quote was set larger" be measured
+    rather than asserted by eye.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    hot = [any(px[y * width + x] == 0 for x in range(x0, x1)) for y in range(y0, y1)]
+    runs = []
+    start = None
+    for i, is_hot in enumerate(hot):
+        if is_hot and start is None:
+            start = i
+        elif not is_hot and start is not None:
+            if i - start >= min_h:
+                runs.append(i - start)
+            start = None
+    if start is not None and len(hot) - start >= min_h:
+        runs.append(len(hot) - start)
+    return runs
+
+
+# The banner's zones, from draw_qotd_weather's own fixed boundaries.
+QUOTE_REGION = ComponentRegion(0, 0, 800, 400)
+BANNER_REGION = ComponentRegion(0, 400, 800, 80)
+QUOTE_BOX = (0, 0, 800, 400)
+Z1 = (14, 400, 185, 480)  # icon + temperature
+Z2 = (185, 400, 430, 480)  # conditions text
+Z3 = (430, 400, 760, 480)  # forecast columns
+ZMOON = (760, 400, 800, 480)  # moon glyph
+
+
+def _banner(weather, today=None, region=BANNER_REGION, style=None) -> Image.Image:
+    img, draw = _make_draw()
+    draw_qotd_weather(draw, weather, today, region=region, style=style)
+    return img
+
+
+def _quote(today=TODAY, region=QUOTE_REGION, **kwargs) -> Image.Image:
+    img, draw = _make_draw()
+    draw_qotd(draw, today, region=region, **kwargs)
+    return img
+
+
+def _with_quotes(quotes, tmp_path):
+    """Context manager swapping in a custom quote store, cache cleared."""
+    from src.render.components.info_panel import _quote_for_today
+
+    qfile = tmp_path / "quotes.json"
+    qfile.write_text(json.dumps(quotes))
+    _quote_for_today.cache_clear()
+    return patch("src.render.quotes.DEFAULT_QUOTES_PATH", qfile)
+
+
+# ---------------------------------------------------------------------------
 # draw_qotd
 # ---------------------------------------------------------------------------
 
 
 class TestDrawQotd:
-    def test_smoke_renders_without_error(self):
-        img, draw = _make_draw()
-        draw_qotd(draw, TODAY)
-        assert img.getbbox() is not None
+    def test_renders_the_quote_and_its_attribution(self):
+        """More than one text line: the quote body plus the attribution."""
+        img = _quote()
+        assert _ink(img, QUOTE_BOX) > 0
+        assert len(_text_line_heights(img, QUOTE_BOX)) >= 2
 
     def test_smoke_various_dates(self):
-        for i in range(7):
-            img, draw = _make_draw()
-            draw_qotd(draw, TODAY + timedelta(days=i))
-            assert img.getbbox() is not None
+        """Every date renders something, and not all dates render the same."""
+        plates = set()
+        for offset in range(6):
+            img = _quote(TODAY + timedelta(days=offset))
+            assert _ink(img, QUOTE_BOX) > 0
+            plates.add(img.tobytes())
+        assert len(plates) > 1, "the quote never changed across six days"
 
     def test_smoke_custom_region(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(0, 0, 800, 400)
-        draw_qotd(draw, TODAY, region=region)
-        assert img.getbbox() is not None
+        """A smaller region gets a smaller text block, still inside its bounds."""
+        small = ComponentRegion(0, 0, 400, 200)
+        img = _quote(region=small)
+        box = (0, 0, 400, 200)
+        assert _ink(img, box) > 0
+        assert _ink(img, (0, 200, 800, 480)) == 0, "the quote drew outside its region"
 
     def test_smoke_small_region_does_not_crash(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(50, 50, 300, 200)
-        draw_qotd(draw, TODAY, region=region)
-        assert img.getbbox() is not None
+        """A region too small for any candidate size falls back rather than failing."""
+        tiny = ComponentRegion(0, 0, 200, 80)
+        img = _quote(region=tiny)
+        assert _ink(img, (0, 0, 200, 80)) > 0, "the fallback path drew nothing"
 
-    def test_long_quote_does_not_crash(self, tmp_path):
-        """A very long quote should trigger fallback font logic without raising."""
+    def test_long_quote_wraps_to_many_lines(self, tmp_path):
+        """A very long quote triggers the fallback and wraps, capped at 8 lines."""
         long_text = " ".join(["extraordinary"] * 40)
-        custom_quotes = [{"text": long_text, "author": "Verbose Author"}]
-        qfile = tmp_path / "quotes.json"
-        qfile.write_text(json.dumps(custom_quotes))
-
-        from src.render.components.info_panel import _quote_for_today
-
-        _quote_for_today.cache_clear()
-
-        with patch("src.render.quotes.DEFAULT_QUOTES_PATH", qfile):
-            _quote_for_today.cache_clear()
-            img, draw = _make_draw()
-            draw_qotd(draw, date(2099, 1, 15))
-        assert img.getbbox() is not None
+        with _with_quotes([{"text": long_text, "author": "Verbose Author"}], tmp_path):
+            img = _quote(date(2099, 1, 15))
+        lines = _text_line_heights(img, QUOTE_BOX)
+        assert len(lines) > 3, f"a 40-word quote did not wrap: {lines}"
+        assert _ink(img, (0, 400, 800, 480)) == 0, "the quote overflowed its region"
 
     def test_short_quote_uses_larger_font(self, tmp_path):
-        """A short quote should fit at a large font size."""
-        short_text = "Be yourself."
-        custom_quotes = [{"text": short_text, "author": "A. Wise"}]
-        qfile = tmp_path / "quotes.json"
-        qfile.write_text(json.dumps(custom_quotes))
+        """A short quote is set larger than a long one — measured, not assumed.
 
-        from src.render.components.info_panel import _quote_for_today
+        Font size shows up as the height of each band of ink, so the short
+        quote's tallest line must beat the long quote's. The previous version
+        of this test asserted `getbbox() is not None`, which says nothing
+        about size.
+        """
+        with _with_quotes([{"text": "Be yourself.", "author": "A. Wise"}], tmp_path):
+            short = _quote(date(2099, 2, 20))
+        long_text = " ".join(["extraordinary"] * 40)
+        with _with_quotes([{"text": long_text, "author": "Verbose Author"}], tmp_path):
+            long_ = _quote(date(2099, 1, 15))
 
-        _quote_for_today.cache_clear()
-
-        with patch("src.render.quotes.DEFAULT_QUOTES_PATH", qfile):
-            _quote_for_today.cache_clear()
-            img, draw = _make_draw()
-            draw_qotd(draw, date(2099, 2, 20))
-        assert img.getbbox() is not None
+        short_lines = _text_line_heights(short, QUOTE_BOX)
+        long_lines = _text_line_heights(long_, QUOTE_BOX)
+        assert max(short_lines) > max(long_lines), (
+            f"short quote not set larger: {max(short_lines)} vs {max(long_lines)}"
+        )
+        assert len(short_lines) < len(long_lines)
 
     def test_different_dates_produce_different_output(self, tmp_path):
-        """Different dates with different quotes should differ in output."""
+        """Different dates select different quotes."""
         import hashlib
 
         quotes = [{"text": f"Quote number {i}.", "author": f"Author {i}"} for i in range(10)]
-        qfile = tmp_path / "quotes.json"
-        qfile.write_text(json.dumps(quotes))
-
-        from src.render.components.info_panel import _quote_for_today
-
-        _quote_for_today.cache_clear()
-
-        with patch("src.render.quotes.DEFAULT_QUOTES_PATH", qfile):
-            _quote_for_today.cache_clear()
+        with _with_quotes(quotes, tmp_path):
             renders = set()
             for i in range(10):
                 img, draw = _make_draw()
                 draw_qotd(draw, date(2099, 1, i + 1))
                 renders.add(hashlib.md5(img.tobytes()).hexdigest())
-
         assert len(renders) > 1
 
     def test_qotd_theme_exposes_qotd_specific_accent_overrides(self):
@@ -211,98 +307,103 @@ class TestDrawQotd:
 
 class TestDrawQotdWeather:
     def test_smoke_none_weather(self):
-        img, draw = _make_draw()
-        draw_qotd_weather(draw, None)
-        assert img.getbbox() is not None
+        """The unavailable message is centred, and no zone content is drawn."""
+        img = _banner(None)
+        assert _ink(img, Z1) == 0, "an icon was drawn without weather"
+        assert _ink(img, ZMOON) == 0, "a moon glyph was drawn without a date"
+        extent = _ink_x_extent(img, (0, 400, 800, 480))
+        assert extent is not None, "no message drawn"
+        midpoint = (extent[0] + extent[1]) / 2
+        assert abs(midpoint - 400) < 12, f"message off-centre: {midpoint}"
 
     def test_smoke_with_weather(self):
-        img, draw = _make_draw()
-        draw_qotd_weather(draw, _make_weather())
-        assert img.getbbox() is not None
+        """Icon + temperature land in zone 1, conditions in zone 2."""
+        img = _banner(_make_weather())
+        assert _ink(img, Z1) > 0, "no icon/temperature"
+        assert _ink(img, Z2) > 0, "no conditions text"
 
     def test_smoke_with_weather_and_today(self):
-        img, draw = _make_draw()
-        draw_qotd_weather(draw, _make_weather(), today=TODAY)
-        assert img.getbbox() is not None
+        """today= adds the moon glyph in its reserved right-hand strip."""
+        assert _ink(_banner(_make_weather(), TODAY), ZMOON) > 0
+        assert _ink(_banner(_make_weather()), ZMOON) == 0
 
     def test_smoke_with_moon_phase(self):
-        img, draw = _make_draw()
-        draw_qotd_weather(draw, _make_weather(), today=date(2026, 1, 6))
-        assert img.getbbox() is not None
+        """The glyph tracks the phase, so two distant dates differ."""
+        near_new = _ink(_banner(_make_weather(), date(2026, 3, 19)), ZMOON)
+        near_full = _ink(_banner(_make_weather(), date(2026, 4, 2)), ZMOON)
+        assert near_new > 0 and near_full > 0
+        assert near_new != near_full, "the moon glyph is not derived from the date"
 
     def test_smoke_custom_region(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(0, 400, 800, 80)
-        draw_qotd_weather(draw, _make_weather(), region=region)
-        assert img.getbbox() is not None
+        """A shifted region moves the banner content with it."""
+        moved = _banner(_make_weather(), region=ComponentRegion(0, 200, 800, 80))
+        assert _ink(moved, (0, 200, 800, 280)) > 0
+        assert _ink(moved, (0, 400, 800, 480)) == 0, "content stayed at the default offset"
 
     def test_smoke_with_forecast(self):
-        img, draw = _make_draw()
-        weather = _make_weather(
-            forecast=[
-                DayForecast(
-                    date=TODAY + timedelta(days=i + 1),
-                    high=72.0 - i,
-                    low=55.0,
-                    icon="02d",
-                    description="partly cloudy",
-                )
-                for i in range(3)
-            ]
-        )
-        draw_qotd_weather(draw, weather, today=TODAY)
-        assert img.getbbox() is not None
+        """Forecast columns fill zone 3, which is empty without them."""
+        forecast = [
+            DayForecast(
+                date=TODAY + timedelta(days=i + 1),
+                high=70.0 + i,
+                low=52.0,
+                icon="01d",
+                description="clear",
+                precip_chance=0.1,
+            )
+            for i in range(3)
+        ]
+        assert _ink(_banner(_make_weather(forecast=forecast)), Z3) > 0
+        assert _ink(_banner(_make_weather()), Z3) == 0
 
     def test_smoke_with_alerts(self):
-        from src.data.models import WeatherAlert
+        """This banner has no alert zone — alerts must not change the plate.
 
-        img, draw = _make_draw()
-        weather = _make_weather(alerts=[WeatherAlert(event="Wind Advisory")])
-        draw_qotd_weather(draw, weather)
-        assert img.getbbox() is not None
+        Asserted as an equality because that is what is true: draw_qotd_weather
+        never reads weather.alerts. The qotd theme surfaces alerts nowhere, so
+        a change here would be a silent layout regression.
+        """
+        with_alert = _banner(_make_weather(alerts=[WeatherAlert(event="Heat Advisory")]))
+        assert with_alert.tobytes() == _banner(_make_weather()).tobytes()
 
     def test_smoke_with_feels_like_and_wind(self):
-        img, draw = _make_draw()
-        weather = _make_weather(
-            feels_like=65.0,
-            wind_speed=12.5,
-            wind_deg=270.0,
-        )
-        draw_qotd_weather(draw, weather)
-        assert img.getbbox() is not None
+        """The detail line grows when feels-like and wind are available."""
+        detailed = _banner(_make_weather(feels_like=64.0, wind_speed=9.0, wind_deg=90.0))
+        assert _ink(detailed, Z2) > _ink(_banner(_make_weather()), Z2)
 
     def test_smoke_with_humidity_only_detail(self):
-        """When feels_like and wind_speed are None, falls back to humidity."""
-        img, draw = _make_draw()
-        weather = _make_weather(feels_like=None, wind_speed=None)
-        draw_qotd_weather(draw, weather)
-        assert img.getbbox() is not None
+        """With neither feels-like nor wind the line falls back to humidity."""
+        humid_40 = _banner(_make_weather(humidity=40))
+        humid_88 = _banner(_make_weather(humidity=88))
+        assert _ink(humid_40, Z2) > 0
+        assert _ink(humid_40, Z2) != _ink(humid_88, Z2), "the humidity fallback is not drawn"
 
     def test_none_weather_differs_from_with_weather(self):
-        """None weather should produce a different render than actual weather."""
-        img_none, draw_none = _make_draw()
-        draw_qotd_weather(draw_none, None)
-
-        img_data, draw_data = _make_draw()
-        draw_qotd_weather(draw_data, _make_weather())
-
-        assert img_none.tobytes() != img_data.tobytes()
+        assert _banner(None).tobytes() != _banner(_make_weather()).tobytes()
 
     def test_smoke_night_icon(self):
-        img, draw = _make_draw()
-        weather = _make_weather(current_icon="01n")
-        draw_qotd_weather(draw, weather)
-        assert img.getbbox() is not None
+        """A night icon is a different glyph from its day counterpart."""
+        assert _ink(_banner(_make_weather(current_icon="01n")), Z1) != _ink(
+            _banner(_make_weather(current_icon="01d")), Z1
+        )
 
     def test_smoke_narrow_region(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(0, 400, 400, 80)
-        draw_qotd_weather(draw, _make_weather(), region=region)
-        assert img.getbbox() is not None
+        """A narrow region still renders and stays inside its own width."""
+        narrow = ComponentRegion(0, 400, 300, 80)
+        img = _banner(_make_weather(), region=narrow)
+        assert _ink(img, (0, 400, 300, 480)) > 0
+        extent = _ink_x_extent(img, (0, 400, 800, 480))
+        assert extent is not None and extent[1] <= 300, "content spilled past the narrow region"
 
-    @pytest.mark.parametrize("icon_code", ["01d", "02d", "10d", "11n", "50d"])
+    @pytest.mark.parametrize("icon_code", ["01d", "02d", "03d", "04d", "09d", "10d", "11d", "13d"])
     def test_various_icon_codes(self, icon_code):
-        img, draw = _make_draw()
-        weather = _make_weather(current_icon=icon_code)
-        draw_qotd_weather(draw, weather)
-        assert img.getbbox() is not None
+        """Every code draws an icon in zone 1."""
+        assert _ink(_banner(_make_weather(current_icon=icon_code)), Z1) > 0
+
+    def test_distinct_icon_codes_draw_distinct_glyphs(self):
+        """The icon map is being consulted, not collapsed to one glyph."""
+        inks = {
+            code: _ink(_banner(_make_weather(current_icon=code)), Z1)
+            for code in ("01d", "03d", "09d", "11d", "13d")
+        }
+        assert len(set(inks.values())) > 1, f"every icon rendered identically: {inks}"

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -17,6 +17,7 @@ from src.data.models import (
 from src.render.canvas import _resolve_style, render_dashboard
 from src.render.theme import Theme, ThemeLayout, ThemeStyle
 from src.render.themes.qotd import qotd_theme
+from tests.inkutils import ink, marks
 
 
 def _make_data(today: date | None = None) -> DashboardData:
@@ -137,7 +138,7 @@ class TestRenderDashboard:
         data = _make_data()
         cfg = DisplayConfig()
         result = render_dashboard(data, cfg)
-        assert result.getbbox() is not None, "Expected black pixels but image is all white"
+        assert ink(result) > 0, "Expected black pixels but image is all white"
 
     def test_scales_to_larger_display(self):
         """When width/height differ from 800×480, the image should be scaled."""
@@ -229,7 +230,7 @@ class TestGreyscaleCanvas:
         cfg = DisplayConfig(width=200, height=100)
         theme = self._make_l_theme()
         result = render_dashboard(data, cfg, theme=theme)
-        assert result.getbbox() is not None, "Expected black pixels but image is all white"
+        assert marks(result) > 0, "Expected drawn pixels but the L-mode plate is uniform"
 
     def test_l_canvas_with_quantization_modes(self):
         """All three quantization modes should return a valid 1-bit image."""

--- a/tests/test_sunrise_theme.py
+++ b/tests/test_sunrise_theme.py
@@ -14,6 +14,7 @@ from src.render.components.sunrise_panel import (
     _sun_position_fraction,
 )
 from src.render.theme import AVAILABLE_THEMES, load_theme
+from tests.inkutils import ink
 
 FIXED_NOW = datetime(2026, 4, 5, 10, 30)
 
@@ -169,7 +170,7 @@ class TestDrawSunriseComponentEdges:
         img, draw = _make_draw()
         data = DashboardData(events=[], weather=_make_weather())
         draw_sunrise(draw, data, date(2026, 4, 5), FIXED_NOW)
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the sunrise panel drew nothing"
 
     def test_renders_with_evening_events(self):
         """Events starting after sunset populate the TONIGHT column."""
@@ -199,5 +200,6 @@ class TestDrawSunriseComponentEdges:
         ]
         data = DashboardData(events=events, weather=weather)
         draw_sunrise(draw, data, today, FIXED_NOW)
-        # Non-blank — something was drawn in the schedule area.
-        assert img.getbbox() is not None
+        empty, empty_draw = _make_draw()
+        draw_sunrise(empty_draw, DashboardData(events=[], weather=weather), today, FIXED_NOW)
+        assert ink(img) > ink(empty), "the schedule events were not drawn"

--- a/tests/test_tides_panel.py
+++ b/tests/test_tides_panel.py
@@ -4,11 +4,36 @@ Covers: _quote_for_panel (key prefix, refresh cadence, fallback),
 individual band draw functions (_band_header, _band_events, _band_weather,
 _band_forecast, _band_environment, _band_birthdays, _band_quote, _band_host),
 and draw_tides (full render, missing data, band distribution).
+
+Assertion discipline (see #229)
+-------------------------------
+Most of the band tests here used to call their function and assert nothing
+at all; the rest asserted ``img.getbbox() is not None``, which on a
+mode-``"1"`` plate filled with 1 can never be false. 40 of the 41 tests
+passed with every band function stubbed to a no-op.
+
+Ink here means **zero-valued** pixels. Watch the polarity: the header,
+weather, environment and quote bands are inverted — filled in ``fg`` with
+their text knocked out in ``bg`` — so for those four *more content means
+less ink*, and the assertions are written in that direction.
+
+At the whole-plate level the structural measure is ``_inverted_runs``: the
+four inverted bands give a fingerprint of which bands were laid down, so
+"losing weather drops a band" and "losing the forecast leaves weather and
+environment contiguous" are checked directly.
+
+Verification: with every band function and draw_tides stubbed to a no-op,
+35 of the 43 tests fail. Of the 8 survivors, 6 are ``_quote_for_panel``
+tests that exercise a pure function and never draw; the other two assert
+that a band draws *nothing* (``test_no_weather_noop`` and
+``test_empty_forecast_list_is_also_a_noop``), which a no-op satisfies by
+construction — both were checked instead by making the guard draw a
+placeholder and confirming they go red.
 """
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from PIL import Image, ImageDraw
 
@@ -34,6 +59,7 @@ from src.render.components.tides_panel import (
     _quote_for_panel,
     draw_tides,
 )
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion, ThemeStyle
 
 FIXED_NOW = datetime(2026, 4, 6, 10, 30)
@@ -96,13 +122,22 @@ class TestTidesQuoteForPanel:
         assert q1["text"] == q2["text"]
 
     def test_tides_prefix_differs_from_scorecard(self):
-        # The two panels should (usually) pick different quotes on same day
-        # because the key prefix differs — just verify both return valid dicts
+        """The two panels must not show the same quote on the same plate.
+
+        That is the entire reason the key prefixes exist, so it is asserted
+        rather than assumed — the previous version of this test only checked
+        that both calls returned a dict, which the prefixes have nothing to
+        do with. Sampled across 60 days because a single day agreeing would
+        be luck, not a bug.
+        """
         from src.render.components.scorecard_panel import _quote_for_panel as sc_quote
 
-        qt = _quote_for_panel(FIXED_TODAY)
-        qs = sc_quote(FIXED_TODAY)
-        assert "text" in qt and "text" in qs
+        collisions = [
+            day
+            for day in (FIXED_TODAY + timedelta(days=i) for i in range(60))
+            if _quote_for_panel(day)["text"] == sc_quote(day)["text"]
+        ]
+        assert not collisions, f"tides and scorecard picked the same quote on {collisions}"
 
     def test_hourly_refresh(self):
         q = _quote_for_panel(FIXED_TODAY, refresh="hourly", now=FIXED_NOW)
@@ -124,44 +159,111 @@ class TestTidesQuoteForPanel:
 
 
 # ---------------------------------------------------------------------------
+# Ink measurement
+#
+# NOTE the polarity: the header, weather, environment and quote bands are
+# INVERTED — filled_rect in fg, with their text knocked out in bg. So for
+# those four, *more content means less ink*. Assertions below are written in
+# whichever direction the band actually works, not a uniform "more ink".
+# ---------------------------------------------------------------------------
+
+
+def _ink(img: Image.Image, height: int, width: int = 800) -> int:
+    """Count ink (value-0) pixels in the top *height* rows."""
+    px = flatten_pixels(img)
+    return sum(1 for y in range(height) for x in range(width) if px[y * img.width + x] == 0)
+
+
+def _inverted_runs(img: Image.Image, threshold: float = 0.5, merge_gap: int = 14):
+    """(start, end) row ranges of the inverted bands on a full plate.
+
+    A row counts as inverted when most of it is ink; knocked-out text
+    interrupts that, so near-adjacent runs are merged. Two inverted bands
+    that end up adjacent (because the normal band between them was skipped)
+    read as one run — which is itself the signal that a band was dropped.
+    """
+    width, height = img.size
+    px = flatten_pixels(img)
+    hot = [
+        sum(1 for x in range(width) if px[y * width + x] == 0) > width * threshold
+        for y in range(height)
+    ]
+    runs: list[list[int]] = []
+    start = None
+    for y, is_hot in enumerate(hot):
+        if is_hot and start is None:
+            start = y
+        elif not is_hot and start is not None:
+            runs.append([start, y])
+            start = None
+    if start is not None:
+        runs.append([start, height])
+    merged: list[list[int]] = []
+    for run in runs:
+        if merged and run[0] - merged[-1][1] <= merge_gap:
+            merged[-1][1] = run[1]
+        else:
+            merged.append(run)
+    return [tuple(r) for r in merged]
+
+
+def _inverted_height(img: Image.Image) -> int:
+    return sum(end - start for start, end in _inverted_runs(img))
+
+
+# ---------------------------------------------------------------------------
 # Individual band functions
 # ---------------------------------------------------------------------------
 
 
 class TestBandHeader:
-    def test_does_not_raise(self):
-        draw, _ = _blank_draw()
-        _band_header(draw, 0, 0, 800, 42, FIXED_NOW, _style())
+    H = 42
 
-    def test_modifies_image(self):
+    def test_draws_an_inverted_bar_with_text_knocked_out(self):
         draw, img = _blank_draw()
-        before = img.tobytes()
-        _band_header(draw, 0, 0, 800, 42, FIXED_NOW, _style())
-        assert img.tobytes() != before
+        _band_header(draw, 0, 0, 800, self.H, FIXED_NOW, _style())
+        inked = _ink(img, self.H)
+        area = 800 * self.H
+        assert inked > area * 0.5, "header band is not inverted"
+        assert inked < area, "no text was knocked out of the fill"
+
+    def test_header_text_tracks_the_clock(self):
+        """Different date/time draws different text into the bar."""
+        draw_a, img_a = _blank_draw()
+        _band_header(draw_a, 0, 0, 800, self.H, FIXED_NOW, _style())
+        draw_b, img_b = _blank_draw()
+        _band_header(draw_b, 0, 0, 800, self.H, datetime(2026, 12, 25, 9, 5), _style())
+        assert _ink(img_a, self.H) != _ink(img_b, self.H), "header ignores the datetime"
 
 
 class TestBandEvents:
-    def test_no_events_today(self):
-        draw, _ = _blank_draw()
+    H = 54
+
+    def _draw_events(self, events):
+        draw, img = _blank_draw()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_events(draw, 0, 0, 800, 54, data, FIXED_TODAY, _style())
+        data.events = events
+        _band_events(draw, 0, 0, 800, self.H, data, FIXED_TODAY, _style())
+        return img
+
+    def test_no_events_today(self):
+        """The empty state is a message, not a blank band."""
+        assert _ink(self._draw_events([]), self.H) > 0
 
     def test_with_timed_events(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.events = [
+        """A timed event replaces the empty-state message."""
+        timed = [
             CalendarEvent(
                 summary="Morning standup",
                 start=datetime(2026, 4, 6, 9, 0),
                 end=datetime(2026, 4, 6, 9, 30),
             )
         ]
-        _band_events(draw, 0, 0, 800, 54, data, FIXED_TODAY, _style())
+        assert _ink(self._draw_events(timed), self.H) != _ink(self._draw_events([]), self.H)
 
     def test_with_all_day_event(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.events = [
+        """An all-day event is labelled differently from a timed one."""
+        all_day = [
             CalendarEvent(
                 summary="Company Holiday",
                 start=datetime(2026, 4, 6, 0, 0),
@@ -169,219 +271,298 @@ class TestBandEvents:
                 is_all_day=True,
             )
         ]
-        _band_events(draw, 0, 0, 800, 54, data, FIXED_TODAY, _style())
+        timed = [
+            CalendarEvent(
+                summary="Company Holiday",
+                start=datetime(2026, 4, 6, 9, 0),
+                end=datetime(2026, 4, 6, 17, 0),
+            )
+        ]
+        assert _ink(self._draw_events(all_day), self.H) != _ink(self._draw_events(timed), self.H), (
+            "an all-day event rendered identically to a timed one with the same summary"
+        )
 
 
 class TestBandWeather:
-    def test_no_weather_data(self):
-        draw, _ = _blank_draw()
+    H = 40
+
+    def _draw_weather(self, weather):
+        draw, img = _blank_draw()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_weather(draw, 0, 0, 800, 40, data, _style())
+        data.weather = weather
+        _band_weather(draw, 0, 0, 800, self.H, data, _style())
+        return img
+
+    def test_no_weather_data(self):
+        """The band still inverts; it just has less to knock out."""
+        inked = _ink(self._draw_weather(None), self.H)
+        assert inked > 800 * self.H * 0.5, "weather band is not inverted"
 
     def test_with_weather_data(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather()
-        _band_weather(draw, 0, 0, 800, 40, data, _style())
+        """Readings are knocked out of the fill, so ink goes DOWN, not up."""
+        assert _ink(self._draw_weather(_weather()), self.H) < _ink(
+            self._draw_weather(None), self.H
+        ), "weather readings left no mark on the band"
 
     def test_weather_without_optional_fields(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather(feels_like=None, humidity=None)
-        _band_weather(draw, 0, 0, 800, 40, data, _style())
+        """Dropping feels-like and humidity removes text, so ink goes back up."""
+        full = _ink(self._draw_weather(_weather()), self.H)
+        trimmed = _ink(self._draw_weather(_weather(feels_like=None, humidity=None)), self.H)
+        assert full < trimmed < _ink(self._draw_weather(None), self.H)
 
 
 class TestBandForecast:
-    def test_no_weather_noop(self):
+    H = 50
+
+    def _draw_forecast(self, weather):
         draw, img = _blank_draw()
-        before = img.tobytes()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_forecast(draw, 0, 0, 800, 50, data, _style())
-        # With no weather, nothing should be drawn
-        assert img.tobytes() == before
+        data.weather = weather
+        _band_forecast(draw, 0, 0, 800, self.H, data, _style())
+        return img
+
+    def test_no_weather_noop(self):
+        assert _ink(self._draw_forecast(None), self.H) == 0
 
     def test_with_forecast(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather()
-        _band_forecast(draw, 0, 0, 800, 50, data, _style())
+        assert _ink(self._draw_forecast(_weather()), self.H) > 0
 
-    def test_empty_forecast_list(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather(forecast=[])
-        _band_forecast(draw, 0, 0, 800, 50, data, _style())
+    def test_empty_forecast_list_is_also_a_noop(self):
+        """Weather present but no days is as blank as no weather at all."""
+        assert _ink(self._draw_forecast(_weather(forecast=[])), self.H) == 0
 
 
 class TestBandEnvironment:
-    def test_no_aqi_no_weather(self):
-        draw, _ = _blank_draw()
+    H = 38
+
+    def _draw_env(self, **attrs):
+        draw, img = _blank_draw()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_environment(draw, 0, 0, 800, 38, data, FIXED_TODAY, _style())
+        for key, value in attrs.items():
+            setattr(data, key, value)
+        _band_environment(draw, 0, 0, 800, self.H, data, FIXED_TODAY, _style())
+        return img
+
+    def test_no_aqi_no_weather(self):
+        """Moon phase alone still fills the inverted band."""
+        assert _ink(self._draw_env(), self.H) > 800 * self.H * 0.5
 
     def test_with_aqi_data(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.air_quality = AirQualityData(aqi=42, category="Good", pm25=8.5)
-        _band_environment(draw, 0, 0, 800, 38, data, FIXED_TODAY, _style())
+        """An AQI reading knocks more out of the fill."""
+        aq = AirQualityData(aqi=42, category="Good", pm25=8.0)
+        assert _ink(self._draw_env(air_quality=aq), self.H) < _ink(self._draw_env(), self.H)
 
     def test_with_weather_sunrise_sunset(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather()
-        _band_environment(draw, 0, 0, 800, 38, data, FIXED_TODAY, _style())
+        assert _ink(self._draw_env(weather=_weather()), self.H) < _ink(self._draw_env(), self.H)
 
     def test_with_all_data(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.weather = _weather()
-        data.air_quality = AirQualityData(aqi=55, category="Moderate", pm25=12.3)
-        _band_environment(draw, 0, 0, 800, 38, data, FIXED_TODAY, _style())
+        """Everything present leaves the least ink of the four combinations."""
+        aq = AirQualityData(aqi=42, category="Good", pm25=8.0)
+        combos = [
+            _ink(self._draw_env(), self.H),
+            _ink(self._draw_env(air_quality=aq), self.H),
+            _ink(self._draw_env(weather=_weather()), self.H),
+            _ink(self._draw_env(air_quality=aq, weather=_weather()), self.H),
+        ]
+        assert combos[-1] == min(combos), "the all-data band is not the fullest"
+        assert len(set(combos)) == 4, "two environment combinations rendered identically"
 
 
 class TestBandBirthdays:
-    def test_no_birthdays(self):
-        draw, _ = _blank_draw()
+    H = 36
+
+    def _draw_birthdays(self, n: int):
+        draw, img = _blank_draw()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_birthdays(draw, 0, 0, 800, 36, data, FIXED_TODAY, _style())
+        data.birthdays = [
+            Birthday(name=f"Person{i}", date=FIXED_TODAY + timedelta(days=i + 1)) for i in range(n)
+        ]
+        _band_birthdays(draw, 0, 0, 800, self.H, data, FIXED_TODAY, _style())
+        return img
+
+    def test_no_birthdays(self):
+        """The empty state is a message, not a blank band."""
+        assert _ink(self._draw_birthdays(0), self.H) > 0
 
     def test_with_birthdays(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.birthdays = [
-            Birthday(name="Alice", date=date(2026, 4, 10), age=30),
-            Birthday(name="Bob", date=date(2026, 4, 15), age=None),
-        ]
-        _band_birthdays(draw, 0, 0, 800, 36, data, FIXED_TODAY, _style())
+        """Names replace the empty-state message, and more names draw more."""
+        one = _ink(self._draw_birthdays(1), self.H)
+        two = _ink(self._draw_birthdays(2), self.H)
+        assert one != _ink(self._draw_birthdays(0), self.H)
+        assert two > one
 
     def test_many_birthdays_truncated_at_4(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.birthdays = [
-            Birthday(name=f"Person {i}", date=date(2026, 4, 7 + i), age=20 + i) for i in range(8)
-        ]
-        _band_birthdays(draw, 0, 0, 800, 36, data, FIXED_TODAY, _style())
+        """The 5th and later entries are dropped — 7 renders exactly like 4."""
+        four = _ink(self._draw_birthdays(4), self.H)
+        assert _ink(self._draw_birthdays(7), self.H) == four, "more than 4 birthdays were drawn"
+        assert four > _ink(self._draw_birthdays(3), self.H), "the 4th birthday was dropped too"
 
 
 class TestBandQuote:
+    H = 86
+
+    def _draw_quote(self, refresh: str, today=FIXED_TODAY, now=FIXED_NOW):
+        draw, img = _blank_draw()
+        _band_quote(draw, 0, 0, 800, self.H, today, now, _style(), refresh, None)
+        return img
+
     def test_daily_refresh(self):
-        draw, _ = _blank_draw()
-        _band_quote(draw, 0, 0, 800, 86, FIXED_TODAY, FIXED_NOW, _style(), "daily")
+        """The band inverts and carries a quote knocked out of the fill."""
+        inked = _ink(self._draw_quote("daily"), self.H)
+        assert 800 * self.H * 0.5 < inked < 800 * self.H
 
     def test_hourly_refresh(self):
-        draw, _ = _blank_draw()
-        _band_quote(draw, 0, 0, 800, 86, FIXED_TODAY, FIXED_NOW, _style(), "hourly")
+        assert _ink(self._draw_quote("hourly"), self.H) > 0
 
     def test_twice_daily_refresh(self):
-        draw, _ = _blank_draw()
-        _band_quote(draw, 0, 0, 800, 86, FIXED_TODAY, FIXED_NOW, _style(), "twice_daily")
+        assert _ink(self._draw_quote("twice_daily"), self.H) > 0
+
+    def test_refresh_modes_select_different_quotes(self):
+        """The three cadences bucket differently, so they do not all agree."""
+        inks = {m: _ink(self._draw_quote(m), self.H) for m in ("daily", "hourly", "twice_daily")}
+        assert len(set(inks.values())) > 1, f"every refresh mode drew the same quote: {inks}"
+
+    def test_quote_changes_with_the_date(self):
+        """A daily quote is a function of the day, not a constant."""
+        today = _ink(self._draw_quote("daily", today=FIXED_TODAY), self.H)
+        later = _ink(self._draw_quote("daily", today=FIXED_TODAY + timedelta(days=40)), self.H)
+        assert today != later, "the daily quote did not change over 40 days"
 
 
 class TestBandHost:
-    def test_no_host_data(self):
-        draw, _ = _blank_draw()
+    H = 34
+
+    def _draw_host(self, host):
+        draw, img = _blank_draw()
         data = DashboardData(fetched_at=FIXED_NOW)
-        _band_host(draw, 0, 0, 800, 34, data, _style())
+        data.host_data = host
+        _band_host(draw, 0, 0, 800, self.H, data, _style())
+        return img
+
+    def test_no_host_data(self):
+        """Called directly with no host data the band still renders a placeholder."""
+        assert _ink(self._draw_host(None), self.H) > 0
 
     def test_full_host_data(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.host_data = HostData(
-            hostname="raspberrypi",
-            uptime_seconds=86400 * 3 + 3600 * 2,
-            load_1m=0.35,
-            ram_used_mb=400,
-            ram_total_mb=1024,
-            cpu_temp_c=48.5,
-            ip_address="192.168.1.10",
+        """A fully-populated HostData draws more than any lesser case."""
+        full = HostData(
+            hostname="dashboard-pi",
+            uptime_seconds=98765,
+            load_1m=0.4,
+            ram_used_mb=512,
+            ram_total_mb=2048,
+            disk_used_gb=8,
+            disk_total_gb=32,
+            cpu_temp_c=48.2,
+            ip_address="10.0.0.5",
         )
-        _band_host(draw, 0, 0, 800, 34, data, _style())
+        assert _ink(self._draw_host(full), self.H) > _ink(self._draw_host(None), self.H)
 
     def test_partial_host_data(self):
-        draw, _ = _blank_draw()
-        data = DashboardData(fetched_at=FIXED_NOW)
-        data.host_data = HostData(hostname="pi", load_1m=None)
-        _band_host(draw, 0, 0, 800, 34, data, _style())
+        """A HostData with one field set is distinguishable from a full one."""
+        partial = HostData(hostname="dashboard-pi")
+        full = HostData(hostname="dashboard-pi", uptime_seconds=98765, load_1m=0.4)
+        assert _ink(self._draw_host(partial), self.H) != _ink(self._draw_host(full), self.H)
 
 
 # ---------------------------------------------------------------------------
-# draw_tides (full function)
+# draw_tides — band composition
 # ---------------------------------------------------------------------------
 
 
 class TestDrawTides:
-    def _draw(self, data: DashboardData, now: datetime = FIXED_NOW) -> Image.Image:
+    def _draw(self, data: DashboardData, now: datetime = FIXED_NOW, **kwargs) -> Image.Image:
         img = Image.new("1", (800, 480), color=1)
         draw = ImageDraw.Draw(img)
-        draw_tides(draw, data, now.date(), now)
+        draw_tides(draw, data, now.date(), now, **kwargs)
         return img
 
     def test_smoke_full_dummy_data(self):
-        data = generate_dummy_data(now=FIXED_NOW)
-        img = self._draw(data)
-        assert img.size == (800, 480)
-        assert not all(p == 255 for p in img.tobytes())
+        """All four inverted bands are laid down, in order, without overlapping."""
+        img = self._draw(generate_dummy_data(now=FIXED_NOW))
+        runs = _inverted_runs(img)
+        assert len(runs) == 4, f"expected 4 inverted bands, got {len(runs)}: {runs}"
+        for (_, end), (start, _) in zip(runs, runs[1:]):
+            assert start > end, f"inverted bands overlap: {runs}"
 
     def test_smoke_minimal_data(self):
-        data = DashboardData(fetched_at=FIXED_NOW)
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        """Bare DashboardData still lays down the always-present bands."""
+        img = self._draw(DashboardData(fetched_at=FIXED_NOW))
+        assert len(_inverted_runs(img)) >= 3, "the always-present bands are missing"
 
     def test_smoke_no_weather(self):
+        """Losing weather drops the weather band, so less of the plate inverts."""
         data = generate_dummy_data(now=FIXED_NOW)
+        full = self._draw(data)
         data.weather = None
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        without = self._draw(data)
+        assert _inverted_height(without) < _inverted_height(full), "weather band was still drawn"
+        assert len(_inverted_runs(without)) == 3
 
     def test_smoke_no_weather_no_forecast(self):
+        """Weather present but no forecast: the forecast band between the
+        weather and environment bands goes, leaving those two contiguous."""
         data = generate_dummy_data(now=FIXED_NOW)
         data.weather = _weather(forecast=[])
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        runs = _inverted_runs(self._draw(data))
+        assert len(runs) == 3, f"expected weather+environment to merge, got {runs}"
+        longest = max(end - start for start, end in runs)
+        assert longest > 60, f"no merged weather+environment run found: {runs}"
 
     def test_smoke_no_air_quality(self):
+        """AQI is optional inside the environment band, not a band of its own."""
         data = generate_dummy_data(now=FIXED_NOW)
+        with_aq = self._draw(data)
         data.air_quality = None
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        without = self._draw(data)
+        assert len(_inverted_runs(without)) == len(_inverted_runs(with_aq)), (
+            "dropping AQI removed a whole band"
+        )
+        assert without.tobytes() != with_aq.tobytes(), "the AQI reading was never drawn"
 
     def test_smoke_no_birthdays(self):
+        """The birthdays band is always present; only its content changes."""
         data = generate_dummy_data(now=FIXED_NOW)
+        with_b = self._draw(data)
         data.birthdays = []
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        without = self._draw(data)
+        assert len(_inverted_runs(without)) == len(_inverted_runs(with_b))
+        assert without.tobytes() != with_b.tobytes()
 
     def test_smoke_no_host_data(self):
+        """No host data drops the host band and reflows the rest."""
         data = generate_dummy_data(now=FIXED_NOW)
+        with_host = self._draw(data)
         data.host_data = None
-        img = self._draw(data)
-        assert img.size == (800, 480)
+        without = self._draw(data)
+        assert without.tobytes() != with_host.tobytes(), "the host band was drawn anyway"
 
-    def test_custom_region(self):
+    def test_custom_region_offset_moves_the_content(self):
         data = generate_dummy_data(now=FIXED_NOW)
-        img = Image.new("1", (800, 480), color=1)
-        draw = ImageDraw.Draw(img)
-        region = ComponentRegion(0, 0, 800, 480)
-        draw_tides(draw, data, FIXED_TODAY, FIXED_NOW, region=region)
-        assert img.size == (800, 480)
+        at_origin = self._draw(data, region=ComponentRegion(0, 0, 800, 240))
+        lower = self._draw(data, region=ComponentRegion(0, 120, 800, 240))
+        assert at_origin.tobytes() != lower.tobytes()
+        assert _inverted_runs(lower)[0][0] > _inverted_runs(at_origin)[0][0], (
+            "region.y offset did not move the bands down"
+        )
 
     def test_custom_style(self):
+        """An inverted style flips which bands are filled."""
         data = generate_dummy_data(now=FIXED_NOW)
-        img = Image.new("1", (800, 480), color=1)
-        draw = ImageDraw.Draw(img)
-        style = ThemeStyle(fg=0, bg=1)
-        draw_tides(draw, data, FIXED_TODAY, FIXED_NOW, style=style)
+        normal = self._draw(data, style=ThemeStyle(fg=0, bg=1))
+        flipped = self._draw(data, style=ThemeStyle(fg=1, bg=0))
+        assert normal.tobytes() != flipped.tobytes()
 
     def test_quote_refresh_modes(self):
+        """The cadence reaches the quote band rather than being ignored."""
         data = generate_dummy_data(now=FIXED_NOW)
-        for mode in ("daily", "twice_daily", "hourly"):
-            img = Image.new("1", (800, 480), color=1)
-            draw = ImageDraw.Draw(img)
-            draw_tides(draw, data, FIXED_TODAY, FIXED_NOW, quote_refresh=mode)
+        plates = {m: self._draw(data, quote_refresh=m).tobytes() for m in ("daily", "hourly")}
+        assert len(set(plates.values())) > 1, "quote_refresh made no difference to the plate"
 
     def test_all_optional_bands_absent(self):
-        """No weather → weather/forecast bands skipped; host absent → host band skipped."""
+        """No weather and no host: both optional bands go, the rest still render."""
         data = DashboardData(fetched_at=FIXED_NOW)
-        # No weather and no host data — fewer active bands; height distribution must not crash
         img = self._draw(data)
-        assert img.size == (800, 480)
+        full = self._draw(generate_dummy_data(now=FIXED_NOW))
+        assert _inverted_height(img) < _inverted_height(full)
+        assert len(_inverted_runs(img)) == 3, "the always-present bands did not all render"

--- a/tests/test_today_view.py
+++ b/tests/test_today_view.py
@@ -13,6 +13,7 @@ from src.render.components.today_view import (
     _fmt_time,
     draw_today,
 )
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion
 
 
@@ -183,71 +184,132 @@ class TestEventsForToday:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Ink measurement
+#
+# The default region is (0, 60, 800, 280): an inverted date panel filling the
+# left 3/10, a vertical rule, then the event list. Each test measures the side
+# that owns what it changes.
+# ---------------------------------------------------------------------------
+
+REGION = ComponentRegion(0, 60, 800, 280)
+_DATE_PANEL_W = 800 * 3 // 10  # 240, per draw_today's own split
+DATE_PANEL = (0, 60, _DATE_PANEL_W, 340)
+EVENTS = (_DATE_PANEL_W, 60, 800, 340)
+
+
+def _ink(img: Image.Image, box: tuple[int, int, int, int] | None = None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _divider_height(img: Image.Image) -> int:
+    """Inked rows in the rule between the date panel and the event list."""
+    px = flatten_pixels(img)
+    width = img.width
+    return sum(1 for y in range(60, 340) if px[y * width + _DATE_PANEL_W] == 0)
+
+
+def _render(events=None, today=TODAY, **kwargs) -> Image.Image:
+    img, draw = _make_draw()
+    draw_today(draw, events or [], today, **kwargs)
+    return img
+
+
 class TestDrawToday:
     def test_smoke_no_events(self):
-        img, draw = _make_draw()
-        draw_today(draw, [], TODAY)
-        assert img.getbbox() is not None
+        """The date panel is inverted and the event list carries the empty message."""
+        img = _render()
+        panel_area = _DATE_PANEL_W * 280
+        assert _ink(img, DATE_PANEL) > panel_area * 0.5, "date panel is not inverted"
+        assert _ink(img, DATE_PANEL) < panel_area, "no date text knocked out of the fill"
+        assert _ink(img, EVENTS) > 0, "no empty-state message"
+        assert _divider_height(img) > 200, "no rule between the panels"
+
+    def test_date_panel_tracks_the_date(self):
+        """Day name, month and numeral come from the date, so they vary with it."""
+        inks = {
+            d: _ink(_render(today=d), DATE_PANEL)
+            for d in (date(2024, 3, 1), date(2024, 3, 15), date(2024, 12, 25))
+        }
+        assert len(set(inks.values())) == 3, f"the date panel is not date-driven: {inks}"
 
     def test_smoke_single_timed_event(self):
-        img, draw = _make_draw()
-        draw_today(draw, [_timed(TODAY, 10, 11)], TODAY)
-        assert img.getbbox() is not None
+        """A timed event replaces the empty-state message."""
+        assert _ink(_render([_timed(TODAY, 10, 11)]), EVENTS) != _ink(_render(), EVENTS)
 
     def test_smoke_single_all_day_event(self):
-        img, draw = _make_draw()
-        draw_today(draw, [_all_day(TODAY, TODAY + timedelta(days=1))], TODAY)
-        assert img.getbbox() is not None
+        """An all-day event draws a filled bar, so it inks far more than a timed row."""
+        all_day = _ink(_render([_all_day(TODAY, TODAY + timedelta(days=1))]), EVENTS)
+        assert all_day > _ink(_render([_timed(TODAY, 10, 11)]), EVENTS) * 5
 
     def test_smoke_mixed_events(self):
-        img, draw = _make_draw()
+        """All three events are drawn, so the plate exceeds any one of them."""
         events = [
             _all_day(TODAY, TODAY + timedelta(days=1), "Holiday"),
             _timed(TODAY, 9, 10, "Standup"),
             _timed(TODAY, 14, 15, "Review"),
         ]
-        draw_today(draw, events, TODAY)
-        assert img.getbbox() is not None
+        mixed = _ink(_render(events), EVENTS)
+        assert mixed > _ink(_render(events[:1]), EVENTS)
+        assert mixed > _ink(_render(events[1:]), EVENTS)
 
     def test_smoke_events_on_different_days_only_today_shown(self):
-        """Events from other days should be silently excluded (no crash)."""
-        img, draw = _make_draw()
-        events = [
+        """Yesterday's and tomorrow's events are filtered out, not merely tolerated."""
+        only_today = [_timed(TODAY, 11, 12, "Today")]
+        with_neighbours = [
             _timed(TODAY - timedelta(days=1), 9, 10, "Yesterday"),
             _timed(TODAY, 11, 12, "Today"),
             _timed(TODAY + timedelta(days=1), 9, 10, "Tomorrow"),
         ]
-        draw_today(draw, events, TODAY)
-        assert img.getbbox() is not None
+        assert _ink(_render(with_neighbours), EVENTS) == _ink(_render(only_today), EVENTS), (
+            "an event from another day reached the plate"
+        )
 
     def test_smoke_with_custom_region(self):
-        img, draw = _make_draw()
-        region = ComponentRegion(0, 60, 800, 300)
-        draw_today(draw, [_timed(TODAY, 10, 11)], TODAY, region=region)
-        assert img.getbbox() is not None
+        """A taller region gives the event list more room, so more fits."""
+        events = [_timed(TODAY, 8 + i, 9 + i, f"Event {i}") for i in range(10)]
+        tall = ComponentRegion(0, 60, 800, 300)
+        short = ComponentRegion(0, 60, 800, 140)
+        tall_ink = _ink(_render(events, region=tall), (240, 60, 800, 360))
+        short_ink = _ink(_render(events, region=short), (240, 60, 800, 360))
+        assert tall_ink > short_ink, "the region height does not affect how much is listed"
 
     def test_smoke_many_events_overflow(self):
-        """More events than fit should show '+N more' without crashing."""
-        img, draw = _make_draw()
-        events = [_timed(TODAY, i, i + 1, f"Event {i}") for i in range(8, 18)]
-        draw_today(draw, events, TODAY)
-        assert img.getbbox() is not None
+        """Beyond what fits, the list stops and shows a '+N more' indicator."""
+
+        def with_events(n):
+            return _ink(
+                _render([_timed(TODAY, 6 + (i % 14), 7 + (i % 14), f"E{i}") for i in range(n)]),
+                EVENTS,
+            )
+
+        eight = with_events(8)
+        assert with_events(10) == eight, "more rows were drawn than fit"
+        # The row count saturates but the "+N more" label still tracks N.
+        assert with_events(20) != eight, "the overflow count is not being drawn"
 
     def test_smoke_all_day_event_non_inverted_bars(self):
-        """invert_allday_bars=False draws an outlined (not filled) all-day bar."""
+        """invert_allday_bars=False outlines the bar instead of filling it."""
         from src.render.theme import ThemeStyle
 
-        img, draw = _make_draw()
-        style = ThemeStyle(invert_allday_bars=False)
-        events = [_all_day(TODAY, TODAY + timedelta(days=1), "Conference Day")]
-        draw_today(draw, events, TODAY, style=style)
-        assert img.getbbox() is not None
+        event = [_all_day(TODAY, TODAY + timedelta(days=1), "Conference Day")]
+        outlined = _ink(_render(event, style=ThemeStyle(invert_allday_bars=False)), EVENTS)
+        filled = _ink(_render(event, style=ThemeStyle(invert_allday_bars=True)), EVENTS)
+        assert outlined > 0
+        assert filled > outlined * 5, "the inverted bar is not filled"
 
     def test_smoke_event_with_location(self):
-        img, draw = _make_draw()
-        evt = _timed(TODAY, 9, 10, "Doctor Visit", location="123 Medical Center, Suite 4")
-        draw_today(draw, [evt], TODAY)
-        assert img.getbbox() is not None
+        """A location adds a line below the title."""
+        with_loc = _timed(TODAY, 9, 10, "Doctor Visit", location="123 Medical Center, Suite 4")
+        assert _ink(_render([with_loc]), EVENTS) > _ink(
+            _render([_timed(TODAY, 9, 10, "Doctor Visit")]), EVENTS
+        )
 
     def test_location_newlines_are_normalized_before_truncation(self):
         img, draw = _make_draw()
@@ -268,31 +330,35 @@ class TestDrawToday:
         assert all("\n" not in t for t in seen_texts)
 
     def test_smoke_event_with_long_title(self):
-        img, draw = _make_draw()
-        evt = _timed(TODAY, 10, 11, "A Very Long Event Title That Should Be Wrapped")
-        draw_today(draw, [evt], TODAY)
-        assert img.getbbox() is not None
+        """A long title wraps rather than being dropped or overflowing."""
+        long_title = _timed(TODAY, 10, 11, "A Very Long Event Title That Should Be Wrapped")
+        img = _render([long_title])
+        assert _ink(img, EVENTS) > _ink(_render([_timed(TODAY, 10, 11, "Short")]), EVENTS)
+        assert _ink(img, (0, 340, 800, 480)) == 0, "the event list overflowed its region"
 
     def test_smoke_small_region(self):
-        """Small region should not crash even with many events."""
-        img, draw = _make_draw()
+        """A small region still renders and keeps everything inside it."""
         region = ComponentRegion(0, 60, 400, 120)
         events = [_timed(TODAY, i, i + 1, f"E{i}") for i in range(9, 14)]
-        draw_today(draw, events, TODAY, region=region)
-        assert img.getbbox() is not None
+        img = _render(events, region=region)
+        assert _ink(img, (0, 60, 400, 180)) > 0
+        assert _ink(img, (400, 0, 800, 480)) == 0, "content escaped a 400px-wide region"
 
     def test_smoke_all_day_invert_style(self):
-        """With invert_allday_bars style, all-day events should still render."""
+        """The inverted all-day bar knocks its title out of the fill."""
         from src.render.theme import ThemeStyle
 
-        img, draw = _make_draw()
-        style = ThemeStyle(invert_allday_bars=True)
         evt = _all_day(TODAY, TODAY + timedelta(days=1), "Inverted")
-        draw_today(draw, [evt], TODAY, style=style)
-        assert img.getbbox() is not None
+        img = _render([evt], style=ThemeStyle(invert_allday_bars=True))
+        bar_ink = _ink(img, EVENTS)
+        assert bar_ink > 0
+        blank_title = _all_day(TODAY, TODAY + timedelta(days=1), "")
+        assert bar_ink < _ink(
+            _render([blank_title], style=ThemeStyle(invert_allday_bars=True)), EVENTS
+        ), "the title is not knocked out of the inverted bar"
 
     def test_smoke_with_forecast(self):
-        img, draw = _make_draw()
+        """A forecast is accepted; this view does not surface it in the event list."""
         forecast = [
             DayForecast(
                 date=TODAY + timedelta(days=i),
@@ -303,28 +369,24 @@ class TestDrawToday:
             )
             for i in range(3)
         ]
-        draw_today(draw, [_timed(TODAY, 10, 11)], TODAY, forecast=forecast)
-        assert img.getbbox() is not None
+        with_fc = _render([_timed(TODAY, 10, 11)], forecast=forecast)
+        assert _ink(with_fc, EVENTS) > 0
 
     def test_no_events_today_message_differs_from_with_events(self):
-        """Empty event panel should differ from a panel with events."""
-        img_empty, draw_empty = _make_draw()
-        draw_today(draw_empty, [], TODAY)
-
-        img_with, draw_with = _make_draw()
-        draw_today(draw_with, [_timed(TODAY, 9, 10)], TODAY)
-
-        assert img_empty.tobytes() != img_with.tobytes()
+        assert _render().tobytes() != _render([_timed(TODAY, 9, 10)]).tobytes()
 
     def test_same_am_period_strips_redundant_suffix(self):
-        """When start and end share the same am/pm, start suffix is stripped."""
-        img, draw = _make_draw()
-        evt = _timed(TODAY, 9, 11, "Morning Block")  # 9a–11a → should show "9–11a"
-        draw_today(draw, [evt], TODAY)
-        assert img.getbbox() is not None
+        """9a–11a is set as '9–11a', which is narrower than a cross-period range.
+
+        Compared against an event of the same duration that crosses noon, so
+        the only difference is the dropped suffix.
+        """
+        same_period = _render([_timed(TODAY, 9, 11, "Block")])
+        cross_noon = _render([_timed(TODAY, 11, 13, "Block")])
+        assert _ink(same_period, EVENTS) < _ink(cross_noon, EVENTS), (
+            "the redundant am/pm suffix was not stripped"
+        )
 
     def test_cross_noon_event(self):
-        img, draw = _make_draw()
-        evt = _timed(TODAY, 11, 13, "Lunch & Meeting")  # 11a–1p
-        draw_today(draw, [evt], TODAY)
-        assert img.getbbox() is not None
+        """An 11a–1p event keeps both suffixes."""
+        assert _ink(_render([_timed(TODAY, 11, 13, "Lunch & Meeting")]), EVENTS) > 0

--- a/tests/test_v2_features.py
+++ b/tests/test_v2_features.py
@@ -32,12 +32,40 @@ from src.fetchers.calendar import (
     _filter_to_window,
     _ser_sync_event,
 )
+from src.render import layout as L
 from src.render.components.weather_panel import draw_weather
 from src.render.components.week_view import draw_week
+from src.render.quantize import flatten_pixels
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*.
+
+    (#229) The draw tests below asserted `img.getbbox() is not None` on a
+    mode-"1" plate filled with 1, where getbbox can never return None.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_x_extent(img, box):
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    xs = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+WEEK_BOX = (L.WEEK_X, L.WEEK_Y, L.WEEK_X + L.WEEK_W, L.WEEK_Y + L.WEEK_H)
+WEATHER_BOX = (L.WEATHER_X, L.WEATHER_Y, L.WEATHER_X + L.WEATHER_W, L.WEATHER_Y + L.WEATHER_H)
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -82,37 +110,62 @@ def _make_weather(**kwargs) -> WeatherData:
 
 
 class TestEventLocationDisplay:
-    def test_event_with_location_renders(self):
-        """Smoke test: events with location should not crash draw_week."""
-        today = date(2024, 3, 15)
-        events = [_timed(today, 9, 10, "Meeting", location="Conference Room A")]
+    def _week(self, events, today=None):
         img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        draw_week(draw, events, today or date(2024, 3, 15))
+        return img
+
+    def test_event_with_location_renders(self):
+        """A location adds a line under the event, so the day column inks more."""
+        today = date(2024, 3, 15)
+        with_loc = self._week([_timed(today, 9, 10, "Meeting", location="Conference Room A")])
+        without = self._week([_timed(today, 9, 10, "Meeting")])
+        assert _ink(with_loc, WEEK_BOX) > _ink(without, WEEK_BOX), "the location is not drawn"
 
     def test_event_location_split_on_comma(self):
-        """Location with comma: only the first component should appear (tested via no-crash)."""
+        """Only the first comma-separated component is drawn.
+
+        Two locations sharing a first component must render identically; one
+        differing in it must not. The old version asserted getbbox and said in
+        its own docstring that it was "tested via no-crash".
+        """
         today = date(2024, 3, 15)
-        events = [_timed(today, 9, 10, "Dentist", location="123 Main St, Suite 4, Springfield")]
-        img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+
+        def with_location(loc):
+            return _ink(self._week([_timed(today, 9, 10, "Dentist", location=loc)]), WEEK_BOX)
+
+        same_head = with_location("123 Main St, Suite 4, Springfield")
+        same_head_other_tail = with_location("123 Main St, Totally Different Tail")
+        different_head = with_location("456 Oak Ave, Suite 4, Springfield")
+        assert same_head == same_head_other_tail, "text past the first comma reached the plate"
+        assert same_head != different_head, "the location is not being drawn at all"
 
     def test_event_without_location_renders(self):
-        """Events without location should still render correctly."""
+        """No location still draws the event itself."""
         today = date(2024, 3, 15)
-        events = [_timed(today, 9, 10, "No Location")]
-        img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        no_loc = self._week([_timed(today, 9, 10, "No Location")])
+        empty = self._week([])
+        assert _ink(no_loc, WEEK_BOX) > _ink(empty, WEEK_BOX)
 
     def test_many_events_with_locations_overflow(self):
-        """Overflow (+N more) should still work when events have locations."""
+        """Rows cap out and the surplus becomes '+N more'."""
         today = date(2024, 3, 15)
-        events = [_timed(today, 8 + i, 9 + i, f"Evt {i}", location=f"Room {i}") for i in range(8)]
-        img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+
+        def with_n(n):
+            # Hours wrap so n can exceed 24 without leaving the clock.
+            return _ink(
+                self._week(
+                    [
+                        _timed(today, 6 + (i % 12), 7 + (i % 12), f"Evt {i}", location=f"Room {i}")
+                        for i in range(n)
+                    ]
+                ),
+                WEEK_BOX,
+            )
+
+        assert with_n(8) > with_n(2), "nothing accumulated"
+        # Past the cap the row count saturates; only the "+N" label grows.
+        assert with_n(8) != with_n(20), "the overflow count is not being drawn"
 
 
 # ---------------------------------------------------------------------------
@@ -122,12 +175,13 @@ class TestEventLocationDisplay:
 
 class TestBusynessHeatmap:
     def test_no_crash_with_max_events(self):
-        """10+ events (> _MAX_DOTS cap) should not crash."""
+        """12 events on one day render, and draw more than a quiet day."""
         today = date(2024, 3, 18)
-        events = [_timed(today, 7, 8, f"Evt {i}") for i in range(12)]
         img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        draw_week(draw, [_timed(today, 7, 8, f"Evt {i}") for i in range(12)], today)
+        quiet, quiet_draw = _make_draw()
+        draw_week(quiet_draw, [_timed(today, 7, 8, "Only one")], today)
+        assert _ink(img, WEEK_BOX) > _ink(quiet, WEEK_BOX)
 
 
 # ---------------------------------------------------------------------------
@@ -137,23 +191,33 @@ class TestBusynessHeatmap:
 
 class TestWeatherAlerts:
     def test_alert_renders_without_crash(self):
-        weather = _make_weather(alerts=[WeatherAlert(event="Flood Watch")])
+        """An alert takes a forecast column as a filled (inverted) bar."""
         img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        draw_weather(draw, _make_weather(alerts=[WeatherAlert(event="Flood Watch")]))
+        plain, plain_draw = _make_draw()
+        draw_weather(plain_draw, _make_weather(alerts=[]))
+        assert _ink(img, WEATHER_BOX) > _ink(plain, WEATHER_BOX) * 2, (
+            "the alert column is not inverted"
+        )
 
     def test_no_alerts_renders_normally(self):
-        weather = _make_weather(alerts=[])
+        """No alerts draws the panel with no inverted column."""
         img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        draw_weather(draw, _make_weather(alerts=[]))
+        area = L.WEATHER_W * L.WEATHER_H
+        assert 0 < _ink(img, WEATHER_BOX) < area * 0.5
 
     def test_long_alert_name_truncated(self):
-        """Very long alert names should be truncated, not overflow."""
-        weather = _make_weather(alerts=[WeatherAlert(event="A" * 200)])
+        """A 200-char alert stays inside the panel rather than overflowing."""
         img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        draw_weather(draw, _make_weather(alerts=[WeatherAlert(event="A" * 200)]))
+        extent = _ink_x_extent(img, WEATHER_BOX)
+        assert extent is not None, "nothing drawn"
+        assert extent[1] <= L.WEATHER_X + L.WEATHER_W, "the alert text left the panel"
+        # Nothing but chrome to the right: the panel's border hlines are drawn
+        # to x0+w inclusive, so they put a few pixels on the column past the
+        # region — the same convention weather_panel and birthday_bar share.
+        assert _ink(img, (L.WEATHER_X + L.WEATHER_W + 1, 0, 800, 480)) == 0
 
     def test_weather_alert_model(self):
         a = WeatherAlert(event="Tornado Warning")

--- a/tests/test_v3_features.py
+++ b/tests/test_v3_features.py
@@ -338,55 +338,12 @@ class TestMultidaySpanning:
 # ---------------------------------------------------------------------------
 
 
-class TestWeekViewForecast:
-    """`draw_week(forecast=...)` is accepted and ignored.
-
-    FINDING (#229): `forecast` appears exactly once in week_view.py — in
-    draw_week's signature — and is never read. _builtins.py nonetheless
-    computes `ctx.data.weather.forecast` on every render and passes it in, so
-    this is live plumbing feeding a parameter that does nothing.
-
-    The three tests below were named as if the week view rendered a forecast
-    and asserted getbbox, which could not have noticed either way. They now
-    assert the equality that is actually true, so they will fail the moment
-    the parameter starts (or stops) mattering. Left as a finding rather than
-    removed, because deleting a public component parameter is outside a
-    test-strengthening change.
-    """
-
-    def _render(self, today, **kwargs):
-        img, draw = _make_draw()
-        draw_week(draw, [], today, **kwargs)
-        return img
-
-    def test_draw_week_forecast_argument_is_ignored(self):
-        today = date(2024, 3, 15)
-        forecast = [
-            DayForecast(
-                date=today + timedelta(days=i),
-                high=50.0 + i,
-                low=40.0 + i,
-                icon="02d",
-                description="cloudy",
-            )
-            for i in range(1, 6)
-        ]
-        with_forecast = self._render(today, forecast=forecast)
-        assert _ink(with_forecast, WEEK_BOX) > 0, "the grid itself did not render"
-        assert with_forecast.tobytes() == self._render(today, forecast=None).tobytes(), (
-            "draw_week started using its forecast argument — update this test and the note above it"
-        )
-
-    def test_draw_week_forecast_none_no_crash(self):
-        today = date(2024, 3, 15)
-        assert _ink(self._render(today, forecast=None), WEEK_BOX) > 0
-
-    def test_draw_week_forecast_empty_list(self):
-        today = date(2024, 3, 15)
-        assert (
-            self._render(today, forecast=[]).tobytes()
-            == self._render(today, forecast=None).tobytes()
-        )
+# `draw_week` used to accept a `forecast` argument that it never read, while
+# _builtins.py computed `ctx.data.weather.forecast` on every render to feed it.
+# The three tests that lived here documented that dead parameter (#229); both
+# the parameter and its caller are gone now, so there is nothing left to pin —
+# passing `forecast=` to draw_week is a TypeError, which the signature enforces
+# more directly than a test could.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v3_features.py
+++ b/tests/test_v3_features.py
@@ -25,6 +25,7 @@ from src.render.components.week_view import (
 )
 from src.render.moon import moon_phase_age, moon_phase_glyph, moon_phase_name
 from src.render.quantize import flatten_pixels
+from tests.inkutils import ink
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -465,4 +466,4 @@ class TestRenderPipelineV3:
         assert isinstance(result, Image.Image)
         assert result.size == (800, 480)
         assert result.mode == "1"
-        assert result.getbbox() is not None
+        assert ink(result) > 0, "the full pipeline rendered a blank plate"

--- a/tests/test_v3_features.py
+++ b/tests/test_v3_features.py
@@ -16,6 +16,7 @@ from src.data.models import (
     WeatherData,
 )
 from src.display.driver import image_changed, image_hash, persist_image_hash
+from src.render import layout as L
 from src.render.components.week_view import (
     _collect_spanning_events,
     _events_for_day,
@@ -23,10 +24,30 @@ from src.render.components.week_view import (
     draw_week,
 )
 from src.render.moon import moon_phase_age, moon_phase_glyph, moon_phase_name
+from src.render.quantize import flatten_pixels
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*.
+
+    (#229) The draw tests below asserted `img.getbbox() is not None` on a
+    mode-"1" plate filled with 1, where every pixel is non-zero and getbbox
+    can never return None.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+WEEK_BOX = (L.WEEK_X, L.WEEK_Y, L.WEEK_X + L.WEEK_W, L.WEEK_Y + L.WEEK_H)
+WEATHER_BOX = (L.WEATHER_X, L.WEATHER_Y, L.WEATHER_X + L.WEATHER_W, L.WEATHER_Y + L.WEATHER_H)
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -276,6 +297,7 @@ class TestMultidaySpanning:
         assert len(spanning) == 0
 
     def test_draw_week_with_spanning_events_no_crash(self):
+        """A spanning bar plus a timed event both reach the grid."""
         today = date(2024, 3, 15)  # Friday
         events = [
             _all_day(date(2024, 3, 12), date(2024, 3, 15), "Conference"),
@@ -283,17 +305,22 @@ class TestMultidaySpanning:
         ]
         img, draw = _make_draw()
         draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        empty, empty_draw = _make_draw()
+        draw_week(empty_draw, [], today)
+        assert _ink(img, WEEK_BOX) > _ink(empty, WEEK_BOX), "no events drawn"
 
     def test_draw_week_multiple_spanning_events(self):
+        """Two overlapping spanning bars both draw — not just the first."""
         today = date(2024, 3, 15)
-        events = [
-            _all_day(date(2024, 3, 11), date(2024, 3, 14), "Trip A"),
-            _all_day(date(2024, 3, 14), date(2024, 3, 17), "Trip B"),
-        ]
-        img, draw = _make_draw()
-        draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        trip_a = _all_day(date(2024, 3, 11), date(2024, 3, 14), "Trip A")
+        trip_b = _all_day(date(2024, 3, 14), date(2024, 3, 17), "Trip B")
+
+        def render(events):
+            img, draw = _make_draw()
+            draw_week(draw, events, today)
+            return _ink(img, WEEK_BOX)
+
+        assert render([trip_a, trip_b]) > render([trip_a]), "the second bar was not drawn"
 
     def test_spanning_event_excluded_from_per_day_rendering(self):
         """Multi-day events drawn as spanning bars should not also appear as per-day bars."""
@@ -311,7 +338,27 @@ class TestMultidaySpanning:
 
 
 class TestWeekViewForecast:
-    def test_draw_week_with_forecast_no_crash(self):
+    """`draw_week(forecast=...)` is accepted and ignored.
+
+    FINDING (#229): `forecast` appears exactly once in week_view.py — in
+    draw_week's signature — and is never read. _builtins.py nonetheless
+    computes `ctx.data.weather.forecast` on every render and passes it in, so
+    this is live plumbing feeding a parameter that does nothing.
+
+    The three tests below were named as if the week view rendered a forecast
+    and asserted getbbox, which could not have noticed either way. They now
+    assert the equality that is actually true, so they will fail the moment
+    the parameter starts (or stops) mattering. Left as a finding rather than
+    removed, because deleting a public component parameter is outside a
+    test-strengthening change.
+    """
+
+    def _render(self, today, **kwargs):
+        img, draw = _make_draw()
+        draw_week(draw, [], today, **kwargs)
+        return img
+
+    def test_draw_week_forecast_argument_is_ignored(self):
         today = date(2024, 3, 15)
         forecast = [
             DayForecast(
@@ -323,21 +370,22 @@ class TestWeekViewForecast:
             )
             for i in range(1, 6)
         ]
-        img, draw = _make_draw()
-        draw_week(draw, [], today, forecast=forecast)
-        assert img.getbbox() is not None
+        with_forecast = self._render(today, forecast=forecast)
+        assert _ink(with_forecast, WEEK_BOX) > 0, "the grid itself did not render"
+        assert with_forecast.tobytes() == self._render(today, forecast=None).tobytes(), (
+            "draw_week started using its forecast argument — update this test and the note above it"
+        )
 
     def test_draw_week_forecast_none_no_crash(self):
         today = date(2024, 3, 15)
-        img, draw = _make_draw()
-        draw_week(draw, [], today, forecast=None)
-        assert img.getbbox() is not None
+        assert _ink(self._render(today, forecast=None), WEEK_BOX) > 0
 
     def test_draw_week_forecast_empty_list(self):
         today = date(2024, 3, 15)
-        img, draw = _make_draw()
-        draw_week(draw, [], today, forecast=[])
-        assert img.getbbox() is not None
+        assert (
+            self._render(today, forecast=[]).tobytes()
+            == self._render(today, forecast=None).tobytes()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -347,28 +395,32 @@ class TestWeekViewForecast:
 
 class TestWeatherPanelMoon:
     def test_draw_weather_with_today_no_crash(self):
+        """today= adds the moon glyph to the weather panel's label row."""
         from src.render.components.weather_panel import draw_weather
 
-        weather = _make_weather()
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=date(2024, 3, 15))
-        assert img.getbbox() is not None
+        with_today, draw = _make_draw()
+        draw_weather(draw, _make_weather(), today=date(2024, 3, 15))
+        without, draw2 = _make_draw()
+        draw_weather(draw2, _make_weather(), today=None)
+        assert _ink(with_today, WEATHER_BOX) > _ink(without, WEATHER_BOX), "no moon glyph"
 
     def test_draw_weather_without_today_no_crash(self):
-        """Backward compat: today=None should still work."""
+        """Backward compat: today=None renders the panel minus the glyph."""
         from src.render.components.weather_panel import draw_weather
 
-        weather = _make_weather()
         img, draw = _make_draw()
-        draw_weather(draw, weather, today=None)
-        assert img.getbbox() is not None
+        draw_weather(draw, _make_weather(), today=None)
+        assert _ink(img, WEATHER_BOX) > 0
 
     def test_draw_weather_none_with_today(self):
+        """The moon glyph is drawn even when there is no weather to pair it with."""
         from src.render.components.weather_panel import draw_weather
 
-        img, draw = _make_draw()
+        with_today, draw = _make_draw()
         draw_weather(draw, None, today=date(2024, 3, 15))
-        assert img.getbbox() is not None
+        without, draw2 = _make_draw()
+        draw_weather(draw2, None, today=None)
+        assert _ink(with_today, WEATHER_BOX) > _ink(without, WEATHER_BOX)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weather_full_component.py
+++ b/tests/test_weather_full_component.py
@@ -3,6 +3,30 @@
 Covers: hero zone, metric cards, detail strip, alert banner, forecast grid,
 and the unavailable fallback — exercising branches not covered by the existing
 test_weather_full_aqi.py (which focuses on the AQI card only).
+
+Assertion discipline (see #229)
+-------------------------------
+These tests used to assert ``img.getbbox() is not None``, or nothing at all.
+On the mode-``"1"`` canvas built below that assertion has no failing input:
+the plate is filled with 1, ``getbbox()`` reports the bounds of *non-zero*
+pixels, so it returns the full canvas even for a plate nothing was drawn to.
+All 42 tests passed with ``draw_weather_full`` stubbed to a no-op.
+
+Ink here therefore means **zero-valued** pixels, measured per zone with the
+helpers below. The component divides the canvas into fixed proportional
+zones, so each feature can be measured in the band that owns it, and most
+assertions are differential — render with and without, compare.
+
+Verification (the step that makes the rewrite worth anything): with
+``draw_weather_full`` stubbed to a no-op, 42 of the 45 tests here fail. The
+three survivors are all assertions a no-op satisfies by construction —
+``test_returns_none`` (a no-op also returns None),
+``test_default_region_and_style`` and ``test_no_alerts_no_banner`` (both
+assert an equivalence, and two blank plates are equal). Each was checked the
+other way instead, by breaking the behaviour it names — returning a value,
+defaulting to a different region, drawing the banner unconditionally — and
+confirming it then fails. If you add a test here, do the same: break the
+thing it is named for and watch it go red before you trust it.
 """
 
 from datetime import date, datetime, timedelta
@@ -16,27 +40,103 @@ from src.data.models import (
     WeatherData,
 )
 from src.render.components.weather_full import draw_weather_full
+from src.render.quantize import flatten_pixels
 from src.render.theme import ComponentRegion, ThemeStyle
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+CANVAS_W, CANVAS_H = 800, 480
 
-def _make_draw(w: int = 800, h: int = 480):
+# Zone geometry, mirrored from draw_weather_full's own proportions so a band
+# follows the component if its layout moves rather than pointing at blank plate.
+_HERO_H = int(CANVAS_H * 0.44)
+_CARDS_H = int(CANVAS_H * 0.155)
+_DETAIL_H = int(CANVAS_H * 0.06)
+_ALERT_H = int(CANVAS_H * 0.055)
+
+HERO = (0, 0, CANVAS_W, _HERO_H)
+CARDS = (0, _HERO_H, CANVAS_W, _HERO_H + _CARDS_H)
+# The thin rule above the forecast lands on the detail zone's last row, and it
+# is drawn whether or not the strip has any content — so it is excluded here.
+DETAIL = (0, _HERO_H + _CARDS_H, CANVAS_W, _HERO_H + _CARDS_H + _DETAIL_H - 1)
+ALERT = (0, _HERO_H + _CARDS_H + _DETAIL_H, CANVAS_W, _HERO_H + _CARDS_H + _DETAIL_H + _ALERT_H)
+
+
+def _forecast_band(has_alerts: bool = False) -> tuple[int, int, int, int]:
+    top = _HERO_H + _CARDS_H + _DETAIL_H + (_ALERT_H if has_alerts else 0)
+    return (0, top, CANVAS_W, CANVAS_H)
+
+
+def _make_draw(w: int = CANVAS_W, h: int = CANVAS_H):
     img = Image.new("1", (w, h), 1)
     return img, ImageDraw.Draw(img)
 
 
-def _make_forecast(n: int = 5) -> list[DayForecast]:
+def _ink(img: Image.Image, box: tuple[int, int, int, int] | None = None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_x_extent(img: Image.Image, box: tuple[int, int, int, int]):
+    """(left, right) x-extent of ink inside *box*, or None if there is none."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    xs = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    return (xs[0], xs[-1] + 1) if xs else None
+
+
+def _ink_clusters(img: Image.Image, box: tuple[int, int, int, int], min_gap: int = 12) -> int:
+    """Count horizontally separated groups of ink inside *box*.
+
+    Used to count forecast columns and metric cards without hardcoding their
+    pixel positions: a column is a run of inked x-positions, and columns are
+    separated by more than *min_gap* blank ones.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    cols = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    if not cols:
+        return 0
+    return 1 + sum(1 for p, q in zip(cols, cols[1:]) if q - p > min_gap)
+
+
+def _card_count(img: Image.Image) -> int:
+    """Number of metric cards, counted from their rounded-rect outlines.
+
+    A scanline through the card bodies crosses each card's left and right
+    edge, so the number of ink runs is exactly twice the card count.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    y = _HERO_H + 10
+    runs = 0
+    prev = False
+    for x in range(CANVAS_W):
+        cur = px[y * width + x] == 0
+        if cur and not prev:
+            runs += 1
+        prev = cur
+    return runs // 2
+
+
+def _make_forecast(n: int = 5, precip: float | None = 0.20, icon: str = "02d"):
     return [
         DayForecast(
             date=date(2024, 3, 16) + timedelta(days=i),
             high=60.0 + i * 2,
             low=45.0 + i,
-            icon="02d",
+            icon=icon,
             description="partly cloudy",
-            precip_chance=0.20,
+            precip_chance=precip,
         )
         for i in range(n)
     ]
@@ -66,6 +166,21 @@ def _make_weather(**overrides) -> WeatherData:
 
 TODAY = date(2024, 3, 15)
 
+_UNSET = object()
+
+
+def _render(weather=_UNSET, today=TODAY, *, air_quality=None, region=None, style=None, **overrides):
+    """Render onto a fresh plate and return the image.
+
+    Leftover kwargs build the WeatherData. Pass ``weather=`` directly —
+    including ``weather=None``, hence the sentinel rather than a default.
+    """
+    if weather is _UNSET:
+        weather = _make_weather(**overrides)
+    img, draw = _make_draw()
+    draw_weather_full(draw, weather, today, air_quality=air_quality, region=region, style=style)
+    return img
+
 
 # ---------------------------------------------------------------------------
 # Smoke — basic rendering
@@ -74,32 +189,36 @@ TODAY = date(2024, 3, 15)
 
 class TestDrawWeatherFullSmoke:
     def test_renders_with_full_data(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), TODAY)
+        """Every zone receives content."""
+        img = _render()
+        assert _ink(img, HERO) > 0, "hero zone empty"
+        assert _ink(img, CARDS) > 0, "metric cards zone empty"
+        assert _ink(img, DETAIL) > 0, "detail strip empty"
+        assert _ink(img, _forecast_band()) > 0, "forecast grid empty"
 
     def test_returns_none(self):
         _, draw = _make_draw()
-        result = draw_weather_full(draw, _make_weather(), TODAY)
-        assert result is None
+        assert draw_weather_full(draw, _make_weather(), TODAY) is None
 
     def test_produces_non_blank_image(self):
-        img, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), TODAY)
-        assert img.getbbox() is not None
+        """Genuinely non-blank: ink pixels exist, which getbbox could never show."""
+        assert _ink(_render()) > 0
 
     def test_default_region_and_style(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), TODAY, region=None, style=None)
+        """region=None/style=None fill in the full-canvas defaults."""
+        explicit = _render(region=ComponentRegion(0, 0, CANVAS_W, CANVAS_H), style=ThemeStyle())
+        assert _render(region=None, style=None).tobytes() == explicit.tobytes()
 
-    def test_custom_region_and_style(self):
-        _, draw = _make_draw()
-        draw_weather_full(
-            draw,
-            _make_weather(),
-            TODAY,
-            region=ComponentRegion(0, 0, 800, 480),
-            style=ThemeStyle(),
-        )
+    def test_custom_region_offset_moves_the_content(self):
+        """A region offset shifts the whole plate rather than being ignored."""
+        at_origin = _render(region=ComponentRegion(0, 0, 400, 240))
+        offset = _render(region=ComponentRegion(100, 0, 400, 240))
+        assert _ink(at_origin) > 0
+        assert at_origin.tobytes() != offset.tobytes()
+        left_origin = _ink_x_extent(at_origin, (0, 0, CANVAS_W, CANVAS_H))
+        left_offset = _ink_x_extent(offset, (0, 0, CANVAS_W, CANVAS_H))
+        assert left_origin is not None and left_offset is not None
+        assert left_offset[0] > left_origin[0], "region.x offset did not move the content"
 
 
 # ---------------------------------------------------------------------------
@@ -109,18 +228,29 @@ class TestDrawWeatherFullSmoke:
 
 class TestDrawWeatherFullUnavailable:
     def test_renders_when_weather_is_none(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, None, TODAY)
+        """The fallback message is drawn and nothing else is."""
+        img = _render(weather=None)
+        assert _ink(img) > 0, "no fallback message drawn"
+        assert _card_count(img) == 0, "metric cards drawn for None weather"
+        assert _ink(img, _forecast_band()) == 0, "forecast grid drawn for None weather"
 
-    def test_unavailable_produces_non_blank_image(self):
-        img, draw = _make_draw()
-        draw_weather_full(draw, None, TODAY)
-        assert img.getbbox() is not None
+    def test_unavailable_message_is_centred(self):
+        """_draw_unavailable centres its message on the region."""
+        img = _render(weather=None)
+        extent = _ink_x_extent(img, (0, 0, CANVAS_W, CANVAS_H))
+        assert extent is not None
+        midpoint = (extent[0] + extent[1]) / 2
+        assert abs(midpoint - CANVAS_W / 2) < 12, f"message off-centre: midpoint {midpoint}"
 
     def test_unavailable_with_air_quality_still_renders(self):
-        _, draw = _make_draw()
+        """Air-quality data does not resurrect any of the normal zones."""
         aq = AirQualityData(aqi=42, category="Good", pm25=9.8)
-        draw_weather_full(draw, None, TODAY, air_quality=aq)
+        with_aq = _render(weather=None, air_quality=aq)
+        without = _render(weather=None)
+        assert _ink(with_aq) > 0
+        assert with_aq.tobytes() == without.tobytes(), (
+            "air quality leaked into the unavailable fallback"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -130,82 +260,106 @@ class TestDrawWeatherFullUnavailable:
 
 class TestHeroZone:
     def test_renders_with_location_name(self):
-        _, draw = _make_draw()
-        wx = _make_weather(location_name="New York")
-        draw_weather_full(draw, wx, TODAY)
+        """The location line is drawn under the hi/lo."""
+        assert _ink(_render(location_name="San Francisco"), HERO) > _ink(
+            _render(location_name=None), HERO
+        )
 
     def test_renders_without_location_name(self):
-        _, draw = _make_draw()
-        wx = _make_weather(location_name=None)
-        draw_weather_full(draw, wx, TODAY)
+        """No location still renders the rest of the hero."""
+        img = _render(location_name=None)
+        assert _ink(img, HERO) > 0
+        assert _ink(img, HERO) < _ink(_render(location_name="San Francisco"), HERO)
 
     def test_renders_negative_temperature(self):
-        _, draw = _make_draw()
-        wx = _make_weather(current_temp=-15.0, high=-10.0, low=-22.0)
-        draw_weather_full(draw, wx, TODAY)
+        """A negative temp draws its minus sign — more ink than the positive."""
+        assert _ink(_render(current_temp=-15.0), HERO) > _ink(_render(current_temp=15.0), HERO)
 
     def test_renders_triple_digit_temperature(self):
-        _, draw = _make_draw()
-        wx = _make_weather(current_temp=105.0, high=110.0, low=90.0)
-        draw_weather_full(draw, wx, TODAY)
+        """Three digits draw more than two."""
+        assert _ink(_render(current_temp=105.0), HERO) > _ink(_render(current_temp=72.0), HERO)
 
     def test_renders_unknown_icon_uses_fallback(self):
-        _, draw = _make_draw()
-        wx = _make_weather(current_icon="unknown_icon_code_xyz")
-        draw_weather_full(draw, wx, TODAY)
+        """Unknown OWM codes all collapse to the same fallback glyph.
+
+        Two different unknown codes must render identically (both fall back),
+        and differently from a known code — which is what 'uses the fallback'
+        actually means.
+        """
+        unknown_a = _render(current_icon="zz9")
+        unknown_b = _render(current_icon="not_a_code")
+        known = _render(current_icon="01d")
+        assert _ink(unknown_a, HERO) == _ink(unknown_b, HERO), (
+            "two unknown icons rendered differently — they are not sharing a fallback"
+        )
+        assert _ink(unknown_a, HERO) != _ink(known, HERO), (
+            "the fallback glyph is identical to the 01d glyph — nothing is being mapped"
+        )
 
 
 # ---------------------------------------------------------------------------
-# Metric cards — optional wind, UV, pressure
+# Metric cards
 # ---------------------------------------------------------------------------
 
 
 class TestMetricCards:
     def test_four_cards_without_air_quality(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), TODAY, air_quality=None)
+        assert _card_count(_render()) == 4
 
     def test_five_cards_with_air_quality(self):
-        _, draw = _make_draw()
-        aq = AirQualityData(aqi=55, category="Moderate", pm25=12.5)
-        draw_weather_full(draw, _make_weather(), TODAY, air_quality=aq)
+        """The AQI card is appended as a fifth."""
+        aq = AirQualityData(aqi=42, category="Good", pm25=9.8)
+        assert _card_count(_render(air_quality=aq)) == 5
 
     def test_feels_like_none_shows_temp_card(self):
-        """When feels_like is None, card shows current temp with 'Temp' label."""
-        _, draw = _make_draw()
-        wx = _make_weather(feels_like=None)
-        draw_weather_full(draw, wx, TODAY)
+        """Without feels_like the card falls back to the current temp + 'Temp' label."""
+        cards_absent = _ink(_render(feels_like=None), CARDS)
+        assert cards_absent > 0
+        assert cards_absent != _ink(_render(feels_like=70.0), CARDS)
+        assert _card_count(_render(feels_like=None)) == 4, "the card disappeared entirely"
 
     def test_wind_speed_none_shows_dash(self):
-        _, draw = _make_draw()
-        wx = _make_weather(wind_speed=None, wind_deg=None)
-        draw_weather_full(draw, wx, TODAY)
+        """No wind speed still draws the card, with a dash instead of a value."""
+        no_wind = _render(wind_speed=None)
+        assert _card_count(no_wind) == 4
+        assert _ink(no_wind, CARDS) < _ink(_render(wind_speed=8.0), CARDS), (
+            "the dash placeholder is not lighter than a real wind reading"
+        )
 
     def test_wind_deg_none_omits_compass(self):
-        _, draw = _make_draw()
-        wx = _make_weather(wind_speed=10.0, wind_deg=None)
-        draw_weather_full(draw, wx, TODAY)
+        """Without a bearing the wind card loses its compass suffix."""
+        assert _ink(_render(wind_deg=None), CARDS) < _ink(_render(wind_deg=270.0), CARDS)
 
     def test_uv_none_shows_pressure_card(self):
-        """When UV is absent but pressure is present, shows pressure card."""
-        _, draw = _make_draw()
-        wx = _make_weather(uv_index=None, pressure=1015.0)
-        draw_weather_full(draw, wx, TODAY)
+        """UV missing but pressure present swaps in the barometer card."""
+        uv_none = _render(uv_index=None)
+        assert _card_count(uv_none) == 4
+        assert _ink(uv_none, CARDS) != _ink(_render(uv_index=4.0), CARDS)
+        assert _ink(uv_none, CARDS) != _ink(_render(uv_index=None, pressure=None), CARDS), (
+            "the pressure card renders the same as the empty-dash card"
+        )
 
     def test_uv_and_pressure_none_shows_dash_card(self):
-        _, draw = _make_draw()
-        wx = _make_weather(uv_index=None, pressure=None)
-        draw_weather_full(draw, wx, TODAY)
+        """Neither available still leaves four cards, the last one a dash."""
+        both_none = _render(uv_index=None, pressure=None)
+        assert _card_count(both_none) == 4
+        assert _ink(both_none, CARDS) < _ink(_render(uv_index=4.0), CARDS)
 
     def test_air_quality_long_category_truncated(self):
-        """Very long category string is truncated to 11 chars in the card."""
-        _, draw = _make_draw()
-        aq = AirQualityData(
-            aqi=120,
-            category="Unhealthy for Sensitive Groups",
-            pm25=38.0,
-        )
-        draw_weather_full(draw, _make_weather(), TODAY, air_quality=aq)
+        """A long category is cut to 11 chars, so it renders like the cut string.
+
+        Two categories sharing their first 11 characters must be
+        indistinguishable on the plate; one differing inside them must not be.
+        """
+        long_a = AirQualityData(aqi=120, category="Unhealthy for Sensitive Groups", pm25=38.0)
+        long_b = AirQualityData(aqi=120, category="Unhealthy fXXXXXXXX different", pm25=38.0)
+        differs_early = AirQualityData(aqi=120, category="Moderate air", pm25=38.0)
+
+        a = _ink(_render(air_quality=long_a), CARDS)
+        b = _ink(_render(air_quality=long_b), CARDS)
+        c = _ink(_render(air_quality=differs_early), CARDS)
+        assert a == b, "text past the 11-char cut reached the plate"
+        assert a != c, "the label is not being drawn at all"
 
 
 # ---------------------------------------------------------------------------
@@ -215,53 +369,54 @@ class TestMetricCards:
 
 class TestDetailStrip:
     def test_renders_with_sunrise_and_sunset(self):
-        _, draw = _make_draw()
-        wx = _make_weather(
-            sunrise=datetime(2024, 3, 15, 6, 24),
-            sunset=datetime(2024, 3, 15, 19, 45),
-        )
-        draw_weather_full(draw, wx, TODAY)
+        """Both times present draw more than either alone."""
+        both = _ink(_render(), DETAIL)
+        assert both > _ink(_render(sunrise=None), DETAIL)
+        assert both > _ink(_render(sunset=None), DETAIL)
 
     def test_renders_without_sunrise(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunrise=None)
-        draw_weather_full(draw, wx, TODAY)
+        no_rise = _ink(_render(sunrise=None), DETAIL)
+        assert _ink(_render(sunrise=None, sunset=None), DETAIL) < no_rise < _ink(_render(), DETAIL)
 
     def test_renders_without_sunset(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunset=None)
-        draw_weather_full(draw, wx, TODAY)
+        no_set = _ink(_render(sunset=None), DETAIL)
+        assert _ink(_render(sunrise=None, sunset=None), DETAIL) < no_set < _ink(_render(), DETAIL)
 
     def test_renders_without_sunrise_and_sunset(self):
-        _, draw = _make_draw()
-        wx = _make_weather(sunrise=None, sunset=None)
-        draw_weather_full(draw, wx, TODAY)
+        """Neither time still leaves the moon and pressure segments."""
+        neither = _render(sunrise=None, sunset=None)
+        assert _ink(neither, DETAIL) > 0
+        assert _ink(neither, DETAIL) < _ink(_render(), DETAIL)
 
     def test_renders_without_today_date(self):
-        """today=None skips moon phase section in the detail strip."""
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), today=None)
+        """today=None drops the moon glyph and its phase name."""
+        assert _ink(_render(today=None), DETAIL) < _ink(_render(today=TODAY), DETAIL)
 
     def test_renders_with_today_and_moon(self):
-        """today provided → moon glyph and phase name rendered in detail strip."""
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(), TODAY)
+        """The moon segment varies with the date — different phases, different ink."""
+        new_moon = _ink(_render(today=date(2024, 3, 10)), DETAIL)
+        full_moon = _ink(_render(today=date(2024, 3, 25)), DETAIL)
+        assert new_moon != full_moon, "the moon phase is not being drawn from the date"
 
     def test_pressure_in_strip_when_uv_present(self):
-        """Pressure appears in the detail strip only when UV is also available."""
-        _, draw = _make_draw()
-        wx = _make_weather(uv_index=3.0, pressure=1013.0)
-        draw_weather_full(draw, wx, TODAY)
+        """Pressure only reaches the strip when UV took the card slot."""
+        with_both = _ink(_render(uv_index=4.0, pressure=1013.0), DETAIL)
+        no_pressure = _ink(_render(uv_index=4.0, pressure=None), DETAIL)
+        assert with_both > no_pressure, "pressure did not reach the strip"
+        # With UV absent the pressure moves to a card instead, not the strip.
+        assert _ink(_render(uv_index=None, pressure=1013.0), DETAIL) == no_pressure
 
     def test_pm_breakdown_in_strip_with_air_quality(self):
-        _, draw = _make_draw()
-        aq = AirQualityData(aqi=42, category="Good", pm25=9.8, pm1=4.5, pm10=15.0)
-        draw_weather_full(draw, _make_weather(), TODAY, air_quality=aq)
+        aq = AirQualityData(aqi=42, category="Good", pm25=9.8, pm1=5.0, pm10=12.0)
+        assert _ink(_render(air_quality=aq), DETAIL) > _ink(_render(), DETAIL)
 
     def test_pm_breakdown_without_pm1_and_pm10(self):
-        _, draw = _make_draw()
-        aq = AirQualityData(aqi=42, category="Good", pm25=9.8, pm1=None, pm10=None)
-        draw_weather_full(draw, _make_weather(), TODAY, air_quality=aq)
+        """Only PM2.5 available draws a shorter segment than the full triple."""
+        full = AirQualityData(aqi=42, category="Good", pm25=9.8, pm1=5.0, pm10=12.0)
+        only25 = AirQualityData(aqi=42, category="Good", pm25=9.8)
+        assert (
+            0 < _ink(_render(air_quality=only25), DETAIL) < _ink(_render(air_quality=full), DETAIL)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -270,37 +425,50 @@ class TestDetailStrip:
 
 
 class TestAlertBanner:
+    # The banner is a filled_rect with knocked-out text, so it inks nearly its
+    # whole band; the same band without alerts carries only stray descenders.
+    FILLED = 0.5
+
+    def _fill_fraction(self, img) -> float:
+        x0, y0, x1, y1 = ALERT
+        return _ink(img, ALERT) / ((x1 - x0) * (y1 - y0))
+
     def test_renders_single_alert(self):
-        _, draw = _make_draw()
-        wx = _make_weather()
-        wx.alerts = [WeatherAlert(event="Flood Watch")]
-        draw_weather_full(draw, wx, TODAY)
+        """One alert inverts the banner band."""
+        img = _render(alerts=[WeatherAlert(event="Flood Watch")])
+        assert self._fill_fraction(img) > self.FILLED, "alert banner is not inverted"
 
     def test_renders_multiple_alerts(self):
-        _, draw = _make_draw()
-        wx = _make_weather()
-        wx.alerts = [
+        """Up to three alerts are joined into the one banner."""
+        alerts = [
             WeatherAlert(event="Flood Watch"),
             WeatherAlert(event="Wind Advisory"),
-            WeatherAlert(event="Freeze Warning"),
+            WeatherAlert(event="Heat Advisory"),
         ]
-        draw_weather_full(draw, wx, TODAY)
+        img = _render(alerts=alerts)
+        assert self._fill_fraction(img) > self.FILLED
+        # Knocked-out text means more alert text leaves *less* ink in the band.
+        one = _render(alerts=alerts[:1])
+        assert _ink(img, ALERT) < _ink(one, ALERT), "extra alerts drew no extra text"
 
     def test_renders_very_long_alert_event_name(self):
-        """Extremely long alert text triggers the truncation branch."""
-        _, draw = _make_draw()
-        wx = _make_weather()
-        wx.alerts = [
-            WeatherAlert(event="A" * 200),
-            WeatherAlert(event="B" * 200),
-        ]
-        draw_weather_full(draw, wx, TODAY)
+        """An over-long alert is truncated rather than overflowing the banner."""
+        img = _render(alerts=[WeatherAlert(event="Extremely " * 40 + "Long Warning")])
+        assert self._fill_fraction(img) > self.FILLED
+        extent = _ink_x_extent(img, ALERT)
+        assert extent is not None
+        assert extent[0] >= 0 and extent[1] <= CANVAS_W, "alert text left the canvas"
 
     def test_no_alerts_no_banner(self):
-        _, draw = _make_draw()
-        wx = _make_weather()
-        wx.alerts = []
-        draw_weather_full(draw, wx, TODAY)
+        """Without alerts the band belongs to the forecast, not a banner."""
+        img = _render()
+        assert self._fill_fraction(img) < self.FILLED, "a banner appeared without alerts"
+
+    def test_alerts_push_the_forecast_grid_down(self):
+        """The banner takes its own zone rather than overlaying the forecast."""
+        with_alert = _render(alerts=[WeatherAlert(event="Flood Watch")])
+        assert _ink(with_alert, _forecast_band(has_alerts=True)) > 0, "forecast lost to the banner"
+        assert _ink_clusters(with_alert, _forecast_band(has_alerts=True)) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -310,83 +478,112 @@ class TestAlertBanner:
 
 class TestForecastGrid:
     def test_renders_five_day_forecast(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(forecast=_make_forecast(5)), TODAY)
+        assert _ink_clusters(_render(), _forecast_band()) == 5
 
     def test_renders_one_day_forecast(self):
-        _, draw = _make_draw()
-        draw_weather_full(draw, _make_weather(forecast=_make_forecast(1)), TODAY)
+        assert _ink_clusters(_render(forecast=_make_forecast(1)), _forecast_band()) == 1
+
+    def test_forecast_column_count_tracks_the_data(self):
+        """Two, three and four days each get their own column count."""
+        for n in (2, 3, 4):
+            img = _render(forecast=_make_forecast(n))
+            assert _ink_clusters(img, _forecast_band()) == n, f"{n} days did not draw {n} columns"
+
+    def test_caps_at_five_columns(self):
+        """More than five days are truncated to five."""
+        assert _ink_clusters(_render(forecast=_make_forecast(8)), _forecast_band()) == 5
 
     def test_renders_empty_forecast_shows_fallback(self):
-        _, draw = _make_draw()
-        wx = _make_weather(forecast=[])
-        draw_weather_full(draw, wx, TODAY)
+        """No forecast draws the single centred fallback message."""
+        img = _render(forecast=[])
+        band = _forecast_band()
+        assert _ink(img, band) > 0, "no fallback message drawn"
+        assert _ink_clusters(img, band) == 1, "fallback should be one centred run, not columns"
+        assert _ink(img, band) < _ink(_render(), band)
 
     def test_renders_forecast_without_precip_chance(self):
-        _, draw = _make_draw()
-        fc = [
-            DayForecast(
-                date=date(2024, 3, 17) + timedelta(days=i),
-                high=65.0 + i,
-                low=50.0 + i,
-                icon="01d",
-                description="clear",
-                precip_chance=None,
-            )
-            for i in range(3)
-        ]
-        draw_weather_full(draw, _make_weather(forecast=fc), TODAY)
+        """precip_chance=None omits the percentage row."""
+        none_precip = _render(forecast=_make_forecast(5, precip=None))
+        with_precip = _render(forecast=_make_forecast(5, precip=0.20))
+        band = _forecast_band()
+        assert _ink(none_precip, band) < _ink(with_precip, band)
 
     def test_renders_forecast_with_low_precip_chance_excluded(self):
-        """precip_chance < 5% should not render the precip label."""
-        _, draw = _make_draw()
-        fc = [
-            DayForecast(
-                date=date(2024, 3, 17),
-                high=65.0,
-                low=50.0,
-                icon="01d",
-                description="clear",
-                precip_chance=0.02,
-            )
-        ]
-        draw_weather_full(draw, _make_weather(forecast=fc), TODAY)
+        """Below the 5% threshold the percentage row is suppressed."""
+        band = _forecast_band()
+        low = _ink(_render(forecast=_make_forecast(5, precip=0.02)), band)
+        none = _ink(_render(forecast=_make_forecast(5, precip=None)), band)
+        high = _ink(_render(forecast=_make_forecast(5, precip=0.20)), band)
+        assert low == none, "a sub-threshold precip chance was drawn"
+        assert low < high
 
     def test_renders_forecast_with_unknown_icon(self):
-        _, draw = _make_draw()
-        fc = [
-            DayForecast(
-                date=date(2024, 3, 17),
-                high=65.0,
-                low=50.0,
-                icon="invalid_xyz",
-                description="unknown",
+        """Unknown forecast icons fall back like the hero icon does."""
+        band = _forecast_band()
+        unknown_a = _ink(_render(forecast=_make_forecast(5, icon="invalid_xyz")), band)
+        unknown_b = _ink(_render(forecast=_make_forecast(5, icon="also_bogus")), band)
+        known = _ink(_render(forecast=_make_forecast(5, icon="02d")), band)
+        assert unknown_a == unknown_b
+        assert unknown_a != known
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    # The hero temp is capped at half the canvas width. Measured against that
+    # constraint rather than a sibling render, so it stays true if the font
+    # changes.
+    MAX_TEMP_W = CANVAS_W // 2
+    TEMP_BAND = (0, 85, CANVAS_W, 165)
+
+    def test_hero_temp_stays_within_its_width_cap(self):
+        """Realistic extremes all fit the cap at the base 64pt size.
+
+        Note what this does NOT do: it does not exercise the auto-scale-down
+        loop. At 64pt the loop only engages past ~11 characters, i.e. around
+        |temp| >= 999,999,999 — no real reading, and not -100.4, which the
+        previous version of this test claimed triggered it. The loop is
+        covered separately below.
+        """
+        for temp in (72.0, -100.4, -1000.0, -10000.0):
+            extent = _ink_x_extent(_render(current_temp=temp), self.TEMP_BAND)
+            assert extent is not None, f"nothing drawn for {temp}"
+            assert extent[1] - extent[0] <= self.MAX_TEMP_W, (
+                f"temp {temp} rendered {extent[1] - extent[0]}px wide, "
+                f"over the {self.MAX_TEMP_W} cap"
             )
-        ]
-        draw_weather_full(draw, _make_weather(forecast=fc), TODAY)
 
     def test_hero_temp_scales_down_for_wide_strings(self):
-        """Extreme temps (e.g. -100°) exercise the font auto-scale-down loop."""
-        img, draw = _make_draw()
-        # A 4-digit temperature string is wide enough to force the scale loop
-        # in the hero zone (see weather_full.py line 139).
-        wx = _make_weather(current_temp=-100.4)
-        draw_weather_full(draw, wx, TODAY)
-        assert img.getbbox() is not None
+        """A string wide enough to trip the scale-down loop is shrunk to fit.
+
+        The value is synthetic — no weather API reports it — but it is the
+        only way to reach the loop, which otherwise never runs. Without the
+        scale-down this string renders ~419px wide, over the 400px cap.
+        """
+        absurd = -999999999.0
+        extent = _ink_x_extent(_render(current_temp=absurd), self.TEMP_BAND)
+        assert extent is not None, "nothing drawn"
+        assert extent[1] - extent[0] <= self.MAX_TEMP_W, (
+            "the hero temp overflowed its cap — the scale-down loop did not engage"
+        )
 
     def test_detail_strip_empty_when_no_sun_no_moon_no_aq(self):
-        """No sunrise/sunset, no pressure+UV pair, no AQ, and no today → strip is skipped.
+        """No segments at all → _draw_detail_strip returns before drawing.
 
-        This covers the early-return in _draw_detail_strip (weather_full.py:329-330)
-        when no detail segments are emitted.
+        The band is measured excluding its last row, which carries the rule
+        above the forecast grid — that is drawn either way.
         """
-        img, draw = _make_draw()
-        wx = _make_weather(
+        img = _render(
             sunrise=None,
             sunset=None,
             uv_index=None,  # pressure needs uv_index to surface in the strip
             pressure=None,
+            today=None,
         )
-        # today=None suppresses the moon-phase placeholder → parts stays empty.
-        draw_weather_full(draw, wx, today=None, air_quality=None)
-        assert img.size == (800, 480)
+        assert _ink(img, DETAIL) == 0, "the strip drew something with no segments to draw"
+        # The rest of the plate is unaffected.
+        assert _ink(img, HERO) > 0
+        assert _ink(img, _forecast_band()) > 0

--- a/tests/test_weather_panel.py
+++ b/tests/test_weather_panel.py
@@ -1,17 +1,53 @@
-"""Tests for src/render/components/weather_panel.py"""
+"""Tests for src/render/components/weather_panel.py
+
+Assertion discipline (see #229)
+-------------------------------
+These tests used to assert ``img.getbbox() is not None``. On the mode-``"1"``
+canvas built below that is not a weak assertion, it is an *impossible* one:
+the canvas is filled with 1, ``getbbox()`` reports the bounds of non-zero
+pixels, so it returns the full canvas even when nothing was drawn at all.
+Every test in this file passed with ``draw_weather`` stubbed to a no-op.
+
+So ink here means **zero-valued** pixels, counted via ``_ink`` / ``_ink_bbox``
+(``flatten_pixels``, not the deprecated ``Image.getdata()``). Assertions are
+differential wherever possible — render with and without the feature and
+compare the band it owns — so they survive font and padding changes while
+still failing if the behaviour they name is deleted.
+
+Verification (the step that makes the rewrite worth anything): with
+``draw_weather`` stubbed to a no-op, 36 of the 47 tests here fail. The 11
+that still pass are the nine pure-helper tests for ``_fmt_time`` and
+``_aqi_accent``, which never touch a canvas, plus two *negative* tests
+(``test_wind_deg_without_wind_speed_no_crash`` and
+``test_aqi_column_suppressed_when_alerts_present``) which assert something is
+NOT drawn and so cannot distinguish a no-op by construction. Both were
+checked the other way instead, by deleting the suppression each names and
+confirming the test then fails. If you add a test here, do the same: delete
+the behaviour it is named for and watch it go red before you trust it.
+"""
 
 from datetime import date, datetime, timedelta, timezone
 
 from PIL import Image, ImageDraw
 
-from src.data.models import AirQualityData, DayForecast, WeatherAlert, WeatherData
+from src.data.models import (
+    AirQualityData,
+    DayForecast,
+    StalenessLevel,
+    WeatherAlert,
+    WeatherData,
+)
+from src.render import layout as L
 from src.render.components.weather_panel import (
     _aqi_accent,
     _draw_aqi_column,
     _fmt_time,
     draw_weather,
 )
-from src.render.theme import ThemeStyle
+from src.render.quantize import flatten_pixels
+from src.render.theme import ComponentRegion, ThemeStyle
+
+REGION = ComponentRegion(L.WEATHER_X, L.WEATHER_Y, L.WEATHER_W, L.WEATHER_H)
 
 
 def _make_draw(w: int = 800, h: int = 480):
@@ -32,87 +68,210 @@ def _make_weather(**kwargs) -> WeatherData:
     return WeatherData(**defaults)
 
 
+# ---------------------------------------------------------------------------
+# Ink measurement
+# ---------------------------------------------------------------------------
+
+
+def _ink(img: Image.Image, box: tuple[int, int, int, int] | None = None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_bbox(img: Image.Image, box: tuple[int, int, int, int] | None = None):
+    """Bounding box of ink pixels as (x0, y0, x1, y1), or None if there is none.
+
+    The honest replacement for ``Image.getbbox()`` on a white mode-``"1"``
+    plate, where every pixel is non-zero and getbbox can never return None.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box if box else (0, 0, img.width, img.height)
+    xs, ys = [], []
+    for y in range(y0, y1):
+        row = y * width
+        for x in range(x0, x1):
+            if px[row + x] == 0:
+                xs.append(x)
+                ys.append(y)
+    if not xs:
+        return None
+    return (min(xs), min(ys), max(xs) + 1, max(ys) + 1)
+
+
+def _bands(region: ComponentRegion = REGION, *, show_forecast: bool = True) -> dict:
+    """Row bands of the panel, mirroring weather_panel's proportional layout.
+
+    Derived from the same fractions the component uses, so a band follows the
+    component if its layout moves rather than silently pointing at blank plate.
+    """
+    h, w, x0, y0 = region.h, region.w, region.x, region.y
+    content = int(h * 0.233)
+    hilo = content + int(h * 0.117)
+    d3 = content + int(h * 0.217)
+    d4 = content + int(h * 0.317)
+    fh = int(h * 0.317) if show_forecast else 0
+    rx = x0 + int(w * 0.513)
+    return {
+        "label": (x0, y0, x0 + w, y0 + content - 2),
+        "hilo": (rx, y0 + hilo - 2, x0 + w, y0 + d3 - 2),
+        "row3": (rx, y0 + d3 - 2, x0 + w, y0 + d4 - 2),
+        "row4": (rx, y0 + d4 - 2, x0 + w, y0 + h - fh - 1),
+        "icon": (x0, y0 + content, x0 + 60, y0 + content + 45),
+        "forecast": (x0, y0 + h - fh, x0 + w, y0 + h),
+        "corner": (x0 + w - 24, y0 + h - 20, x0 + w, y0 + h),
+    }
+
+
+def _fcol(i: int, n_cols: int, region: ComponentRegion = REGION):
+    """Bounding box of forecast column *i* of *n_cols*."""
+    col_w = region.w // n_cols
+    fh = int(region.h * 0.317)
+    top = region.y + region.h - fh
+    return (region.x + i * col_w, top, region.x + (i + 1) * col_w, region.y + region.h)
+
+
+def _content_style(**kwargs) -> ThemeStyle:
+    """A style with borders off, for measuring content rather than chrome.
+
+    The panel's right separator and forecast rule span whole bands, so ink
+    counts inside a band include them. Turning borders off keeps a band's
+    count about what was drawn into it.
+    """
+    kwargs.setdefault("show_borders", False)
+    return ThemeStyle(**kwargs)
+
+
+_UNSET = object()
+
+
+def _render(**kwargs) -> Image.Image:
+    """Render a weather panel onto a fresh plate and return the image.
+
+    Any leftover kwargs build the WeatherData. Pass ``weather=`` to supply one
+    directly — including ``weather=None``, which is why this needs a sentinel
+    rather than a default argument.
+    """
+    today = kwargs.pop("today", None)
+    air_quality = kwargs.pop("air_quality", None)
+    staleness = kwargs.pop("staleness", None)
+    region = kwargs.pop("region", None)
+    style = kwargs.pop("style", None)
+    weather = kwargs.pop("weather", _UNSET)
+    if weather is _UNSET:
+        weather = _make_weather(**kwargs)
+    img, draw = _make_draw()
+    draw_weather(
+        draw,
+        weather,
+        today=today,
+        air_quality=air_quality,
+        region=region,
+        style=style,
+        staleness=staleness,
+    )
+    return img
+
+
 class TestDrawWeatherNone:
     def test_none_weather_renders_unavailable(self):
-        img, draw = _make_draw()
-        draw_weather(draw, None)
-        assert img.getbbox() is not None
+        """The 'Unavailable' message is drawn, and none of the data furniture is."""
+        img = _render(weather=None, style=_content_style())
+        bands = _bands()
+        centre = (
+            REGION.x,
+            REGION.y + REGION.h // 2 - 14,
+            REGION.x + REGION.w,
+            REGION.y + REGION.h // 2 + 14,
+        )
+
+        assert _ink(img, centre) > 0, "no message drawn in the centre of the panel"
+        # The early return happens before the icon and forecast strip.
+        assert _ink(img, bands["icon"]) == 0, "weather icon drawn for None weather"
+        assert _ink(img, bands["forecast"]) == 0, "forecast strip drawn for None weather"
+        assert _ink(img) < _ink(_render(style=_content_style())), (
+            "None plate should carry less ink than a real one"
+        )
 
     def test_none_weather_with_today_renders_moon(self):
-        img, draw = _make_draw()
-        draw_weather(draw, None, today=date(2024, 3, 15))
-        assert img.getbbox() is not None
+        """today= adds the moon glyph to the label row even when weather is None."""
+        without = _render(weather=None)
+        with_moon = _render(weather=None, today=date(2024, 3, 15))
+        label = _bands()["label"]
+
+        assert _ink(with_moon, label) > _ink(without, label), "moon glyph not drawn"
+        # It belongs in the right-hand end of the label row, beside the label.
+        bbox = _ink_bbox(with_moon, label)
+        assert bbox is not None and bbox[2] > REGION.x + REGION.w * 0.7
 
 
 class TestDrawWeatherDetails:
+    """Row 3 carries feels-like / wind, falling back to humidity when both are unset."""
+
     def test_feels_like_renders(self):
-        weather = _make_weather(feels_like=48.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        row3 = _bands()["row3"]
+        assert _ink(_render(feels_like=48.0), row3) != _ink(_render(), row3)
 
     def test_wind_speed_renders(self):
-        weather = _make_weather(wind_speed=15.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        row3 = _bands()["row3"]
+        assert _ink(_render(wind_speed=15.0), row3) != _ink(_render(), row3)
 
     def test_both_feels_like_and_wind_renders(self):
-        weather = _make_weather(feels_like=48.0, wind_speed=12.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """Both set joins them, so row 3 carries more ink than either alone."""
+        row3 = _bands()["row3"]
+        both = _ink(_render(feels_like=48.0, wind_speed=12.0), row3)
+        assert both > _ink(_render(feels_like=48.0), row3)
+        assert both > _ink(_render(wind_speed=12.0), row3)
 
     def test_neither_feels_like_nor_wind_falls_back_to_humidity(self):
-        """When neither feels_like nor wind_speed is set, humidity is shown."""
-        weather = _make_weather(feels_like=None, wind_speed=None, humidity=72)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """The fallback shows the humidity *value* — changing it changes the row."""
+        row3 = _bands()["row3"]
+        humid_72 = _render(feels_like=None, wind_speed=None, humidity=72)
+        humid_11 = _render(feels_like=None, wind_speed=None, humidity=11)
+
+        assert _ink(humid_72, row3) > 0
+        assert _ink(humid_72, row3) != _ink(humid_11, row3), (
+            "row 3 did not change with humidity — the fallback is not being drawn"
+        )
+
+    def _sun(self, hour: int, minute: int) -> datetime:
+        return datetime(2024, 3, 15, hour, minute, tzinfo=timezone.utc)
 
     def test_sunrise_and_sunset_render(self):
-        tz = timezone.utc
-        today = date(2024, 3, 15)
-        weather = _make_weather(
-            sunrise=datetime.combine(today, datetime.min.time().replace(hour=6, minute=24)).replace(
-                tzinfo=tz
-            ),
-            sunset=datetime.combine(today, datetime.min.time().replace(hour=19, minute=51)).replace(
-                tzinfo=tz
-            ),
-        )
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=today)
-        assert img.getbbox() is not None
+        row4 = _bands()["row4"]
+        both = _render(sunrise=self._sun(6, 24), sunset=self._sun(19, 51), today=date(2024, 3, 15))
+        neither = _render(today=date(2024, 3, 15))
+        assert _ink(both, row4) > _ink(neither, row4)
 
     def test_only_sunrise_renders(self):
-        tz = timezone.utc
-        today = date(2024, 3, 15)
-        weather = _make_weather(
-            sunrise=datetime.combine(today, datetime.min.time().replace(hour=6, minute=24)).replace(
-                tzinfo=tz
-            ),
-            sunset=None,
-        )
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=today)
-        assert img.getbbox() is not None
+        row4 = _bands()["row4"]
+        one = _render(sunrise=self._sun(6, 24), sunset=None, today=date(2024, 3, 15))
+        both = _render(sunrise=self._sun(6, 24), sunset=self._sun(19, 51), today=date(2024, 3, 15))
+        neither = _render(today=date(2024, 3, 15))
+        assert _ink(neither, row4) < _ink(one, row4) < _ink(both, row4)
 
     def test_only_sunset_renders(self):
-        tz = timezone.utc
-        today = date(2024, 3, 15)
-        weather = _make_weather(
-            sunrise=None,
-            sunset=datetime.combine(today, datetime.min.time().replace(hour=19, minute=51)).replace(
-                tzinfo=tz
-            ),
-        )
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=today)
-        assert img.getbbox() is not None
+        row4 = _bands()["row4"]
+        one = _render(sunrise=None, sunset=self._sun(19, 51), today=date(2024, 3, 15))
+        both = _render(sunrise=self._sun(6, 24), sunset=self._sun(19, 51), today=date(2024, 3, 15))
+        neither = _render(today=date(2024, 3, 15))
+        assert _ink(neither, row4) < _ink(one, row4) < _ink(both, row4)
 
 
 class TestDrawWeatherForecastStrip:
+    """The strip splits into columns; alert columns are inverted (filled) bars."""
+
+    # An alert column is a filled_rect, so it inks the great majority of its
+    # box; a forecast column is icon + two short text rows. Measured on the
+    # default region the two sit at ~92% and ~10%, so the midpoint separates
+    # them with a very wide margin.
+    FILLED = 0.5
+
     def _forecast(self, n: int) -> list[DayForecast]:
         return [
             DayForecast(
@@ -125,259 +284,265 @@ class TestDrawWeatherForecastStrip:
             for i in range(n)
         ]
 
+    def _fill_fraction(self, img, i: int, n_cols: int) -> float:
+        box = _fcol(i, n_cols)
+        area = (box[2] - box[0]) * (box[3] - box[1])
+        return _ink(img, box) / area
+
     def test_no_forecast_no_crash(self):
-        weather = _make_weather(forecast=[])
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """No forecast and no alerts means no columns — the strip stays empty.
+
+        Measured borderless: the strip's top rule and the panel's right
+        separator are chrome and are drawn either way.
+        """
+        img = _render(forecast=[], style=_content_style())
+        assert _ink(img, _bands()["forecast"]) == 0
+        populated = _render(forecast=self._forecast(3), style=_content_style())
+        assert _ink(populated, _bands()["forecast"]) > 0
 
     def test_three_forecast_columns_no_alerts(self):
-        weather = _make_weather(forecast=self._forecast(3))
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """Three days fill three columns, none of them inverted."""
+        img = _render(forecast=self._forecast(3))
+        for i in range(3):
+            assert _ink(img, _fcol(i, 3)) > 0, f"column {i} is empty"
+            assert self._fill_fraction(img, i, 3) < self.FILLED, f"column {i} is inverted"
 
     def test_one_alert_plus_two_forecast_columns(self):
-        weather = _make_weather(
-            forecast=self._forecast(2),
-            alerts=[WeatherAlert(event="Flood Watch")],
-        )
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """One alert takes column 0 as a filled bar; the two forecasts follow."""
+        img = _render(forecast=self._forecast(2), alerts=[WeatherAlert(event="Flood Watch")])
+        assert self._fill_fraction(img, 0, 3) > self.FILLED, "alert column is not inverted"
+        for i in (1, 2):
+            assert 0 < _ink(img, _fcol(i, 3))
+            assert self._fill_fraction(img, i, 3) < self.FILLED
 
     def test_two_alerts_plus_one_forecast_column(self):
-        weather = _make_weather(
+        """Two alerts take columns 0 and 1; one forecast column remains."""
+        img = _render(
             forecast=self._forecast(1),
-            alerts=[
-                WeatherAlert(event="Flood Watch"),
-                WeatherAlert(event="Wind Advisory"),
-            ],
+            alerts=[WeatherAlert(event="Flood Watch"), WeatherAlert(event="Wind Advisory")],
         )
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        assert self._fill_fraction(img, 0, 3) > self.FILLED
+        assert self._fill_fraction(img, 1, 3) > self.FILLED
+        assert self._fill_fraction(img, 2, 3) < self.FILLED
 
     def test_two_alerts_no_forecast(self):
-        weather = _make_weather(
+        """With no forecast the two alerts split the strip in half."""
+        img = _render(
             forecast=[],
             alerts=[
                 WeatherAlert(event="Dense Fog Advisory"),
                 WeatherAlert(event="Winter Storm Warning"),
             ],
         )
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        assert self._fill_fraction(img, 0, 2) > self.FILLED
+        assert self._fill_fraction(img, 1, 2) > self.FILLED
+
+    def _one_day(self, precip: float, icon: str = "10d") -> list[DayForecast]:
+        return [
+            DayForecast(
+                date=date(2024, 3, 16),
+                high=50.0,
+                low=38.0,
+                icon=icon,
+                description="rain",
+                precip_chance=precip,
+            )
+        ]
 
     def test_forecast_with_precip_chance(self):
-        forecast = [
-            DayForecast(
-                date=date(2024, 3, 16),
-                high=50.0,
-                low=38.0,
-                icon="10d",
-                description="rain",
-                precip_chance=0.75,
-            )
-        ]
-        weather = _make_weather(forecast=forecast)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """A precip chance at or above the 5% threshold adds a third text row."""
+        box = _fcol(0, 1)
+        third_row = (box[0], box[1] + 23, box[2], box[3])
+        assert _ink(_render(forecast=self._one_day(0.75)), third_row) > 0
 
     def test_forecast_below_precip_threshold_no_third_row(self):
-        """Precipitation below 5% should not render the precip percentage row."""
-        forecast = [
-            DayForecast(
-                date=date(2024, 3, 16),
-                high=50.0,
-                low=38.0,
-                icon="01d",
-                description="clear",
-                precip_chance=0.02,
-            )
-        ]
-        weather = _make_weather(forecast=forecast)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """Below 5% the percentage row is suppressed — the band loses its ink."""
+        box = _fcol(0, 1)
+        third_row = (box[0], box[1] + 23, box[2], box[3])
+        below = _ink(_render(forecast=self._one_day(0.02, icon="01d")), third_row)
+        above = _ink(_render(forecast=self._one_day(0.75, icon="01d")), third_row)
+        assert below < above, "the 5% precip threshold is not being applied"
 
     def test_with_moon_phase(self):
-        weather = _make_weather(forecast=self._forecast(2))
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=date(2024, 3, 15))
-        assert img.getbbox() is not None
+        """today= draws the moon glyph in the label row."""
+        label = _bands()["label"]
+        with_moon = _render(forecast=self._forecast(2), today=date(2024, 3, 15))
+        without = _render(forecast=self._forecast(2))
+        assert _ink(with_moon, label) > _ink(without, label)
 
 
 class TestEnhancedWeatherRendering:
-    """Tests for wind compass direction and UV index rendering paths."""
+    """Wind compass and UV index."""
 
     def test_wind_compass_rendered_when_wind_deg_present(self):
-        """wind_deg should trigger compass suffix in wind string — no crash."""
-        weather = _make_weather(wind_speed=12.0, wind_deg=270.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """wind_deg appends a compass point to the wind string."""
+        row3 = _bands()["row3"]
+        with_deg = _ink(_render(wind_speed=12.0, wind_deg=270.0), row3)
+        without = _ink(_render(wind_speed=12.0), row3)
+        assert with_deg > without, "compass suffix not drawn"
 
     def test_wind_compass_all_cardinal_directions(self):
-        """All 8 compass sectors render without error."""
-        for deg in [0, 45, 90, 135, 180, 225, 270, 315]:
-            weather = _make_weather(wind_speed=10.0, wind_deg=float(deg))
-            _, draw = _make_draw()
-            draw_weather(draw, weather)  # must not raise
+        """Each sector draws its own label, so the eight are not all identical."""
+        row3 = _bands()["row3"]
+        counts = {
+            deg: _ink(_render(wind_speed=10.0, wind_deg=float(deg)), row3)
+            for deg in (0, 45, 90, 135, 180, 225, 270, 315)
+        }
+        for deg, count in counts.items():
+            assert count > 0, f"nothing drawn for {deg}°"
+        assert len(set(counts.values())) > 1, (
+            "every compass sector produced identical ink — the label is not varying"
+        )
 
     def test_wind_deg_without_wind_speed_no_crash(self):
-        """wind_deg alone (no wind_speed) should not crash rendering."""
-        weather = _make_weather(wind_speed=None, wind_deg=90.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """wind_deg alone draws no compass: the suffix lives inside the wind branch."""
+        row3 = _bands()["row3"]
+        deg_only = _render(wind_speed=None, wind_deg=90.0)
+        neither = _render(wind_speed=None, wind_deg=None)
+        assert _ink(deg_only, row3) == _ink(neither, row3), (
+            "a compass appeared without a wind speed to attach it to"
+        )
 
     def test_uv_index_renders_in_hilo_row(self):
-        """uv_index is appended to the hi/lo row when it fits."""
-        weather = _make_weather(uv_index=5.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        hilo = _bands()["hilo"]
+        assert _ink(_render(uv_index=5.0), hilo) > _ink(_render(), hilo)
 
     def test_uv_index_zero_renders(self):
-        weather = _make_weather(uv_index=0.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """UV 0 is a real reading, not a missing one — it still renders."""
+        hilo = _bands()["hilo"]
+        assert _ink(_render(uv_index=0.0), hilo) > _ink(_render(uv_index=None), hilo)
 
     def test_uv_index_high_value_renders(self):
-        weather = _make_weather(uv_index=11.0)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        hilo = _bands()["hilo"]
+        assert _ink(_render(uv_index=11.0), hilo) > _ink(_render(), hilo)
 
     def test_uv_index_none_no_crash(self):
-        """uv_index=None should not crash and should render normal hi/lo."""
-        weather = _make_weather(uv_index=None)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """uv_index=None renders the plain hi/lo row and nothing more."""
+        hilo = _bands()["hilo"]
+        img = _render(uv_index=None)
+        assert _ink(img, hilo) > 0
+        assert _ink(img, hilo) < _ink(_render(uv_index=5.0), hilo)
 
     def test_all_enhanced_fields_together(self):
-        """All v3 enhanced fields (wind_deg, uv_index) together."""
-        weather = _make_weather(
-            wind_speed=15.0,
-            wind_deg=135.0,
-            uv_index=8.0,
-            feels_like=52.0,
-        )
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """Every optional field set at once still lands in its own row."""
+        bands = _bands()
+        img = _render(wind_speed=15.0, wind_deg=135.0, uv_index=8.0, feels_like=52.0)
+        plain = _render()
+        assert _ink(img, bands["hilo"]) > _ink(plain, bands["hilo"]), "UV missing"
+        assert _ink(img, bands["row3"]) > _ink(plain, bands["row3"]), "feels/wind missing"
 
 
 class TestLocationName:
     def test_location_name_in_label_renders(self):
-        """location_name should be appended to the WEATHER label without crashing."""
-        weather = _make_weather(location_name="San Francisco")
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        """A short name is appended to the WEATHER label."""
+        label = _bands()["label"]
+        assert _ink(_render(location_name="San Francisco"), label) > _ink(_render(), label)
 
-    def test_location_name_none_no_crash(self):
-        """location_name=None (default) should render identically to before."""
-        weather = _make_weather(location_name=None)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+    def test_location_name_none_renders_the_bare_label(self):
+        """With no name the row still carries the bare label, shorter than with one.
 
-    def test_very_long_location_name_truncated_gracefully(self):
-        """A very long location name that doesn't fit should be silently omitted."""
-        weather = _make_weather(location_name="A" * 100)
-        img, draw = _make_draw()
-        draw_weather(draw, weather)
-        assert img.getbbox() is not None
+        (The old test compared `location_name=None` against the default, which
+        is the same input — it asserted X == X.)
+        """
+        label = _bands()["label"]
+        bare = _render(location_name=None, style=_content_style())
+        named = _render(location_name="San Francisco", style=_content_style())
+        assert _ink(bare, label) > 0, "no label drawn at all"
+        assert _ink(bare, label) < _ink(named, label)
+
+    def test_very_long_location_name_is_dropped_not_overflowed(self):
+        """A name that cannot fit is omitted entirely rather than truncated or spilled.
+
+        The component only appends the city when the combined string measures
+        within the label width, so the plate must be identical to the bare one.
+        """
+        label = _bands()["label"]
+        long_name = _render(location_name="A" * 100, style=_content_style())
+        bare = _render(style=_content_style())
+        assert _ink(long_name, label) == _ink(bare, label), (
+            "an oversized location name reached the plate"
+        )
+        # And nothing escaped into the strip reserved for the moon glyph.
+        bbox = _ink_bbox(long_name, label)
+        assert bbox is not None and bbox[2] <= REGION.x + REGION.w - L.PAD
 
 
 class TestStalenessGlyph:
-    def test_stale_weather_renders_glyph(self):
-        """STALE staleness should draw the '!' badge without crashing."""
-        from src.data.models import StalenessLevel
-        from src.render.theme import ComponentRegion
+    """The '!' badge is painted into the region's bottom-right corner."""
 
-        weather = _make_weather()
-        img, draw = _make_draw()
-        draw_weather(
-            draw,
-            weather,
-            region=ComponentRegion(0, 0, 300, 120),
-            staleness=StalenessLevel.STALE,
+    def _corner(self, region: ComponentRegion):
+        return (
+            region.x + region.w - 24,
+            region.y + region.h - 20,
+            region.x + region.w,
+            region.y + region.h,
         )
-        assert img.getbbox() is not None
+
+    def test_stale_weather_renders_glyph(self):
+        """Regression: this case (no forecast, no alerts) used to drop the badge.
+
+        With the strip enabled but nothing to put in it, draw_weather returned
+        at `n_cols == 0` before reaching the staleness call at the end of the
+        function — so the badge was silently skipped in precisely the degraded
+        state it exists to announce. The old vacuous assertion here could not
+        see it. Found while rewriting this file for #229.
+        """
+        region = ComponentRegion(0, 0, 300, 120)
+        corner = self._corner(region)
+        stale = _render(region=region, staleness=StalenessLevel.STALE)
+        none = _render(region=region, staleness=None)
+        assert _ink(stale, corner) > _ink(none, corner), "no staleness badge drawn"
 
     def test_expired_weather_renders_glyph(self):
-        """EXPIRED staleness should also draw the badge."""
-        from src.data.models import StalenessLevel
-        from src.render.theme import ComponentRegion
+        region = ComponentRegion(0, 0, 300, 120)
+        corner = self._corner(region)
+        expired = _render(region=region, staleness=StalenessLevel.EXPIRED)
+        none = _render(region=region, staleness=None)
+        assert _ink(expired, corner) > _ink(none, corner)
 
-        weather = _make_weather()
-        img, draw = _make_draw()
-        draw_weather(
-            draw,
-            weather,
-            region=ComponentRegion(0, 0, 300, 120),
-            staleness=StalenessLevel.EXPIRED,
-        )
-        assert img.getbbox() is not None
+    def test_fresh_weather_draws_no_glyph(self):
+        """FRESH is not a warning, so its corner stays clear of the badge STALE draws.
 
-    def test_fresh_weather_no_glyph_no_crash(self):
-        """FRESH staleness should not draw a badge and must not crash."""
-        from src.data.models import StalenessLevel
-
-        weather = _make_weather()
-        img, draw = _make_draw()
-        draw_weather(draw, weather, staleness=StalenessLevel.FRESH)
-        assert img.getbbox() is not None
+        Compared against STALE, not against staleness=None: both of those are
+        badge-free, so an always-draw regression would keep them equal and the
+        test would not notice.
+        """
+        region = ComponentRegion(0, 0, 300, 120)
+        corner = self._corner(region)
+        fresh = _render(region=region, staleness=StalenessLevel.FRESH)
+        stale = _render(region=region, staleness=StalenessLevel.STALE)
+        assert _ink(fresh, corner) < _ink(stale, corner), "FRESH drew a staleness badge"
 
     def test_stale_weather_without_forecast_strip_still_renders_glyph(self):
-        """show_forecast_strip=False returns early but still draws the stale badge."""
-        from src.data.models import StalenessLevel
-        from src.render.theme import ComponentRegion, ThemeStyle
-
-        weather = _make_weather()
-        img, draw = _make_draw()
-        # Wide enough to hit the no-forecast branch — four detail rows fill
-        # the full panel height, then the early-return path emits the glyph.
+        """show_forecast_strip=False returns early — the badge must still be emitted."""
+        region = ComponentRegion(0, 0, 300, 240)
         style = ThemeStyle(show_forecast_strip=False)
-        draw_weather(
-            draw,
-            weather,
-            region=ComponentRegion(0, 0, 300, 240),
-            style=style,
-            staleness=StalenessLevel.STALE,
+        corner = self._corner(region)
+        stale = _render(region=region, style=style, staleness=StalenessLevel.STALE)
+        none = _render(region=region, style=style, staleness=None)
+        assert _ink(stale, corner) > _ink(none, corner), (
+            "the early-return branch skipped the staleness badge"
         )
-        assert img.getbbox() is not None
 
     def test_stale_weather_with_populated_forecast_renders_glyph(self):
-        """Forecast strip drawn AND staleness EXPIRED → glyph painted at the end."""
-        from src.data.models import StalenessLevel
-        from src.render.theme import ComponentRegion
-
-        # Explicit three-day forecast so the forecast strip is fully populated
-        # (n_cols=3) and execution reaches the tail-end staleness glyph call.
+        """Forecast strip drawn AND EXPIRED → the badge is painted at the tail end."""
+        region = ComponentRegion(0, 0, 400, 160)
+        corner = self._corner(region)
         weather = _make_weather(forecast=_make_forecast(3))
-        img, draw = _make_draw()
-        draw_weather(
-            draw,
-            weather,
-            region=ComponentRegion(0, 0, 400, 160),
-            staleness=StalenessLevel.EXPIRED,
-        )
-        assert img.getbbox() is not None
+        expired = _render(weather=weather, region=region, staleness=StalenessLevel.EXPIRED)
+        none = _render(weather=weather, region=region, staleness=None)
+        assert _ink(expired, corner) > _ink(none, corner)
 
-    def test_none_staleness_no_crash(self):
-        """staleness=None (default) must not crash."""
-        weather = _make_weather()
-        img, draw = _make_draw()
-        draw_weather(draw, weather, staleness=None)
-        assert img.getbbox() is not None
+    def test_none_staleness_draws_no_glyph(self):
+        """The default draws no badge either — again measured against STALE."""
+        region = ComponentRegion(0, 0, 300, 120)
+        corner = self._corner(region)
+        default = _render(region=region, staleness=None)
+        stale = _render(region=region, staleness=StalenessLevel.STALE)
+        assert _ink(default, corner) < _ink(stale, corner), "staleness=None drew a badge"
+        assert _ink(default, corner) == _ink(
+            _render(region=region, staleness=StalenessLevel.FRESH), corner
+        )
 
 
 class TestFmtTime:
@@ -422,53 +587,72 @@ class TestAQIForecastColumn:
     """Exercises the air-quality column that replaces a forecast slot when AQ data exists."""
 
     def test_aqi_column_renders_when_air_quality_present(self):
+        """The last column becomes the AQI card, and it renders the AQI *value*."""
         weather = _make_weather(forecast=_make_forecast(3))
-        aqi = _make_aqi(aqi=42, category="Good")
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=date(2026, 4, 20), air_quality=aqi)
-        # Something was rendered — the image is no longer blank white.
-        assert img.getbbox() is not None
+        last = _fcol(2, 3)
+
+        good = _render(weather=weather, today=date(2026, 4, 20), air_quality=_make_aqi(42, "Good"))
+        unhealthy = _render(
+            weather=weather, today=date(2026, 4, 20), air_quality=_make_aqi(199, "Unhealthy")
+        )
+        no_aq = _render(weather=weather, today=date(2026, 4, 20))
+
+        assert _ink(good, last) > 0
+        assert _ink(good, last) != _ink(no_aq, last), "AQI column looks like a forecast column"
+        assert _ink(good, last) != _ink(unhealthy, last), (
+            "the AQI reading is not being drawn — two different values rendered identically"
+        )
 
     def test_aqi_column_truncates_long_category_label(self):
-        """Long category labels are truncated with an ellipsis so they fit the column."""
-        weather = _make_weather(forecast=_make_forecast(3))
-        aqi = _make_aqi(
-            aqi=175,
-            category="Unhealthy for Sensitive Groups with Extra Long Descriptor",
-        )
+        """A long category is truncated so the label stays inside its column."""
         img, draw = _make_draw()
-        # Use a narrow region so truncation kicks in.
-        from src.render.theme import ComponentRegion
-
-        region = ComponentRegion(0, 0, 160, 200)
-        draw_weather(
+        col_x, col_w = 100, 100
+        _draw_aqi_column(
             draw,
-            weather,
-            today=date(2026, 4, 20),
-            air_quality=aqi,
-            region=region,
+            _make_aqi(
+                aqi=175, category="Unhealthy for Sensitive Groups with Extra Long Descriptor"
+            ),
+            cx=col_x,
+            top=0,
+            col_w=col_w,
+            col_h=38,
+            style=ThemeStyle(),
         )
-        assert img.getbbox() is not None
+        bbox = _ink_bbox(img, (0, 0, img.width, 38))
+        assert bbox is not None, "nothing drawn"
+        assert bbox[0] >= col_x, "AQI label spilled off the left of its column"
+        assert bbox[2] <= col_x + col_w, "AQI label spilled off the right of its column"
 
     def test_aqi_column_suppressed_when_alerts_present(self):
-        """When there is 1 alert, there are 2 forecast columns + alert column — no AQI column."""
+        """An alert outranks air quality — the plate must equal the no-AQ render."""
         weather = _make_weather(
             forecast=_make_forecast(3),
             alerts=[WeatherAlert(event="Heat Advisory")],
         )
-        aqi = _make_aqi(aqi=42, category="Good")
-        img, draw = _make_draw()
-        draw_weather(draw, weather, today=date(2026, 4, 20), air_quality=aqi)
-        # No crash; rendering path ran without AQI-specific column.
-        assert img.getbbox() is not None
+        with_aq = _render(
+            weather=weather, today=date(2026, 4, 20), air_quality=_make_aqi(42, "Good")
+        )
+        without_aq = _render(weather=weather, today=date(2026, 4, 20))
+        assert with_aq.tobytes() == without_aq.tobytes(), (
+            "an AQI column was drawn despite an active weather alert"
+        )
 
     def test_draw_aqi_column_direct(self):
-        """Directly exercise _draw_aqi_column in isolation."""
+        """Directly exercise _draw_aqi_column: it fills, and stays inside, its column."""
         img, draw = _make_draw(w=200, h=100)
-        style = ThemeStyle()
-        aqi = _make_aqi(aqi=87, category="Moderate")
-        _draw_aqi_column(draw, aqi, cx=0, top=0, col_w=80, col_h=80, style=style)
-        assert img.getbbox() is not None
+        _draw_aqi_column(
+            draw,
+            _make_aqi(aqi=87, category="Moderate"),
+            cx=0,
+            top=0,
+            col_w=80,
+            col_h=80,
+            style=ThemeStyle(),
+        )
+        bbox = _ink_bbox(img)
+        assert bbox is not None, "nothing drawn"
+        assert bbox[2] <= 80, "content escaped the column width"
+        assert bbox[3] <= 80, "content escaped the column height"
 
 
 class TestAQIAccent:

--- a/tests/test_weather_theme.py
+++ b/tests/test_weather_theme.py
@@ -1,4 +1,16 @@
-"""Tests for the full-screen weather theme and weather_full component."""
+"""Tests for the full-screen weather theme and weather_full component.
+
+Assertion discipline (see #229)
+-------------------------------
+The rendering tests asserted only isinstance/size, and every component test
+in this file called draw_weather_full and asserted nothing at all. All 25
+passed with the component stubbed to a no-op.
+
+The zone geometry mirrors draw_weather_full's own proportions and matches
+tests/test_weather_full_component.py, which covers the component directly;
+this file's focus is the theme wiring and the paths that file does not
+reach. Ink means zero-valued pixels.
+"""
 
 from datetime import date, datetime, timedelta
 
@@ -13,6 +25,7 @@ from src.data.models import (
 )
 from src.render.canvas import render_dashboard
 from src.render.components.weather_full import draw_weather_full
+from src.render.quantize import flatten_pixels
 from src.render.theme import (
     AVAILABLE_THEMES,
     ComponentRegion,
@@ -127,35 +140,105 @@ class TestWeatherThemeRegistration:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Ink measurement — zones mirrored from draw_weather_full's proportions
+# ---------------------------------------------------------------------------
+
+CANVAS_W, CANVAS_H = 800, 480
+_HERO_H = int(CANVAS_H * 0.44)
+_CARDS_H = int(CANVAS_H * 0.155)
+_DETAIL_H = int(CANVAS_H * 0.06)
+_ALERT_H = int(CANVAS_H * 0.055)
+
+HERO = (0, 0, CANVAS_W, _HERO_H)
+CARDS = (0, _HERO_H, CANVAS_W, _HERO_H + _CARDS_H)
+# The rule above the forecast lands on the detail zone's last row and is drawn
+# either way, so it is excluded here.
+DETAIL = (0, _HERO_H + _CARDS_H, CANVAS_W, _HERO_H + _CARDS_H + _DETAIL_H - 1)
+ALERT = (0, _HERO_H + _CARDS_H + _DETAIL_H, CANVAS_W, _HERO_H + _CARDS_H + _DETAIL_H + _ALERT_H)
+
+
+def _forecast_band(has_alerts: bool = False) -> tuple[int, int, int, int]:
+    top = _HERO_H + _CARDS_H + _DETAIL_H + (_ALERT_H if has_alerts else 0)
+    return (0, top, CANVAS_W, CANVAS_H)
+
+
+def _ink(img, box=None) -> int:
+    """Count ink (value-0) pixels, optionally only inside *box*."""
+    px = flatten_pixels(img)
+    width = img.width
+    if box is None:
+        return sum(1 for v in px if v == 0)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] == 0)
+
+
+def _ink_clusters(img, box, min_gap: int = 12) -> int:
+    """Count horizontally separated groups of ink — one per forecast column."""
+    px = flatten_pixels(img)
+    width = img.width
+    x0, y0, x1, y1 = box
+    cols = [x for x in range(x0, x1) if any(px[y * width + x] == 0 for y in range(y0, y1))]
+    if not cols:
+        return 0
+    return 1 + sum(1 for p, q in zip(cols, cols[1:]) if q - p > min_gap)
+
+
+def _card_count(img) -> int:
+    """Metric cards, counted from their rounded-rect outlines (two edges each)."""
+    px = flatten_pixels(img)
+    width = img.width
+    y = _HERO_H + 10
+    runs = 0
+    prev = False
+    for x in range(CANVAS_W):
+        cur = px[y * width + x] == 0
+        if cur and not prev:
+            runs += 1
+        prev = cur
+    return runs // 2
+
+
+def _component(weather, today=date(2024, 3, 15), **kwargs):
+    """Render the component alone onto a fresh plate."""
+    img = Image.new("1", (CANVAS_W, CANVAS_H), 1)
+    draw_weather_full(draw_surface := ImageDraw.Draw(img), weather, today=today, **kwargs)
+    del draw_surface
+    return img
+
+
 class TestWeatherThemeRendering:
+    def _render(self, weather):
+        return render_dashboard(
+            _make_data(weather=weather), DisplayConfig(), theme=load_theme("weather")
+        )
+
     def test_renders_valid_image_with_full_data(self):
-        theme = load_theme("weather")
-        data = _make_data(weather=_make_weather())
-        config = DisplayConfig()
-        img = render_dashboard(data, config, theme=theme)
-        assert isinstance(img, Image.Image)
-        assert img.size[0] > 0
-        assert img.size[1] > 0
+        """The theme wires the component through: every zone gets content."""
+        img = self._render(_make_weather())
+        assert img.size == (CANVAS_W, CANVAS_H)
+        assert _ink(img, HERO) > 0, "hero zone empty"
+        assert _ink(img, CARDS) > 0, "metric cards empty"
+        assert _ink(img, _forecast_band()) > 0, "forecast grid empty"
 
     def test_renders_with_none_weather(self):
-        theme = load_theme("weather")
-        data = _make_data(weather=None)
-        config = DisplayConfig()
-        img = render_dashboard(data, config, theme=theme)
-        assert isinstance(img, Image.Image)
+        """No weather draws the fallback and none of the furniture."""
+        img = self._render(None)
+        assert _ink(img) > 0, "no fallback message"
+        assert _card_count(img) == 0, "metric cards drawn without weather"
+        assert _ink(img, _forecast_band()) == 0, "forecast grid drawn without weather"
 
     def test_renders_with_alerts(self):
-        weather = _make_weather(
-            alerts=[WeatherAlert(event="Flood Watch"), WeatherAlert(event="Wind Advisory")],
-        )
-        theme = load_theme("weather")
-        data = _make_data(weather=weather)
-        config = DisplayConfig()
-        img = render_dashboard(data, config, theme=theme)
-        assert isinstance(img, Image.Image)
+        """Alerts invert their own banner band and push the forecast down."""
+        alerts = [WeatherAlert(event="Flood Watch"), WeatherAlert(event="Wind Advisory")]
+        img = self._render(_make_weather(alerts=alerts))
+        area = CANVAS_W * _ALERT_H
+        assert _ink(img, ALERT) > area * 0.5, "alert banner is not inverted"
+        assert _ink(img, _forecast_band(has_alerts=True)) > 0, "forecast lost to the banner"
 
     def test_renders_with_minimal_data(self):
-        weather = WeatherData(
+        """Only the required fields still fills all four cards, with less in them."""
+        minimal = WeatherData(
             current_temp=55.0,
             current_icon="03d",
             current_description="overcast",
@@ -163,11 +246,9 @@ class TestWeatherThemeRendering:
             low=45.0,
             humidity=80,
         )
-        theme = load_theme("weather")
-        data = _make_data(weather=weather)
-        config = DisplayConfig()
-        img = render_dashboard(data, config, theme=theme)
-        assert isinstance(img, Image.Image)
+        img = self._render(minimal)
+        assert _card_count(img) == 4
+        assert _ink(img, CARDS) < _ink(self._render(_make_weather()), CARDS)
 
 
 # ---------------------------------------------------------------------------
@@ -177,88 +258,114 @@ class TestWeatherThemeRendering:
 
 class TestDrawWeatherFull:
     def test_none_weather_does_not_crash(self):
-        draw = _draw_surface()
-        draw_weather_full(draw, None, today=date(2024, 3, 15))
+        img = _component(None)
+        assert _ink(img) > 0
+        assert _card_count(img) == 0
 
     def test_basic_weather(self):
-        draw = _draw_surface()
-        weather = _make_weather()
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        img = _component(_make_weather())
+        assert _ink(img, HERO) > 0
+        assert _card_count(img) == 4
 
     def test_all_optional_fields(self):
-        draw = _draw_surface()
-        weather = _make_weather()
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """Every optional field set draws more than none of them."""
+        full = _component(_make_weather())
+        bare = _component(
+            WeatherData(
+                current_temp=72.0,
+                current_icon="01d",
+                current_description="clear sky",
+                high=78.0,
+                low=60.0,
+                humidity=45,
+            )
+        )
+        assert _ink(full, CARDS) > _ink(bare, CARDS)
 
     def test_no_optional_fields(self):
-        draw = _draw_surface()
-        weather = WeatherData(
-            current_temp=55.0,
-            current_icon="01d",
-            current_description="clear",
-            high=60.0,
-            low=45.0,
-            humidity=50,
+        """Missing optionals fall back to placeholders, not to blank cards."""
+        img = _component(
+            WeatherData(
+                current_temp=55.0,
+                current_icon="01d",
+                current_description="clear",
+                high=60.0,
+                low=45.0,
+                humidity=50,
+            )
         )
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        assert _card_count(img) == 4
+        assert _ink(img, CARDS) > 0
 
     def test_with_alerts(self):
-        draw = _draw_surface()
-        weather = _make_weather(
-            alerts=[WeatherAlert(event="Tornado Warning")],
-        )
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        img = _component(_make_weather(alerts=[WeatherAlert(event="Tornado Warning")]))
+        assert _ink(img, ALERT) > CANVAS_W * _ALERT_H * 0.5
 
     def test_empty_forecast(self):
-        draw = _draw_surface()
-        weather = _make_weather(forecast=[])
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """No days draws the single centred fallback, not five columns."""
+        img = _component(_make_weather(forecast=[]))
+        band = _forecast_band()
+        assert _ink(img, band) > 0, "no fallback message"
+        assert _ink_clusters(img, band) == 1, "columns drawn for an empty forecast"
 
     def test_many_forecast_days_capped_at_five(self):
-        draw = _draw_surface()
-        forecast = [
-            DayForecast(
-                date=date(2024, 3, 16) + timedelta(days=i),
-                high=60.0 + i,
-                low=40.0 + i,
-                icon="02d",
-                description="cloudy",
+        """Ten days draw five columns — the same plate as exactly five."""
+
+        def with_days(n):
+            return _component(
+                _make_weather(
+                    forecast=[
+                        DayForecast(
+                            date=date(2024, 3, 16) + timedelta(days=i),
+                            high=60.0 + i,
+                            low=40.0 + i,
+                            icon="02d",
+                            description="cloudy",
+                        )
+                        for i in range(n)
+                    ]
+                )
             )
-            for i in range(10)
-        ]
-        weather = _make_weather(forecast=forecast)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+
+        five = with_days(5)
+        assert _ink_clusters(with_days(10), _forecast_band()) == 5
+        assert with_days(10).tobytes() == five.tobytes(), "a sixth forecast day reached the plate"
 
     def test_wind_without_direction(self):
-        draw = _draw_surface()
-        weather = _make_weather(wind_speed=10.0, wind_deg=None)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """No bearing drops the compass suffix from the wind card."""
+        assert _ink(_component(_make_weather(wind_speed=10.0, wind_deg=None)), CARDS) < _ink(
+            _component(_make_weather(wind_speed=10.0, wind_deg=270.0)), CARDS
+        )
 
     def test_negative_temperature(self):
-        draw = _draw_surface()
-        weather = _make_weather(current_temp=-15.0, high=-5.0, low=-20.0)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """A minus sign draws more than the equivalent positive."""
+        assert _ink(
+            _component(_make_weather(current_temp=-15.0, high=-5.0, low=-20.0)), HERO
+        ) > _ink(_component(_make_weather(current_temp=15.0, high=5.0, low=20.0)), HERO)
 
     def test_custom_region(self):
-        draw = _draw_surface()
-        weather = _make_weather()
-        region = ComponentRegion(10, 10, 780, 460)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15), region=region)
+        """An inset region moves the content in from the canvas edges."""
+        inset = _component(_make_weather(), region=ComponentRegion(10, 10, 780, 460))
+        assert inset.tobytes() != _component(_make_weather()).tobytes()
+        assert _ink(inset, (0, 0, CANVAS_W, 8)) == 0, "content ignored the region y offset"
 
     def test_no_today_date(self):
-        """Moon phase is skipped when today is None."""
-        draw = _draw_surface()
-        weather = _make_weather()
-        draw_weather_full(draw, weather, today=None)
+        """Moon phase is skipped when today is None, so the strip carries less."""
+        assert _ink(_component(_make_weather(), today=None), DETAIL) < _ink(
+            _component(_make_weather()), DETAIL
+        )
 
     def test_pressure_shown_in_detail_when_uv_in_cards(self):
-        """When UV is available, pressure appears in the detail strip."""
-        draw = _draw_surface()
-        weather = _make_weather(uv_index=5.0, pressure=1020.0)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """UV takes the card slot, so pressure goes to the detail strip."""
+        with_pressure = _component(_make_weather(uv_index=5.0, pressure=1020.0))
+        without = _component(_make_weather(uv_index=5.0, pressure=None))
+        assert _ink(with_pressure, DETAIL) > _ink(without, DETAIL), "pressure missed the strip"
 
     def test_pressure_in_cards_when_no_uv(self):
-        """When UV is None, pressure takes the 4th card slot."""
-        draw = _draw_surface()
-        weather = _make_weather(uv_index=None, pressure=1015.0)
-        draw_weather_full(draw, weather, today=date(2024, 3, 15))
+        """With UV absent, pressure takes the 4th card and leaves the strip alone."""
+        no_uv = _component(_make_weather(uv_index=None, pressure=1015.0))
+        no_uv_no_pressure = _component(_make_weather(uv_index=None, pressure=None))
+        assert _ink(no_uv, CARDS) != _ink(no_uv_no_pressure, CARDS), "the barometer card is missing"
+        assert _ink(no_uv, DETAIL) == _ink(no_uv_no_pressure, DETAIL), (
+            "pressure reached the strip as well as the card"
+        )

--- a/tests/test_weatherglass_panel.py
+++ b/tests/test_weatherglass_panel.py
@@ -13,6 +13,26 @@ Both were previously exercised only incidentally through the pixel-snapshot
 suite, which renders every theme at a single pinned moment under imperial
 units — so the metric and standard branches and every pressure-history path
 had no regression protection.
+
+Assertion discipline (see #229)
+-------------------------------
+#229 singles this file out: its parametrized sweeps across the AQI scale,
+the wind rose and the UV scale are *deliberate* smoke tests and should keep
+their shape. They have — the change here is only that they can now fail.
+They asserted ``img.getbbox() is not None`` on a white plate with fg=0,
+where getbbox reports the bounds of non-zero pixels and so returns the full
+canvas whether or not anything was drawn; ``_marks`` counts pixels that
+differ from the background instead.
+
+Each sweep also gained one companion test asserting that the range actually
+reaches its instrument. The sweep says every value renders; the companion
+says the values do not all render *identically*. A compass that ignores the
+bearing passes the first and fails the second.
+
+Verification: with ``draw_weatherglass`` stubbed to a no-op, 52 of the 126
+tests fail (10 did before). The survivors are the pure scale/format helpers,
+the theme-registry cases, and the pressure-history tests, which assert on
+files in ``state/`` rather than on pixels.
 """
 
 from __future__ import annotations
@@ -49,6 +69,7 @@ from src.render.components.weatherglass_panel import (
     _wind_unit_label,
     draw_weatherglass,
 )
+from src.render.quantize import flatten_pixels
 from src.render.theme import AVAILABLE_THEMES, ComponentRegion, ThemeStyle, load_theme
 
 FIXED_NOW = datetime(2026, 4, 6, 10, 30)
@@ -91,6 +112,22 @@ def _style(mode: str = "L") -> ThemeStyle:
     if mode == "RGB":
         return ThemeStyle(fg=(0, 0, 0), bg=(255, 255, 255))
     return ThemeStyle(fg=0, bg=255)
+
+
+def _marks(img, box=None) -> int:
+    """Pixels differing from the canvas background.
+
+    The honest replacement for ``img.getbbox() is not None`` here: the plate
+    is white with fg=0, so getbbox reports the bounds of non-zero pixels and
+    returns the full canvas whether or not anything was drawn.
+    """
+    px = flatten_pixels(img)
+    width = img.width
+    background = px[0]
+    if box is None:
+        return sum(1 for v in px if v != background)
+    x0, y0, x1, y1 = box
+    return sum(1 for y in range(y0, y1) for x in range(x0, x1) if px[y * width + x] != background)
 
 
 def _history(path) -> list[dict]:
@@ -340,8 +377,11 @@ class TestLoadPrevPressure:
 
 
 class TestSavePressureSample:
-    def test_no_state_dir_is_a_noop(self):
+    def test_no_state_dir_is_a_noop(self, tmp_path):
+        """state_dir=None disables history entirely, in both directions."""
         _save_pressure_sample(None, 1013.0, NOW_UTC)  # must not raise
+        assert _load_prev_pressure(None, NOW_UTC) == (None, None)
+        assert list(tmp_path.iterdir()) == [], "something was written despite no state dir"
 
     def test_none_pressure_is_not_recorded(self, tmp_path):
         _save_pressure_sample(str(tmp_path), None, NOW_UTC)
@@ -414,13 +454,20 @@ class TestSavePressureSample:
         it from an aware now never raises TypeError."""
         _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC.replace(tzinfo=None))
         ts = _history(tmp_path / _PRESSURE_FILE)[0]["ts"]
-        assert datetime.fromisoformat(ts).tzinfo is not None
+        parsed = datetime.fromisoformat(ts)
+        assert parsed.tzinfo is not None, "a naive timestamp was persisted"
+        assert parsed.utcoffset() == timedelta(0), f"not stored as UTC: {ts}"
+        # And it round-trips: subtracting from an aware now must not raise.
+        assert (NOW_UTC - parsed) == timedelta(0)
 
     def test_unwritable_state_dir_degrades_silently(self, tmp_path):
         """History bookkeeping must never break a render."""
         blocker = tmp_path / "state"
         blocker.write_text("i am a file, not a directory")
         _save_pressure_sample(str(blocker), 1013.0, NOW_UTC)  # must not raise
+        # The blocker is untouched and the read side degrades to "no history".
+        assert blocker.read_text() == "i am a file, not a directory"
+        assert _load_prev_pressure(str(blocker), NOW_UTC) == (None, None)
 
     def test_write_leaves_no_temp_files_behind(self, tmp_path):
         _save_pressure_sample(str(tmp_path), 1013.0, NOW_UTC)
@@ -517,7 +564,7 @@ class TestDrawWeatherglass:
         temps = {"imperial": 64.0, "metric": 18.0, "standard": 291.0}[units]
         data = DashboardData(weather=_weather(units=units, current_temp=temps))
         img = self._draw(data)
-        assert img.getbbox() is not None
+        assert _marks(img) > 0
 
     def test_unit_systems_produce_distinct_plates(self):
         """The scale, comfort band and wind label all change with units — if
@@ -536,7 +583,7 @@ class TestDrawWeatherglass:
         assert imperial.tobytes() != metric.tobytes()
 
     def test_renders_without_weather(self):
-        assert self._draw(DashboardData()).getbbox() is not None
+        assert _marks(self._draw(DashboardData())) > 0
 
     def test_renders_with_every_optional_field_missing(self):
         data = DashboardData(
@@ -550,14 +597,14 @@ class TestDrawWeatherglass:
                 units=None,
             )
         )
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     def test_renders_with_air_quality(self):
         data = DashboardData(
             weather=_weather(),
             air_quality=AirQualityData(aqi=142, category="Unhealthy", pm25=52.3),
         )
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     @pytest.mark.parametrize("aqi", [0, 25, 75, 125, 175, 250, 400, 500])
     def test_renders_across_the_aqi_scale(self, aqi):
@@ -566,7 +613,7 @@ class TestDrawWeatherglass:
             weather=_weather(),
             air_quality=AirQualityData(aqi=aqi, category="X", pm25=float(aqi) / 4),
         )
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     def test_alert_cartouche_overlays_the_plate(self):
         plain = self._draw(DashboardData(weather=_weather()))
@@ -580,26 +627,26 @@ class TestDrawWeatherglass:
     @pytest.mark.parametrize("temp", [-40.0, 0.0, 32.0, 64.0, 85.0, 110.0, 130.0])
     def test_temperatures_beyond_the_scale_clamp(self, temp):
         data = DashboardData(weather=_weather(current_temp=temp))
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     @pytest.mark.parametrize("deg", [0.0, 45.0, 90.0, 180.0, 270.0, 359.0])
     def test_wind_compass_across_the_rose(self, deg):
         data = DashboardData(weather=_weather(wind_deg=deg))
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     @pytest.mark.parametrize("uv", [0.0, 2.0, 5.5, 8.0, 11.0, 15.0])
     def test_uv_bar_across_the_scale(self, uv):
         data = DashboardData(weather=_weather(uv_index=uv))
-        assert self._draw(data).getbbox() is not None
+        assert _marks(self._draw(data)) > 0
 
     def test_renders_on_rgb_for_inky(self):
         data = DashboardData(weather=_weather())
-        assert self._draw(data, mode="RGB").getbbox() is not None
+        assert _marks(self._draw(data, mode="RGB")) > 0
 
     def test_polar_latitude_renders(self):
         """Svalbard in April has no sunset — the sun arc must still draw."""
         data = DashboardData(weather=_weather())
-        assert self._draw(data, latitude=78.2, longitude=15.6).getbbox() is not None
+        assert _marks(self._draw(data, latitude=78.2, longitude=15.6)) > 0
 
     def test_unset_coordinates_fall_back_to_owm_times(self):
         data = DashboardData(
@@ -609,12 +656,51 @@ class TestDrawWeatherglass:
             )
         )
         # Exact (0.0, 0.0) is the project-wide "unset" convention.
-        assert self._draw(data, latitude=0.0, longitude=0.0).getbbox() is not None
+        assert _marks(self._draw(data, latitude=0.0, longitude=0.0)) > 0
+
+    # The parametrized sweeps above are deliberate smoke tests (#229 calls
+    # them out as such) — they check that every value in a range renders.
+    # These companions check the complementary thing: that the range is
+    # actually reaching the instrument. A scale that draws identically at
+    # every value passes the sweep and is still broken.
+
+    def test_the_aqi_sweep_reaches_the_badge(self):
+        plates = {
+            aqi: self._draw(
+                DashboardData(
+                    weather=_weather(),
+                    air_quality=AirQualityData(aqi=aqi, category="X", pm25=float(aqi) / 4),
+                )
+            ).tobytes()
+            for aqi in (0, 75, 175, 400)
+        }
+        assert len(set(plates.values())) > 1, "every AQI band drew the same badge"
+
+    def test_the_temperature_sweep_reaches_the_thermometer(self):
+        plates = {
+            temp: self._draw(DashboardData(weather=_weather(current_temp=temp))).tobytes()
+            for temp in (0.0, 32.0, 64.0, 110.0)
+        }
+        assert len(set(plates.values())) > 1, "every temperature drew the same column"
+
+    def test_the_wind_sweep_reaches_the_compass(self):
+        plates = {
+            deg: self._draw(DashboardData(weather=_weather(wind_deg=deg))).tobytes()
+            for deg in (0.0, 90.0, 180.0, 270.0)
+        }
+        assert len(set(plates.values())) == 4, "the compass needle ignores the bearing"
+
+    def test_the_uv_sweep_reaches_the_bar(self):
+        plates = {
+            uv: self._draw(DashboardData(weather=_weather(uv_index=uv))).tobytes()
+            for uv in (0.0, 5.5, 11.0)
+        }
+        assert len(set(plates.values())) == 3, "the UV bar ignores the index"
 
     def test_defaults_are_supplied_when_region_and_style_are_omitted(self):
         img, draw = _canvas("L", (800, 480))
         draw_weatherglass(draw, DashboardData(weather=_weather()), TODAY, FIXED_NOW)
-        assert img.getbbox() is not None
+        assert _marks(img) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -738,7 +824,7 @@ class TestWeatherglassTheme:
     def test_renders_end_to_end(self):
         img = _render()
         assert img.size == (800, 480)
-        assert img.getbbox() is not None
+        assert _marks(img) > 0
 
     def test_render_is_deterministic(self):
         assert _render().tobytes() == _render().tobytes()

--- a/tests/test_week_view.py
+++ b/tests/test_week_view.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from PIL import Image, ImageDraw
 
 from src.data.models import CalendarEvent, DayForecast
+from src.render import layout as L
 from src.render.components.week_view import (
     _density_tier,
     _events_for_day,
@@ -14,10 +15,14 @@ from src.render.components.week_view import (
     draw_week,
 )
 from src.render.quantize import flatten_pixels
+from tests.inkutils import ink
 
 # ---------------------------------------------------------------------------
 # _fmt_time
 # ---------------------------------------------------------------------------
+
+
+WEEK_BOX = (L.WEEK_X, L.WEEK_Y, L.WEEK_X + L.WEEK_W, L.WEEK_Y + L.WEEK_H)
 
 
 class TestFmtTime:
@@ -134,8 +139,8 @@ class TestDrawWeek:
     def test_smoke_no_events(self):
         img, draw = self._make_draw()
         draw_week(draw, [], date(2024, 3, 15))
-        # Should draw something (header lines at minimum)
-        assert img.getbbox() is not None
+        # The empty grid is still the day headers + column rules.
+        assert ink(img, WEEK_BOX) > 0
 
     def test_smoke_with_timed_events(self):
         img, draw = self._make_draw()
@@ -148,7 +153,9 @@ class TestDrawWeek:
             ),
         ]
         draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        empty, empty_draw = self._make_draw()
+        draw_week(empty_draw, [], today)
+        assert ink(img, WEEK_BOX) > ink(empty, WEEK_BOX), "the event was not drawn"
 
     def test_location_newlines_are_normalized_before_truncation(self):
         img, draw = self._make_draw()
@@ -188,7 +195,9 @@ class TestDrawWeek:
             ),
         ]
         draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        empty, empty_draw = self._make_draw()
+        draw_week(empty_draw, [], today)
+        assert ink(img, WEEK_BOX) > ink(empty, WEEK_BOX), "the all-day bar was not drawn"
 
     def test_smoke_many_events_per_day(self):
         """Overflow indicator (+N more) should not crash."""
@@ -203,7 +212,9 @@ class TestDrawWeek:
             for i in range(10)
         ]
         draw_week(draw, events, today)
-        assert img.getbbox() is not None
+        few, few_draw = self._make_draw()
+        draw_week(few_draw, events[:2], today)
+        assert ink(img, WEEK_BOX) > ink(few, WEEK_BOX), "ten events drew no more than two"
 
     @staticmethod
     def _header_ink_by_column(img, region=None):
@@ -277,7 +288,13 @@ class TestDrawWeek:
             for i in range(5)
         ]
         draw_week(draw, [], today, forecast=forecast)
-        assert img.getbbox() is not None
+        # NOTE: draw_week accepts `forecast` and never reads it — see the
+        # finding recorded in tests/test_v3_features.py::TestWeekViewForecast.
+        # This asserts the grid renders, not that a forecast appears.
+        plain, plain_draw = self._make_draw()
+        draw_week(plain_draw, [], today)
+        assert ink(img, WEEK_BOX) > 0
+        assert img.tobytes() == plain.tobytes(), "draw_week started using its forecast argument"
 
     def test_today_bordered_not_inverted_draws_underline(self):
         """invert_today_col=False + show_borders=True → thick accent underline under today.
@@ -402,7 +419,9 @@ class TestDrawWeek:
             is_all_day=True,
         )
         draw_week(draw, [spanning], today)
-        assert img.getbbox() is not None
+        empty, empty_draw = self._make_draw()
+        draw_week(empty_draw, [], today)
+        assert ink(img, WEEK_BOX) > ink(empty, WEEK_BOX), "the spanning bar was not drawn"
 
 
 # ---------------------------------------------------------------------------
@@ -558,7 +577,7 @@ class TestDrawDayEvents:
             title_font=semibold(13),
             allday_font=None,  # triggers line 392
         )
-        assert img.getbbox() is not None
+        assert ink(img) > 0, "the allday_font=None fallback drew nothing"
 
     def test_overflow_indicator_shown_when_events_exceed_space(self):
         """When events don't fit, '+N more' is shown (lines 404-406)."""
@@ -580,4 +599,17 @@ class TestDrawDayEvents:
             time_font=regular(10),
             title_font=semibold(13),
         )
-        assert img.getbbox() is not None
+        # A 50px column cannot hold ten events, so most become "+N more".
+        assert ink(img) > 0, "nothing drawn"
+        roomy, roomy_draw = self._make_draw()
+        _draw_day_events(
+            draw=roomy_draw,
+            events=events,
+            cx=0,
+            y_start=40,
+            col_w=114,
+            max_h=280,
+            time_font=regular(10),
+            title_font=semibold(13),
+        )
+        assert ink(img) < ink(roomy), "the tiny column listed as much as a roomy one"

--- a/tests/test_week_view.py
+++ b/tests/test_week_view.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from PIL import Image, ImageDraw
 
-from src.data.models import CalendarEvent, DayForecast
+from src.data.models import CalendarEvent
 from src.render import layout as L
 from src.render.components.week_view import (
     _density_tier,
@@ -272,29 +272,18 @@ class TestDrawWeek:
         ink = self._header_ink_by_column(img)
         assert ink[4] < 0.5, "the today cell must not be filled when inversion is off"
 
-    def test_smoke_with_forecast_icons(self):
-        """draw_week with forecast data should not crash."""
+    def test_smoke_with_forecast_data_present(self):
+        """A weather forecast in the data does not reach the week grid.
+
+        draw_week takes no forecast argument: the grid renders events only.
+        It used to accept one and never read it, with _builtins.py computing
+        `ctx.data.weather.forecast` on every render to feed it (#229); both are
+        gone. This keeps a rendering check on the same Monday-anchored week.
+        """
         img, draw = self._make_draw()
         today = date(2024, 3, 18)  # Monday
-        forecast = [
-            DayForecast(
-                date=today + timedelta(days=i),
-                high=50.0 + i,
-                low=35.0,
-                icon="01d",
-                description="clear",
-                precip_chance=0.1,
-            )
-            for i in range(5)
-        ]
-        draw_week(draw, [], today, forecast=forecast)
-        # NOTE: draw_week accepts `forecast` and never reads it — see the
-        # finding recorded in tests/test_v3_features.py::TestWeekViewForecast.
-        # This asserts the grid renders, not that a forecast appears.
-        plain, plain_draw = self._make_draw()
-        draw_week(plain_draw, [], today)
+        draw_week(draw, [], today)
         assert ink(img, WEEK_BOX) > 0
-        assert img.tobytes() == plain.tobytes(), "draw_week started using its forecast argument"
 
     def test_today_bordered_not_inverted_draws_underline(self):
         """invert_today_col=False + show_borders=True → thick accent underline under today.


### PR DESCRIPTION
## What and why

Closes #228
Closes #229

**#228** — `_cache_is_recent` guarded on `fetcher.save_metadata is not None`, but `save_metadata` defaults to a *function*, so the test was always true and the branch behind it unreachable. Deleted it. Worth noting: the issue offered two readings and suggested picking reading 2 because it does "marginally less work per run" — that isn't so. Both cache helpers funnel into the same `_decode_v2_block`, differing only in whether the metadata element is returned, so reading 2 saves nothing and reading 1 wins outright. The dead branch was also incoherent, not merely dead: it fell through to an `interval_map` lookup that would have raised `KeyError` for the very sources it claimed to serve.

**#229** — every `assert img.getbbox() is not None` in the suite is gone, 60 of them. On a white 1-bit plate that assertion has *no failing input*: `getbbox` reports the bounds of non-zero pixels, and every pixel is non-zero, so it returns the full canvas whether or not anything was drawn. Several whole files passed with their draw function stubbed to a no-op.

The weak-assertion count the issue opened with is down from **403 of 3238 (12.6%) to 73 (2.3%)**. I stopped there deliberately: the remainder is what the issue predicted the heuristic would over-flag — `assert x is not None` where awareness *is* the check, no-raise checks on error paths, and genuine smoke tests. Chasing those adds noise, not safety.

Coverage moved 97.64% → 97.76%, consistent with the issue's "this shouldn't move the number much".

## Notes for the reviewer

**The method mattered more than the rewrites.** Every rewritten test was verified by deleting the behaviour it names and confirming it goes red. That step caught a defect *in one of my own rewrites* — my first version of the AQI clamp test still passed with `min(aqi, _AQI_MAX)` deleted, because on a 1-bit plate the bar saturates either way and every accent collapses to `fg`. It's now measured on a greyscale plate where the zone labels expose it. So the deletion check isn't diligence you can skip; it's the part that works.

**What the sweep turned up beyond weak assertions:**

- **A real bug.** `draw_weather` returned at `n_cols == 0` before the staleness call, so the "!" badge was dropped when the forecast was empty — the degraded state it exists to announce. Changelogged under Fixed.
- **Two dead parameters**, both actively fed by the registry every render: `draw_week(forecast=…)` and `draw_air_quality_full(today=…)`. Removed in their own commit; verified pixel-neutral.
- **Six false test names**, including one citing a source line for a scale-down loop that never runs (it needs ~11 characters; no temperature reaches it).
- **Four bad fixtures.** Two rendered white-on-black panels using the *default* `ThemeStyle` (fg=0), so nothing was visible — in moonphase that meant SF and Reykjavik rendered byte-identically and the documented moonrise line was never exercised. One built an all-day event with a `date` start, which an earlier `isinstance` guard rejects, so the `is_all_day` guard it named was untestable. One compared identical inputs.

**Suggested addition to #229's method:** it targets assertions, but a fixture that doesn't match how the code is really invoked defeats a test just as thoroughly — that's 4 of 13 findings here, and only the deletion check surfaces them.

**Two things I left alone deliberately**, both flagged in-code rather than changed: the border convention where `hline`/`vline` draw to `x0+w` inclusive, putting a pixel past the region (shared by `weather_panel` and `birthday_bar`, so local "fixes" would be wrong); and `message_panel`'s overflow below ~300px regions, caused by a hardcoded 52px pad plus word-wrapping that can't break inside a word. No theme configures a narrow message region.

**Reviewing this efficiently:** the per-file commits are self-contained and each explains its own findings. `tests/inkutils.py` and the two new Key Conventions bullets in `CLAUDE.md` are the best entry points for the approach.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate (97.76% against a 94% floor)
- [x] `venv/bin/python -m mypy src/` is clean — "Success: no issues found in 143 source files"
- [x] Tests added or updated for behaviour changes

If the change touches **themes, components, or anything that renders**:

- [x] Pixel-hash baselines regenerated — **not needed, and correctly not done.** No theme's output changes. I verified this locally by hashing all 37 themes before and after each component change (empty diff every time), because the strict snapshot assertions *skip* under this container's Pillow 12.3.0 against the pinned 12.2.0 — the documented gate behaving as designed. **CI's `snapshot-tests` job has run under the pinned version and passed**, so this is confirmed rather than merely argued.
- [x] Preview PNGs regenerated — not needed; no theme's appearance changed.
- [x] Refactor confirmed pixel-neutral — all 37 theme hashes unchanged, and `snapshot-tests` green in CI.

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs — no theme, config option or workflow changed. CLAUDE.md's description of `draw_air_quality_full` stays accurate after the parameter removal.
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

If the change adds a **config option**: n/a — none added.

If the change affects **architecture or contributor workflow**:

- [x] `CLAUDE.md` updated — two Key Conventions bullets covering what to use instead of `getbbox()` and why, the helpers in `tests/inkutils.py`, the two traps that are easy to get backwards (inverted bands where more content means *less* ink; white-on-black panels that render blank under the default style), and the delete-the-behaviour verification step. Plus a repository-structure line for `inkutils.py`.

---

**CI:** all 9 checks green on the current head `64008f3` — `lint`, `typecheck`, `smoke`, `snapshot-tests`, `test-core-install`, and `test` on 3.10 / 3.11 / 3.12 / 3.13. Mergeable, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhDCS51H5nsT2zhtz4G2tb