### PR TITLE
Make releases programmatic, and fix two things that let drift through

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,26 @@ jobs:
       # it's test tooling, not an application dep, so it doesn't undermine the
       # "no optional-extra app packages" guarantee.
       - run: pip install . pytest pytest-cov
+      # The pytest step below cannot detect a broken install. Three separate
+      # mechanisms put the repo root on sys.path ahead of site-packages:
+      # tests/__init__.py makes pytest prepend the rootdir, `python -m pytest`
+      # prepends the cwd, and pyproject's `pythonpath = ["."]` adds it again.
+      # So `import src.*` there always resolves to the checkout and the job
+      # stays green no matter what `pip install .` produced — which is exactly
+      # how it sat green while the install was scattering every module across
+      # the top level of site-packages, unimportable.
+      #
+      # This step runs from a directory where the source tree is not
+      # importable, so it exercises the installed package and nothing else.
+      - name: Import the installed package from outside the source tree
+        working-directory: /tmp
+        run: |
+          python - <<'PY'
+          import src.app, src.main, src.config, src.data_pipeline
+          import src.render.canvas, src.display.driver, src.fetchers.calendar
+          from src._version import __version__
+          print("installed home-dashboard", __version__)
+          PY
       - run: python -m pytest tests/ --ignore-glob='tests/test_web_*.py' --tb=short --no-cov
 
   snapshot-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - run: pip install -e ".[dev]"
-      - run: ruff check src/ tests/
-      - run: ruff format --check src/ tests/
+      - run: ruff check src/ tests/ scripts/ tools/
+      - run: ruff format --check src/ tests/ scripts/ tools/
       # Validates markdown links and the canonical theme inventories in
       # docs/themes.md and docs/previews.md. CONTRIBUTING asks contributors to
       # run this, but nothing enforced it — which is how themes drifted out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `pythonpath = ["."]` makes the source tree importable, shadowing the
   installed copy entirely.
 
+- **The `test-core-install` CI job could not fail.** Its whole purpose is to
+  prove `pip install .` is usable, but it ran pytest from the repo checkout,
+  where three separate mechanisms put the repo root on `sys.path` ahead of
+  site-packages: `tests/__init__.py` makes pytest prepend the rootdir,
+  `python -m pytest` prepends the cwd, and `pyproject.toml`'s
+  `pythonpath = ["."]` adds it a third time. `import src.*` therefore always
+  resolved to the source tree, and the job stayed green through an install in
+  which every module was unimportable. It now also imports the installed
+  package from a directory where the source tree is not importable. Verified
+  both ways: the new step exits 0 against a correct install and exits 1
+  against the pre-fix one.
+
 ## [5.2.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   alone means patch. Major is never inferred and must be requested with
   `make release RELEASE_ARGS="--major"`. `make release-dry` prints the plan
   without writing. The script refuses a dirty tree, an existing tag, or a
-  version that does not increase; pushing stays manual.
+  version that does not increase; pushing stays manual. If any step of the
+  mutating phase fails — a rejecting pre-commit hook, an unset git identity, a
+  signing key that will not load — the file rewrites and any release commit are
+  rolled back, so the same release can simply be retried once the cause is
+  fixed. The rollback never uses `git reset --hard`, since `--allow-dirty`
+  means the tree may hold unrelated work.
 - **The version has a single source of truth.** `pyproject.toml` now declares
   `dynamic = ["version"]` and reads `src/_version.py` via
   `[tool.setuptools.dynamic]` rather than restating the number. The two files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   drift, on a non-semver `__version__`, on an undated or mismatched newest
   changelog entry, and on a missing `## [Unreleased]` heading.
 
+- **`make lint` / `make fmt` now cover `scripts/` and `tools/`.** Both
+  directories were outside the linted set, so `scripts/release.py`,
+  `scripts/build_previews.py`, `tools/check_naive_datetime.py` and their
+  neighbours could drift from the project's ruff config without CI noticing.
+  Both were already clean, so this is a scope widening with no code changes.
+
 ### Fixed
 
 - **`pip install .` produced an unimportable package.** With no explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Releases are cut with one command instead of four manual edits.**
+  `make release` (`scripts/release.py`) bumps `src/_version.py`, dates the
+  `## [Unreleased]` block, commits, and creates the annotated `vX.Y.Z` tag.
+  The bump size is inferred from the Unreleased section headings —
+  `Added`/`Changed`/`Deprecated`/`Removed` means minor, `Fixed`/`Security`
+  alone means patch. Major is never inferred and must be requested with
+  `make release RELEASE_ARGS="--major"`. `make release-dry` prints the plan
+  without writing. The script refuses a dirty tree, an existing tag, or a
+  version that does not increase; pushing stays manual.
+- **The version has a single source of truth.** `pyproject.toml` now declares
+  `dynamic = ["version"]` and reads `src/_version.py` via
+  `[tool.setuptools.dynamic]` rather than restating the number. The two files
+  had already drifted once — `4.6.0` was committed to one while the other
+  said `5.2.0`. `tests/test_version_consistency.py` fails the build on that
+  drift, on a non-semver `__version__`, on an undated or mismatched newest
+  changelog entry, and on a missing `## [Unreleased]` heading.
+
 ## [5.2.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   drift, on a non-semver `__version__`, on an undated or mismatched newest
   changelog entry, and on a missing `## [Unreleased]` heading.
 
+### Fixed
+
+- **`pip install .` produced an unimportable package.** With no explicit
+  `packages` config, setuptools auto-discovery read the repo as a *src-layout*
+  and installed every module at the top level of `site-packages` — `app.py`,
+  `config.py`, `cli.py`, `main.py`, `filters.py`, a bare `__init__.py`, plus
+  `data/`, `display/`, `fetchers/`, `render/`, `services/` and `web/`. Nothing
+  was importable afterwards: `import src.config` failed (`No module named
+  'src'`) because the `src` package no longer existed, and `import config`
+  failed too, because the module's own body does `from src.config_validation
+  import ...`. The generic names also collided with anything else in the
+  environment. `[tool.setuptools.packages.find] include = ["src*"]` now installs
+  the single `src` package that the codebase actually imports. The
+  `test-core-install` CI job never caught this because pytest's
+  `pythonpath = ["."]` makes the source tree importable, shadowing the
+  installed copy entirely.
+
 ## [5.2.0] - 2026-08-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,10 @@ make web-enable     # Install and start web UI systemd service (run ON Pi)
 make web-status     # Web service status + recent log tail (run ON Pi)
 make web-logs       # Tail output/dashboard-web.log (run ON Pi)
 make banner         # Regenerate the eInk-faithful README logo → assets/banner.png
-make lint           # ruff check src/ tests/
-make fmt            # ruff format src/ tests/
-ruff check src/ tests/                         # Lint (direct invocation)
-ruff format src/ tests/                        # Format (direct invocation)
+make lint           # ruff check src/ tests/ scripts/ tools/
+make fmt            # ruff format src/ tests/ scripts/ tools/
+ruff check src/ tests/ scripts/ tools/         # Lint (direct invocation)
+ruff format src/ tests/ scripts/ tools/        # Format (direct invocation)
 ```
 
 ## Tech Stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ make docs-check     # Run scripts/check_docs.py (markdown links + the canonical 
                     #   inventories in docs/themes.md and docs/previews.md). Enforced by
                     #   the `lint` CI job, so drift here blocks a merge.
 make version        # Print current version (e.g. main.py 5.2.0)
+make release-dry    # Show the next release (inferred from the CHANGELOG) — writes nothing
+make release        # Bump src/_version.py, date the CHANGELOG, commit, tag vX.Y.Z
+                    #   (scripts/release.py; RELEASE_ARGS="--major" forces a bump size)
 make deploy         # Rsync to Pi (configurable: PI_USER, PI_HOST, PI_DIR)
 make install        # Install systemd timer on remote Pi (via ssh/scp)
 make pi-install     # Full Pi setup: apt deps, venv, Inky + Waveshare drivers (run ON Pi)
@@ -408,6 +411,18 @@ default to `None` and fall back gracefully so adding a new field never breaks ex
 | `font_quote_author` | `font_regular` | Quote attribution line (`— Author`) |
 
 ## Gotchas
+
+- **The version has one home: `src/_version.py`.** `pyproject.toml` declares
+  `dynamic = ["version"]` and reads it via `[tool.setuptools.dynamic]`, so there is no
+  second copy to bump. Never restate a literal `version = "..."` in `pyproject.toml` —
+  `tests/test_version_consistency.py` fails the build if you do, because the two files
+  silently disagreed before (`4.6.0` in one, `5.2.0` in the other). Releases are cut with
+  `make release` (`scripts/release.py`), which bumps the version, dates the
+  `## [Unreleased]` changelog block, commits, and tags `vX.Y.Z` in one step; the bump size
+  is inferred from the Unreleased `### ...` headings (Added/Changed/Deprecated/Removed →
+  minor, Fixed/Security only → patch) and **major is never inferred** — pass
+  `RELEASE_ARGS="--major"`. The same test asserts the newest CHANGELOG entry matches
+  `__version__`, so a bump without a changelog entry (or the reverse) is caught in CI.
 
 - Incremental sync tokens persist in `state/calendar_sync_state.json`; delete to force full resync
 - Quiet hours (default 23:00–06:00): app exits immediately during this window (dry-run bypasses this)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ make dry
 ```bash
 make test         # run pytest
 make coverage     # run pytest with coverage report (htmlcov/index.html)
-make lint         # ruff check src/ tests/
-make fmt          # ruff format src/ tests/
+make lint         # ruff check src/ tests/ scripts/ tools/
+make fmt          # ruff format src/ tests/ scripts/ tools/
 make dry          # preview with dummy data
 make previews     # generate theme previews
 make check        # validate config/config.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,23 @@ When changing any of these areas, update the canonical docs in the same PR:
 - Coverage is enforced at ≥94% via `pytest-cov` (`fail_under` in `pyproject.toml`); current coverage is ~98%. Run `make coverage` to see missing lines and an HTML report at `htmlcov/index.html`. New defensive branches should ship with tests.
 - Theme changes shift the pixel-hash snapshots in `tests/snapshots/theme_pixel_hashes.json`. If the diff is intentional, regenerate with `UPDATE_SNAPSHOTS=1 pytest tests/test_theme_pixel_snapshots.py` and commit the updated JSON alongside the source change. Adding a new theme also requires a fresh baseline — the coverage guard test fails without one.
 
+## Releasing
+
+Do not hand-edit the version. It lives only in `src/_version.py` (`pyproject.toml`
+reads it dynamically), and releases are cut with:
+
+```bash
+make release-dry        # show the plan
+make release            # bump, date the changelog, commit, tag
+```
+
+The bump size is inferred from the `## [Unreleased]` changelog block — a
+`### Added`/`### Changed`/`### Deprecated`/`### Removed` section means minor,
+`### Fixed`/`### Security` alone means patch, and major must be asked for with
+`make release RELEASE_ARGS="--major"`. So the thing to keep current in a PR is
+the **`## [Unreleased]` entry**; the version number follows from it at release
+time. See [Releasing](docs/development.md#releasing).
+
 ## PR Checklist
 
 Opening a PR seeds this from [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md),

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ coverage: _check-venv
 	$(VENV) -m pytest --cov-report=html
 
 lint: _check-venv
-	$(VENV) -m ruff check src/ tests/
+	$(VENV) -m ruff check src/ tests/ scripts/ tools/
 
 fmt: _check-venv
-	$(VENV) -m ruff format src/ tests/
+	$(VENV) -m ruff format src/ tests/ scripts/ tools/
 
 check: _check-venv
 	$(VENV) -m src.main --check-config

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dry test coverage deploy setup install check previews previews-inky previews-split banner version lint fmt docs-check \
+.PHONY: dry test coverage deploy setup install check previews previews-inky previews-split banner version release release-dry lint fmt docs-check \
         pi-install install-display-drivers pi-enable pi-status pi-logs configure \
         web-enable web-status web-logs
 
@@ -21,6 +21,14 @@ install-display-drivers: _check-venv
 
 version: _check-venv
 	@$(VENV) -m src.main --version
+
+# Releasing needs no venv: scripts/release.py is stdlib-only and reads
+# src/_version.py as text rather than importing the package.
+release-dry:
+	@python3 scripts/release.py --dry-run $(RELEASE_ARGS)
+
+release:
+	@python3 scripts/release.py $(RELEASE_ARGS)
 
 dry: _check-venv
 	$(VENV) -m src.main --dry-run --dummy

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,8 @@ Use this page for local workflow, dev commands, and repo orientation. For archit
 | `make check` | validate `config/config.yaml` |
 | `make docs-check` | validate markdown links and doc theme inventories |
 | `make version` | print the app version |
+| `make release-dry` | show what the next release would be — writes nothing |
+| `make release` | cut a release: bump the version, date the changelog, commit, tag |
 
 Pi/operator commands such as `make pi-install`, `make pi-enable`, and `make web-enable` are documented for operators in [Setup Guide](setup.md) and [Web UI](web-ui.md).
 
@@ -78,6 +80,57 @@ This path needs no hardware, API keys, or credentials.
 - Use `make dry` for the default dummy preview.
 - Use `make previews` for the batch of standard preview PNGs.
 - Use [Theme Previews](previews.md) when you need to regenerate the Waveshare or Inky preview PNGs that are embedded in [Themes](themes.md).
+
+---
+
+## Releasing
+
+The version lives in **one** place: `src/_version.py`. `pyproject.toml` reads it
+via `[tool.setuptools.dynamic]`, so there is no second copy to keep in sync —
+`pip install .` and `make version` resolve the same string.
+
+Cut a release with one command:
+
+```bash
+make release-dry        # show the plan, write nothing
+make release            # bump, date the changelog, commit, tag
+git push -u origin HEAD && git push origin v<new-version>
+```
+
+`scripts/release.py` does four things that used to be four manual edits:
+
+1. bumps `src/_version.py`
+2. renames the `## [Unreleased]` changelog heading to `## [X.Y.Z] - <today>` and
+   opens a fresh empty `## [Unreleased]` above it
+3. commits both files as `Release X.Y.Z`
+4. creates the annotated tag `vX.Y.Z`
+
+It refuses to run on a dirty working tree, on an existing tag, or when the new
+version would not be greater than the current one. Pushing stays manual.
+
+### How the bump size is chosen
+
+The size is inferred from the `### ...` headings in the `## [Unreleased]` block,
+following [Keep a Changelog](https://keepachangelog.com/):
+
+| Unreleased contains | Bump |
+|---|---|
+| `Added`, `Changed`, `Deprecated`, or `Removed` | minor |
+| only `Fixed` and/or `Security` | patch |
+
+**Major is never inferred.** "Is this breaking?" is not a question the headings
+can answer, so it has to be asked for: `make release RELEASE_ARGS="--major"`.
+Any bump can be forced the same way — `--minor`, `--patch`, or
+`--version 6.0.0`. An empty `## [Unreleased]` block is an error rather than a
+silent patch bump; write the entries first.
+
+### The guard
+
+`tests/test_version_consistency.py` fails the build when the release invariants
+drift: `pyproject.toml` restating a literal version, `__version__` not being
+semver, the newest changelog entry disagreeing with `__version__`, an undated
+newest entry, or a missing `## [Unreleased]` heading. Forgetting to bump is
+caught by CI instead of noticed three releases later.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,8 +36,8 @@ Use this page for local workflow, dev commands, and repo orientation. For archit
 | `make test` | run the full pytest suite |
 | `make coverage` | run pytest with coverage; prints missing lines and writes `htmlcov/index.html` |
 | `UPDATE_SNAPSHOTS=1 pytest tests/test_theme_pixel_snapshots.py` | regenerate theme pixel-hash baselines after an intentional theme change (commit the updated `tests/snapshots/theme_pixel_hashes.json`) |
-| `make lint` | run `ruff check src/ tests/` |
-| `make fmt` | run `ruff format src/ tests/` |
+| `make lint` | run `ruff check src/ tests/ scripts/ tools/` |
+| `make fmt` | run `ruff format src/ tests/ scripts/ tools/` |
 | `make check` | validate `config/config.yaml` |
 | `make docs-check` | validate markdown links and doc theme inventories |
 | `make version` | print the app version |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "home-dashboard"
-version = "5.2.0"
+dynamic = ["version"]
 description = "Python eInk dashboard for Raspberry Pi — calendar, weather, birthdays, and daily quotes"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -35,6 +39,11 @@ web = [
     "flask>=3.0",
     "waitress>=3.0",
 ]
+
+[tool.setuptools.dynamic]
+# Single source of truth: src/_version.py. setuptools reads the literal via AST,
+# so this never imports the package (no Pillow/numpy needed at build time).
+version = {attr = "src._version.__version__"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ web = [
 # so this never imports the package (no Pillow/numpy needed at build time).
 version = {attr = "src._version.__version__"}
 
+[tool.setuptools.packages.find]
+include = ["src*"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -30,6 +30,7 @@ import argparse
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
@@ -157,6 +158,40 @@ def assert_tag_free(tag: str) -> None:
 # --------------------------------------------------------------------------
 
 
+@dataclass
+class _Snapshot:
+    """The repo state captured just before the mutating phase of a release."""
+
+    version_text: str
+    changelog_text: str
+    head: str
+    committed: bool = False
+
+
+def _restore(snapshot: _Snapshot) -> None:
+    """Put the tree back the way it was before a failed release attempt.
+
+    Deliberately avoids ``git reset --hard``: ``--allow-dirty`` means the tree
+    may hold unrelated work that a hard reset would destroy. Instead the two
+    files this script owns are rewritten from the snapshot, the release commit
+    (if one was made) is peeled off with a soft reset, and only those two paths
+    are unstaged. Every step is best-effort — a rollback must not mask the
+    original failure with one of its own.
+    """
+    for path, original in (
+        (VERSION_FILE, snapshot.version_text),
+        (CHANGELOG, snapshot.changelog_text),
+    ):
+        try:
+            path.write_text(original, encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - filesystem failure
+            print(f"warning: could not restore {path.name}: {exc}", file=sys.stderr)
+
+    if snapshot.committed and snapshot.head:
+        git("reset", "--soft", snapshot.head, check=False)
+    git("reset", "-q", "HEAD", "--", str(VERSION_FILE), str(CHANGELOG), check=False)
+
+
 def rewrite_version_file(new_version: str) -> None:
     text = VERSION_FILE.read_text(encoding="utf-8")
     updated, count = VERSION_RE.subn(f'__version__ = "{new_version}"', text, count=1)
@@ -250,11 +285,28 @@ def main(argv: list[str] | None = None) -> int:
             print("\n--dry-run: nothing written.")
             return 0
 
-        rewrite_version_file(version_str)
-        roll_changelog(version_str, today)
-        git("add", str(VERSION_FILE), str(CHANGELOG))
-        git("commit", "-m", f"Release {version_str}")
-        git("tag", "-a", tag, "-m", f"Release {version_str}")
+        # Everything from here mutates the repo. A failure partway (a rejecting
+        # pre-commit hook, an unset git identity, a signing key that will not
+        # load) would otherwise strand the release: the files are rewritten, the
+        # Unreleased block is already rolled, and the next attempt reports
+        # "the Unreleased block is empty" — which is true, and says nothing
+        # about what actually went wrong. Undo the writes so the same release
+        # can simply be retried once the cause is fixed.
+        snapshot = _Snapshot(
+            version_text=VERSION_FILE.read_text(encoding="utf-8"),
+            changelog_text=text,
+            head=git("rev-parse", "HEAD", check=False),
+        )
+        try:
+            rewrite_version_file(version_str)
+            roll_changelog(version_str, today)
+            git("add", str(VERSION_FILE), str(CHANGELOG))
+            git("commit", "-m", f"Release {version_str}")
+            snapshot.committed = True
+            git("tag", "-a", tag, "-m", f"Release {version_str}")
+        except Exception:
+            _restore(snapshot)
+            raise
 
         print(f"\nCommitted and tagged {tag}.")
         print(f"Push it with:  git push -u origin HEAD && git push origin {tag}")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Cut a release: bump the version, date the changelog, commit, and tag.
+
+The version lives in exactly one place — ``src/_version.py``. ``pyproject.toml``
+reads it via ``[tool.setuptools.dynamic]``, so this script never has to edit two
+files in lockstep.
+
+The bump size is inferred from the ``## [Unreleased]`` block in ``CHANGELOG.md``,
+following Keep a Changelog conventions:
+
+* an ``### Added`` / ``### Changed`` / ``### Deprecated`` / ``### Removed``
+  section present  -> **minor**
+* only ``### Fixed`` / ``### Security``                 -> **patch**
+
+A **major** bump is never inferred. "Is this breaking?" is a judgement call the
+changelog headings cannot answer, so it must be asked for explicitly with
+``--major`` or ``--version``.
+
+Usage::
+
+    python scripts/release.py --dry-run     # show the plan, touch nothing
+    python scripts/release.py               # infer the bump and cut it
+    python scripts/release.py --minor       # force a bump size
+    python scripts/release.py --version 6.0.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / "src" / "_version.py"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+VERSION_RE = re.compile(r'^__version__\s*=\s*"(?P<version>[^"]+)"', re.MULTILINE)
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+UNRELEASED_HEADING = "## [Unreleased]"
+
+#: Changelog sections that imply new surface area rather than a pure fix.
+MINOR_SECTIONS = {"Added", "Changed", "Deprecated", "Removed"}
+PATCH_SECTIONS = {"Fixed", "Security"}
+
+
+class ReleaseError(RuntimeError):
+    """A precondition failed; the working tree has not been touched."""
+
+
+# --------------------------------------------------------------------------
+# reading state
+# --------------------------------------------------------------------------
+
+
+def read_version() -> tuple[int, int, int]:
+    """Return the current version from ``src/_version.py`` as a triple."""
+    match = VERSION_RE.search(VERSION_FILE.read_text(encoding="utf-8"))
+    if match is None:
+        raise ReleaseError(f"no __version__ assignment found in {VERSION_FILE}")
+    return parse_semver(match.group("version"))
+
+
+def parse_semver(raw: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.match(raw.strip())
+    if match is None:
+        raise ReleaseError(f"{raw!r} is not a MAJOR.MINOR.PATCH version")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def fmt(version: tuple[int, int, int]) -> str:
+    return "{}.{}.{}".format(*version)
+
+
+def unreleased_block(text: str) -> str:
+    """Return the body of the ``## [Unreleased]`` section, without its heading.
+
+    Raises when the heading is missing entirely — that means the changelog has
+    drifted from the format every other tool here assumes.
+    """
+    start = text.find(UNRELEASED_HEADING)
+    if start == -1:
+        raise ReleaseError(
+            f"{CHANGELOG.name} has no '{UNRELEASED_HEADING}' heading — "
+            "add one above the newest release before cutting a release"
+        )
+    body_start = start + len(UNRELEASED_HEADING)
+    next_release = re.search(r"^## \[", text[body_start:], re.MULTILINE)
+    end = body_start + next_release.start() if next_release else len(text)
+    return text[body_start:end]
+
+
+def sections_in(block: str) -> set[str]:
+    """Return the ``### Foo`` heading names present in a changelog block."""
+    return {m.group(1).strip() for m in re.finditer(r"^### (.+)$", block, re.MULTILINE)}
+
+
+def infer_bump(block: str) -> str:
+    """Infer ``"minor"`` or ``"patch"`` from an Unreleased block's sections."""
+    sections = sections_in(block)
+    if not sections:
+        raise ReleaseError(
+            f"the '{UNRELEASED_HEADING}' block is empty — nothing to release.\n"
+            "Add the entries for this release under it, or pass an explicit "
+            "--version / --major / --minor / --patch."
+        )
+    if sections & MINOR_SECTIONS:
+        return "minor"
+    if sections & PATCH_SECTIONS:
+        return "patch"
+    raise ReleaseError(
+        "could not infer a bump from the Unreleased sections "
+        f"{sorted(sections)}; pass --major / --minor / --patch explicitly"
+    )
+
+
+def apply_bump(current: tuple[int, int, int], bump: str) -> tuple[int, int, int]:
+    major, minor, patch = current
+    if bump == "major":
+        return major + 1, 0, 0
+    if bump == "minor":
+        return major, minor + 1, 0
+    return major, minor, patch + 1
+
+
+# --------------------------------------------------------------------------
+# git helpers
+# --------------------------------------------------------------------------
+
+
+def git(*args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        raise ReleaseError(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def assert_clean_tree() -> None:
+    if git("status", "--porcelain"):
+        raise ReleaseError(
+            "working tree has uncommitted changes — commit or stash them first "
+            "so the release commit contains only the version and changelog"
+        )
+
+
+def assert_tag_free(tag: str) -> None:
+    if git("tag", "--list", tag):
+        raise ReleaseError(f"tag {tag} already exists")
+
+
+# --------------------------------------------------------------------------
+# writing
+# --------------------------------------------------------------------------
+
+
+def rewrite_version_file(new_version: str) -> None:
+    text = VERSION_FILE.read_text(encoding="utf-8")
+    updated, count = VERSION_RE.subn(f'__version__ = "{new_version}"', text, count=1)
+    if count != 1:
+        raise ReleaseError(f"failed to rewrite {VERSION_FILE}")
+    VERSION_FILE.write_text(updated, encoding="utf-8")
+
+
+def roll_changelog(new_version: str, today: str) -> None:
+    """Date the Unreleased block and open a fresh empty one above it."""
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if UNRELEASED_HEADING not in text:
+        raise ReleaseError(f"{CHANGELOG.name} has no '{UNRELEASED_HEADING}' heading")
+    updated = text.replace(
+        UNRELEASED_HEADING,
+        f"{UNRELEASED_HEADING}\n\n## [{new_version}] - {today}",
+        1,
+    )
+    CHANGELOG.write_text(updated, encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# entry point
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Cut a release: bump version, date the changelog, commit, tag."
+    )
+    size = parser.add_mutually_exclusive_group()
+    size.add_argument("--major", action="store_true", help="force a major bump")
+    size.add_argument("--minor", action="store_true", help="force a minor bump")
+    size.add_argument("--patch", action="store_true", help="force a patch bump")
+    size.add_argument("--version", help="set an explicit MAJOR.MINOR.PATCH version")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the plan without editing, committing, or tagging",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="skip the clean-working-tree check (for testing this script)",
+    )
+    return parser
+
+
+def resolve_target(args: argparse.Namespace, current: tuple[int, int, int], block: str):
+    """Return ``(new_version_triple, how_it_was_chosen)``."""
+    if args.version:
+        return parse_semver(args.version), "explicit --version"
+    for name in ("major", "minor", "patch"):
+        if getattr(args, name):
+            return apply_bump(current, name), f"explicit --{name}"
+    bump = infer_bump(block)
+    return apply_bump(current, bump), f"inferred {bump} from the Unreleased sections"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        current = read_version()
+        text = CHANGELOG.read_text(encoding="utf-8")
+        block = unreleased_block(text)
+        new_version, reason = resolve_target(args, current, block)
+
+        if new_version <= current:
+            raise ReleaseError(
+                f"refusing to go from {fmt(current)} to {fmt(new_version)} — "
+                "the new version must be greater than the current one"
+            )
+
+        version_str = fmt(new_version)
+        tag = f"v{version_str}"
+        today = date.today().isoformat()
+
+        assert_tag_free(tag)
+        if not args.allow_dirty:
+            assert_clean_tree()
+
+        sections = sorted(sections_in(block)) or ["(none)"]
+        print(f"current version : {fmt(current)}")
+        print(f"new version     : {version_str}  ({reason})")
+        print(f"tag             : {tag}")
+        print(f"date            : {today}")
+        print(f"changelog       : {', '.join(sections)}")
+
+        if args.dry_run:
+            print("\n--dry-run: nothing written.")
+            return 0
+
+        rewrite_version_file(version_str)
+        roll_changelog(version_str, today)
+        git("add", str(VERSION_FILE), str(CHANGELOG))
+        git("commit", "-m", f"Release {version_str}")
+        git("tag", "-a", tag, "-m", f"Release {version_str}")
+
+        print(f"\nCommitted and tagged {tag}.")
+        print(f"Push it with:  git push -u origin HEAD && git push origin {tag}")
+        return 0
+
+    except ReleaseError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,221 @@
+"""Tests for ``scripts/release.py``.
+
+The script mutates the repository — it rewrites two files, commits, and tags —
+so the behaviour that matters most is what happens when one of those steps
+fails partway. Each test drives the real script against a throwaway git repo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "release.py"
+
+CHANGELOG_SEED = """# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Something small.
+
+## [1.2.3] - 2026-01-01
+
+### Added
+
+- The first thing.
+"""
+
+
+def _load_release_module():
+    """Import ``scripts/release.py`` by path — ``scripts/`` is not a package."""
+    spec = importlib.util.spec_from_file_location("_release_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # @dataclass resolves its module via sys.modules[cls.__module__]; without
+    # this the decorator raises AttributeError on a module loaded by path.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def release(tmp_path, monkeypatch):
+    """A release module pointed at a throwaway repo, plus that repo's path."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "_version.py").write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_SEED, encoding="utf-8")
+
+    _git(tmp_path, "init", "-q", ".")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "seed")
+
+    module = _load_release_module()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "VERSION_FILE", tmp_path / "src" / "_version.py")
+    monkeypatch.setattr(module, "CHANGELOG", tmp_path / "CHANGELOG.md")
+    return module, tmp_path
+
+
+# --------------------------------------------------------------------------
+# bump inference
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("section", "expected"),
+    [
+        ("Added", "minor"),
+        ("Changed", "minor"),
+        ("Deprecated", "minor"),
+        ("Removed", "minor"),
+        ("Fixed", "patch"),
+        ("Security", "patch"),
+    ],
+)
+def test_infer_bump_from_section(release, section, expected):
+    module, _ = release
+    assert module.infer_bump(f"\n\n### {section}\n\n- An entry.\n") == expected
+
+
+def test_added_beats_fixed(release):
+    """A block with both is a feature release, not a patch."""
+    module, _ = release
+    block = "\n\n### Fixed\n\n- A fix.\n\n### Added\n\n- A feature.\n"
+    assert module.infer_bump(block) == "minor"
+
+
+def test_major_is_never_inferred(release):
+    """No combination of headings may produce a major bump."""
+    module, _ = release
+    every = "".join(
+        f"\n\n### {name}\n\n- x.\n" for name in module.MINOR_SECTIONS | module.PATCH_SECTIONS
+    )
+    assert module.infer_bump(every) != "major"
+
+
+def test_empty_unreleased_block_is_an_error(release):
+    module, _ = release
+    with pytest.raises(module.ReleaseError, match="empty"):
+        module.infer_bump("\n\n")
+
+
+# --------------------------------------------------------------------------
+# the happy path
+# --------------------------------------------------------------------------
+
+
+def test_release_bumps_commits_and_tags(release):
+    module, repo = release
+    assert module.main([]) == 0
+
+    assert '__version__ = "1.2.4"' in (repo / "src" / "_version.py").read_text()
+    changelog = (repo / "CHANGELOG.md").read_text()
+    assert "## [1.2.4] - " in changelog
+    # A fresh empty Unreleased block is opened above the dated one.
+    assert changelog.index("## [Unreleased]") < changelog.index("## [1.2.4]")
+    assert _git(repo, "tag", "--list") == "v1.2.4"
+    assert not _git(repo, "status", "--porcelain")
+
+
+# --------------------------------------------------------------------------
+# rollback — the reason this module exists
+# --------------------------------------------------------------------------
+
+
+def _snapshot(repo: Path) -> tuple[str, str, str]:
+    return (
+        (repo / "src" / "_version.py").read_text(),
+        (repo / "CHANGELOG.md").read_text(),
+        _git(repo, "rev-parse", "HEAD"),
+    )
+
+
+def test_rollback_when_the_commit_fails(release):
+    """A rejecting pre-commit hook must leave the tree exactly as it was.
+
+    Without the rollback the files stay rewritten and the Unreleased block
+    stays rolled, so the retry reports "the Unreleased block is empty" — true,
+    and nothing to do with the real failure.
+    """
+    module, repo = release
+    before = _snapshot(repo)
+
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+
+    assert module.main([]) == 1
+    assert _snapshot(repo) == before
+    assert not _git(repo, "status", "--porcelain")
+    assert _git(repo, "tag", "--list") == ""
+
+
+def test_retry_succeeds_after_a_rolled_back_failure(release):
+    """The whole point: fix the cause, run again, get the same release."""
+    module, repo = release
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    assert module.main([]) == 1
+
+    hook.unlink()
+    assert module.main([]) == 0
+    assert '__version__ = "1.2.4"' in (repo / "src" / "_version.py").read_text()
+    assert _git(repo, "tag", "--list") == "v1.2.4"
+
+
+def test_rollback_when_the_tag_fails_after_a_successful_commit(release):
+    """The harder path: the release commit has to be peeled back off HEAD."""
+    module, repo = release
+    before = _snapshot(repo)
+
+    real_git = module.git
+
+    def failing_tag(*args, **kwargs):
+        if args[:2] == ("tag", "-a"):
+            raise module.ReleaseError("simulated tag failure")
+        return real_git(*args, **kwargs)
+
+    module.git = failing_tag
+    try:
+        assert module.main([]) == 1
+    finally:
+        module.git = real_git
+
+    assert _snapshot(repo) == before, "HEAD or the files were left moved"
+    assert not _git(repo, "status", "--porcelain")
+    assert _git(repo, "tag", "--list") == ""
+
+
+def test_rollback_leaves_unrelated_work_alone(release):
+    """``--allow-dirty`` means the tree may hold other edits; never blow them away."""
+    module, repo = release
+    # Tracked and modified, not merely untracked: `git reset --hard` leaves
+    # untracked files alone, so an untracked file could not detect the mistake
+    # this test exists to prevent.
+    unrelated = repo / "notes.txt"
+    unrelated.write_text("committed\n", encoding="utf-8")
+    _git(repo, "add", "notes.txt")
+    _git(repo, "commit", "-qm", "add notes")
+    unrelated.write_text("work in progress\n", encoding="utf-8")
+
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+
+    assert module.main(["--allow-dirty"]) == 1
+    assert unrelated.read_text() == "work in progress\n"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,95 @@
+"""Guard the release invariants that used to drift by hand.
+
+The version has exactly one home (``src/_version.py``) and exactly one mirror
+that has to agree with it (the newest dated ``CHANGELOG.md`` entry). Both used
+to be edited by hand in separate commits, which is how ``pyproject.toml`` and
+``src/_version.py`` came to disagree — see the ``4.6.0`` / ``5.2.0`` pair in the
+history. These tests fail the build rather than letting the drift ship.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+#: ``## [5.2.0] - 2026-08-21``. Older entries omit the date and some use two
+#: components (``## [4.2]``), so the date and the patch component are optional.
+RELEASE_HEADING_RE = re.compile(
+    r"^## \[(?P<version>\d+(?:\.\d+)*)\](?: - (?P<date>\d{4}-\d{2}-\d{2}))?\s*$",
+    re.MULTILINE,
+)
+
+
+@pytest.fixture(scope="module")
+def version() -> str:
+    from src._version import __version__
+
+    return __version__
+
+
+@pytest.fixture(scope="module")
+def changelog_text() -> str:
+    return CHANGELOG.read_text(encoding="utf-8")
+
+
+def test_version_is_semver(version: str) -> None:
+    assert SEMVER_RE.match(version), (
+        f"__version__ is {version!r}; it must be MAJOR.MINOR.PATCH so the "
+        "release script and the vX.Y.Z tag format stay derivable from it"
+    )
+
+
+def test_pyproject_does_not_pin_a_second_version() -> None:
+    """``pyproject.toml`` must read the version, never restate it."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    hardcoded = re.search(r'^version\s*=\s*"', text, re.MULTILINE)
+    assert hardcoded is None, (
+        "pyproject.toml declares a literal version again. It must stay "
+        'dynamic = ["version"] reading src/_version.py, or the two files can '
+        "drift apart the way they did before 5.2.0."
+    )
+    assert 'dynamic = ["version"]' in text
+    assert 'version = {attr = "src._version.__version__"}' in text
+
+
+def test_changelog_has_an_unreleased_heading(changelog_text: str) -> None:
+    """The release script rolls this heading forward; it has to be there."""
+    assert "## [Unreleased]" in changelog_text
+
+
+def test_changelog_newest_entry_matches_version(version: str, changelog_text: str) -> None:
+    """A bump without a changelog entry (or the reverse) fails here."""
+    headings = RELEASE_HEADING_RE.findall(changelog_text)
+    assert headings, "no '## [X.Y.Z]' release headings found in CHANGELOG.md"
+    newest = headings[0][0]
+    assert newest == version, (
+        f"__version__ is {version} but the newest CHANGELOG entry is {newest}. "
+        "Cut releases with `make release` so both move together."
+    )
+
+
+def test_newest_changelog_entry_is_dated(changelog_text: str) -> None:
+    match = RELEASE_HEADING_RE.search(changelog_text)
+    assert match is not None
+    assert match.group("date"), (
+        f"the newest release heading '## [{match.group('version')}]' has no date. "
+        "Released entries are dated; undated work belongs under [Unreleased]."
+    )
+
+
+def test_release_versions_descend(changelog_text: str) -> None:
+    """Newest first, no duplicates — so 'the newest entry' is unambiguous."""
+    versions = [
+        tuple(int(p) for p in v.split(".")) for v, _ in RELEASE_HEADING_RE.findall(changelog_text)
+    ]
+    assert len(versions) == len(set(versions)), "duplicate release headings in CHANGELOG.md"
+    assert versions == sorted(versions, reverse=True), (
+        "CHANGELOG.md release headings are not in descending version order"
+    )


### PR DESCRIPTION
## What and why

The version was written in four places and kept in sync by hand — `src/_version.py`, `pyproject.toml`, `CHANGELOG.md`, and a git tag — so each could be forgotten independently, and they were. `pyproject.toml` and `src/_version.py` had already drifted apart across the `4.6.0` / `5.2.0` commits. Of 14 tags, only 6 line up with the CHANGELOG: 4.0.0, 4.2.1, 5.0.0 and 5.1.0 are documented as released but never tagged, and `v.4.5.1` / `v.4.5.4` carry a stray dot.

This makes the version dynamic (one source of truth), collapses the release ritual into `make release`, and adds a CI guard that fails on the drift itself.

Two adjacent bugs surfaced while wiring it up and are fixed in their own commits, so either can be dropped without touching the versioning work.

Four commits, each independently revertable:

| Commit | What |
|---|---|
| `9bfc074` | One source of truth + `make release` + the drift guard |
| `d786641` | Fix `pip install .` producing an unimportable package |
| `82d77d7` | Make the `test-core-install` job capable of failing |
| `1d1aee0` | Lint `scripts/` and `tools/` |

### Releasing

`pyproject.toml` now reads `src/_version.py` via `[tool.setuptools.dynamic]`, so there is no second copy. `scripts/release.py` (`make release` / `make release-dry`) bumps the version, dates the `## [Unreleased]` block and opens a fresh one, commits, and creates the annotated `vX.Y.Z` tag.

Bump size comes from the Unreleased section headings: `Added`/`Changed`/`Deprecated`/`Removed` → minor, `Fixed`/`Security` alone → patch. **Major is never inferred** — the headings cannot answer whether a change is breaking, so it must be requested with `--major`. An empty Unreleased block is an error, not a silent patch bump. The script refuses a dirty tree, an existing tag, or a non-increasing version. Pushing stays manual.

`tests/test_version_consistency.py` fails the build on a literal version restated in `pyproject.toml`, a non-semver `__version__`, a newest changelog entry that disagrees with `__version__` or carries no date, a missing `## [Unreleased]` heading, or out-of-order release headings.

### The two bugs

**`pip install .` produced an unimportable package.** With no explicit `packages` config, setuptools auto-discovery read the repo as a *src-layout* and installed every module at the top level of `site-packages` — `app.py`, `config.py`, `cli.py`, `main.py`, a bare `__init__.py`, plus `data/`, `render/`, `web/` and the rest. Nothing was importable afterwards: `import src.config` failed with `No module named 'src'`, and `import config` failed for the same reason one level down, since the module's own body does `from src.config_validation import ...`. The generic names would also collide with unrelated packages.

**The `test-core-install` job could not fail.** Its whole purpose is to prove `pip install .` is usable, but it ran pytest from the checkout, where three separate mechanisms put the repo root on `sys.path` ahead of `site-packages`: `tests/__init__.py` makes pytest prepend the rootdir, `python -m pytest` prepends the cwd, and `pyproject.toml`'s `pythonpath = ["."]` adds it a third time. That is how it stayed green through the install above.

## Notes for the reviewer

**Major is deliberately not inferrable.** Every other part of the bump is derived from the changelog, but "is this breaking?" is not something `### Removed` can tell you. Guessing wrong is worse than asking, so it errors instead.

**The `test-core-install` fix does not make the whole suite run against `site-packages`.** Defeating all three shadowing mechanisms would be brittle and would break tests for reasons unrelated to packaging. Instead there is one explicit step that imports the installed package with `working-directory: /tmp`, where the source tree is not importable. Worth knowing this is an "the installed package is importable" proof, not a full "it works installed" proof — data files like `fonts/` are still not exercised, which is fine given the Pi deploys by rsync, not pip.

**The packaging fix changes what `pip install .` produces.** That is a real behaviour change, but nothing could have depended on the old output, since every module in it failed to import.

**Each guard test was verified by breaking the invariant it names** and confirming only that test went red — per the convention in `CLAUDE.md`. The first pass produced a false result from a stale `.pyc` (the mutations all landed inside one filesystem mtime tick); re-run with cache clearing, each of the 5 mutations failed exactly its own test. The `test-core-install` step was verified by extracting its exact shell out of the workflow YAML and running it against both installs: exit 0 against the fixed packaging, exit 1 with `ModuleNotFoundError: No module named 'src'` against the pre-fix one.

**Lint scope:** `scripts/` and `tools/` were both already clean, so `1d1aee0` widens the scope with no code changes. `make lint` / `make fmt` and the three places documenting them were updated in step so local matches CI.

**On the checklist below:** this branch was developed in a container whose library versions produce **71 pre-existing test failures** in the ical/recurrence and sync suites. I confirmed the identical 71 on a clean tree before making any changes — they are not from this branch, and I did not diagnose them. My changes take the suite from 3521 to 3527 passing. Because those failures make a local coverage number meaningless, CI is the real check on the gate; no file under `src/` is touched by this branch, so `--cov=src` should be unaffected.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes — verified over the new wider scope (`src/ tests/ scripts/ tools/`)
- [ ] `make test` passes, including the coverage gate — **see the note above**; 71 failures are pre-existing and environmental, +6 new passing tests, coverage untouched (no `src/` changes)
- [x] `venv/bin/python -m mypy src/` is clean — `Success: no issues found in 143 source files`
- [x] Tests added or updated for behaviour changes — `tests/test_version_consistency.py`, 6 tests, each mutation-verified

If the change touches **themes, components, or anything that renders**:

- N/A — nothing under `src/render/` is touched and no pixel-hash baseline moves

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs updated — new "Releasing" section in `docs/development.md`, release guidance in `CONTRIBUTING.md`, commands and a gotcha in `CLAUDE.md`
- [x] `CHANGELOG.md` entry under `## [Unreleased]`

If the change adds a **config option**:

- N/A

If the change affects **architecture or contributor workflow**:

- [x] `CLAUDE.md` updated — release commands plus a gotcha recording the single-source-of-truth invariant

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFQqm7d4pJLArd7k21KY6j)_