### PR TITLE
Name the terminal theme's replacement faces in the font table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,7 +354,7 @@ The cooldown is `display.min_refresh_interval_seconds` (config), defaulting to 6
 |---|---|---|
 | `PlusJakartaSans-*.ttf` | `regular`, `medium`, `semibold`, `bold` | Default font for all themes |
 | `weathericons-regular.ttf` | `weather_icon` | Weather condition icons + moon phase glyphs (all themes) |
-| `ShareTechMono-Regular.ttf` | `cyber_mono` | `terminal` — event body text; `diags` — all data rows |
+| `ShareTechMono-Regular.ttf` | `cyber_mono` | `terminal` — all four base text slots (`font_regular`/`medium`/`semibold`/`bold`), so every element not claimed by a specialised slot: event rows, weather readings, birthday rows, header timestamp; `diags` — all data rows |
 | `Oxanium-Variable.ttf` (OFL, variable) | `oxanium`, `oxanium_bold` | `terminal` — dashboard title, day column headers, quote body |
 | `Rajdhani-Regular.ttf` / `Rajdhani-SemiBold.ttf` (OFL) | `rajdhani`, `rajdhani_semibold` | `terminal` — month band, section labels, quote attribution |
 | `Orbitron-Variable.ttf` (OFL, variable) | `orbitron_black` | `terminal` — large today date numeral |

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -530,6 +530,6 @@ Bundled font families used by the current built-in themes:
 | Rajdhani | `terminal` (month band, section labels, quote attribution) |
 | Orbitron | `terminal` (large today date numeral) |
 | Space Grotesk | `air_quality`, `message`, `year_pulse`, `scorecard` |
-| Share Tech Mono | `terminal` (event body text), `diags` (all data rows), `trends` (tabular numerals), select utility text |
+| Share Tech Mono | `terminal` (all four base text slots — the theme's general body and data face: event rows, weather readings, birthday rows, header timestamp; the display faces above cover only the title, section-label, month-band, date-numeral and quote slots), `diags` (all data rows), `trends` (tabular numerals), select utility text |
 
 To regenerate the Waveshare and Inky preview images embedded above, see [Previews](previews.md).

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -526,7 +526,10 @@ Bundled font families used by the current built-in themes:
 | Audiowide | `constellation_map` (cardinal letters, star + constellation labels) |
 | Astloch | `almanac` (masthead + dateline character font), `naturalist` (masthead character font) |
 | Antonio | `sunrise`, `tides` (condensed display title + section labels) |
+| Oxanium | `terminal` (dashboard title, day column headers, quote body) |
+| Rajdhani | `terminal` (month band, section labels, quote attribution) |
+| Orbitron | `terminal` (large today date numeral) |
 | Space Grotesk | `air_quality`, `message`, `year_pulse`, `scorecard` |
-| Share Tech Mono / terminal fonts | `terminal`, `diags`, `trends` (tabular numerals), select utility text |
+| Share Tech Mono | `terminal` (event body text), `diags` (all data rows), `trends` (tabular numerals), select utility text |
 
 To regenerate the Waveshare and Inky preview images embedded above, see [Previews](previews.md).


### PR DESCRIPTION
<!-- Follow-up to #250. -->

## What and why

Follow-up to #250. That PR re-set `terminal` in three OFL faces but left `docs/themes.md` describing its typography as "Share Tech Mono / terminal fonts" — already vague, and now wrong: three of the four faces that theme uses are **Oxanium** (title, day column headers, quote body), **Rajdhani** (month band, section labels, quote attribution) and **Orbitron** (the hero date numeral).

Each gets its own row in the font table. The Antonio row for `sunrise` / `tides` was already correct.

The Share Tech Mono row is also corrected, and that correction came out of review (thread below): `terminal` points **all four base slots** at `cyber_mono` — `font_regular`, `font_medium`, `font_semibold`, `font_bold` — so it is the theme's general body and data face, setting everything the five specialised slots don't claim: event rows, weather readings, birthday rows, the header timestamp. Measured, the components `terminal` draws pull from those slots at 37 call sites across `header`, `week_view`, `weather_panel`, `birthday_bar` and `info_panel`. My first version of the row said "event body text", which would have led a reader trying to identify or replace terminal's fonts to think three display faces plus a mono for event bodies covered it. **CLAUDE.md carried the same narrow phrasing** — it is where I took it from — so both tables are corrected together rather than left to disagree.

Docs only — no code, no images.

## Notes for the reviewer

**No preview regeneration was needed, and I verified that rather than assuming it.** Re-running `scripts/build_previews.py` for `terminal`, `sunrise` and `tides` on both providers reproduces all six committed PNGs byte-for-byte, and `build_split_previews.py` leaves those three splits unchanged. The images committed with #250 are current.

**One thing that turned up while checking, worth knowing.** Diffing the pre-swap `theme_sunrise.png` against the current one, NuCore Condensed had been rendering `DAYLIGHT` as `DAYL□GHT` and `TONIGHT` as `TON□GHT`. It isn't tofu — its `I` is a constructed boxy letterform that reads as a filled block at panel size. I rendered the string in both faces side by side to confirm rather than infer it from the preview. So #250 fixed real legibility on `sunrise` and `tides` too, not only `terminal`'s date numeral, which is now in the record.

**Six split previews are stale on `main` and I deliberately left them alone.** `build_split_previews.py` rewrites `fantasy`, `minimalist`, `old_fashioned`, `photo`, `timeline` and `year_pulse` differently from what is committed. Pre-existing, unrelated to the font swap, and not this PR's business — I reverted them rather than smuggle six unrelated images in. Worth a separate look if you want the set self-consistent.

## Checklist

Always:

- [x] `make lint` and `make fmt` leave no changes
- [x] `make test` passes, including the coverage gate — 3954 passed, 97.78% (gate 94%)
- [x] `mypy src/` is clean — `Success: no issues found in 145 source files`
- [ ] n/a — docs only, no behaviour change to test

If the change touches **themes, components, or anything that renders**:

- [ ] n/a — no render path touched; pixel-hash baselines unchanged
- [x] Preview PNGs confirmed current — all six regenerate byte-identically, so nothing to commit
- [x] Unrelated theme hashes confirmed **unchanged**

If the change touches **docs or user-facing behaviour**:

- [x] `make docs-check` passes
- [x] Canonical docs updated — the font tables in `docs/themes.md` and `CLAUDE.md`
- [ ] `CHANGELOG.md` entry — deliberately skipped: this corrects the documentation of a change already described under `## [Unreleased]` by #250, and a second entry for the same swap would read as a separate change

If the change adds a **config option**:

- [ ] n/a

If the change affects **architecture or contributor workflow**:

- [x] `CLAUDE.md` updated — its Share Tech Mono row carried the same understatement as `docs/themes.md` and is corrected alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnyNJefX9ufV5cpi2uhLKi